### PR TITLE
Bump halo2 commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ pasta_curves = "0.1"
 bigint = "4"
 
 [patch.crates-io]
-halo2 = { git = "https://github.com/zcash/halo2.git", rev = "d04b532368d05b505e622f8cac4c0693574fbd93" }
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "4283713ec76051eaf21a06d0279fa7d3497cafb6" }


### PR DESCRIPTION
This brings in the `SimpleFloorPlanner` and changes the `Circuit` trait.

This also updates the public inputs API, which is the main motivation
for bumping the commit. (This change will not be noticeable in this diff
since our codebase does not currently use public inputs.)

This also brings in zero-knowledge blinding factors; however, we
will fork those out in a future commit.