### PR TITLE
EVM Circuit and trait OpGadget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [
     "zkevm-circuits",
     "bus-mapping",
     "keccak256"
-    ]
+]
 
 [patch.crates-io]
 halo2 = { git = "https://github.com/zcash/halo2.git", rev = "4283713ec76051eaf21a06d0279fa7d3497cafb6" }

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -1,5 +1,6 @@
 //! Evm types needed for parsing instruction sets as well
 
+pub(crate) mod gas;
 pub(crate) mod instruction;
 pub(crate) mod opcodes;
 
@@ -9,6 +10,7 @@ use lazy_static::lazy_static;
 use num::{BigUint, Num, Zero};
 use serde::{Deserialize, Serialize};
 pub use {
+    gas::GasCost,
     instruction::Instruction,
     opcodes::{ids::OpcodeId, Opcode},
 };

--- a/bus-mapping/src/evm/gas.rs
+++ b/bus-mapping/src/evm/gas.rs
@@ -1,0 +1,31 @@
+/// Gas cost enum.
+pub struct GasCost(pub u8);
+
+impl GasCost {
+    /// Constant cost for quick step
+    pub const QUICK: Self = Self(2);
+    /// Constant cost for fastest step
+    pub const FASTEST: Self = Self(3);
+    /// Constant cost for fast step
+    pub const FAST: Self = Self(5);
+    /// Constant cost for mid step
+    pub const MID: Self = Self(8);
+    /// Constant cost for slow step
+    pub const SLOW: Self = Self(10);
+    /// Constant cost for ext step
+    pub const EXT: Self = Self(20);
+}
+
+impl GasCost {
+    /// Returns the `GasCost` as a `u8`.
+    #[inline]
+    pub const fn as_u8(&self) -> u8 {
+        self.0
+    }
+
+    /// Returns the `GasCost` as a `usize`.
+    #[inline]
+    pub const fn as_usize(&self) -> usize {
+        self.0 as usize
+    }
+}

--- a/bus-mapping/src/evm/opcodes/ids.rs
+++ b/bus-mapping/src/evm/opcodes/ids.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 /// Opcode enum. One-to-one corresponding to an `u8` value.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct OpcodeId(pub u8);
 
 // Core opcodes.

--- a/bus-mapping/src/exec_trace.rs
+++ b/bus-mapping/src/exec_trace.rs
@@ -270,6 +270,7 @@ impl From<(Target, usize)> for OperationRef {
             Target::Memory => Self(Target::Memory, op_ref_data.1),
             Target::Stack => Self(Target::Stack, op_ref_data.1),
             Target::Storage => Self(Target::Storage, op_ref_data.1),
+            _ => unreachable!(),
         }
     }
 }

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -43,6 +43,8 @@ impl RW {
 /// Enum used to differenciate between EVM Stack, Memory and Storage operations.
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum Target {
+    /// Dummy target to pad meaningful targets
+    Noop,
     /// Means the target of the operation is the Memory.
     Memory,
     /// Means the target of the operation is the Stack.

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -13,3 +13,4 @@ pasta_curves = "0.1"
 bigint = "4"
 sha3 = "0.7.2"
 digest = "0.7.6"
+bus-mapping = { path = "../bus-mapping" }

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -11,6 +11,7 @@ ff = "0.10"
 halo2 = "0.0"
 pasta_curves = "0.1"
 bigint = "4"
+num = "0.4"
 sha3 = "0.7.2"
 digest = "0.7.6"
 bus-mapping = { path = "../bus-mapping" }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -738,7 +738,7 @@ impl<F: FieldExt> EvmCircuit<F> {
                 }
 
                 // Range32
-                for idx in 0..31 {
+                for idx in 0..32 {
                     region.assign_fixed(
                         || "Range32: tag",
                         self.fixed_table[0],

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -3,7 +3,9 @@
 use halo2::{
     arithmetic::FieldExt,
     circuit::{self, Layouter, Region},
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+    plonk::{
+        Advice, Column, ConstraintSystem, Error, Expression, Fixed, Selector,
+    },
     poly::Rotation,
 };
 use std::convert::TryInto;
@@ -12,7 +14,7 @@ mod op_execution;
 use op_execution::{OpExecutionGadget, OpExecutionState};
 
 #[derive(Clone, Debug)]
-enum CallField {
+pub(crate) enum CallField {
     // Transaction id.
     TxId,
     // Global counter at the begin of call.
@@ -48,7 +50,7 @@ enum CallField {
 }
 
 #[derive(Clone, Debug)]
-enum CallStateField {
+pub(crate) enum CallStateField {
     // Program counter.
     ProgramCounter,
     // Stack pointer.
@@ -68,7 +70,7 @@ enum CallStateField {
 }
 
 #[derive(Clone, Debug)]
-enum BusMappingLookup<F> {
+pub(crate) enum BusMappingLookup<F> {
     // Read-Write
     OpExecutionState {
         field: CallStateField,
@@ -77,8 +79,9 @@ enum BusMappingLookup<F> {
     },
     Stack {
         // One can only access its own stack, so id is no needed to be
-        // specified. Stack index is always deterministic respect to
-        // stack pointer, so an index offset is enough.
+        // specified.
+        // Stack index is always deterministic respect to stack pointer, so an
+        // index offset is enough.
         index_offset: i32,
         value: Expression<F>,
         is_write: bool,
@@ -106,15 +109,31 @@ enum BusMappingLookup<F> {
         field: CallField,
         value: Expression<F>,
     },
-    /* TODO: Block,
-     * TODO: Bytecode,
-     * TODO: Tx,
-     * TODO: TxCalldata, */
+    Bytecode {
+        hash: Expression<F>,
+        index: Expression<F>,
+        value: Expression<F>,
+    },
+    // TODO: Block,
+    // TODO: Bytecode,
+    // TODO: Tx,
+    // TODO: TxCalldata,
+}
+
+#[derive(Clone, Copy, Debug, PartialOrd, PartialEq, Eq, Ord)]
+pub(crate) enum FixedLookup {
+    // Noop provides [0, 0, 0, 0] row
+    Noop,
+    // meaningful tags start with 1
+    Range256,
+    BitwiseAnd,
+    BitwiseOr,
+    BitwiseXor,
 }
 
 #[derive(Clone, Debug)]
-enum Lookup<F> {
-    RangeLookup(/* usize, Expression<F> */),
+pub(crate) enum Lookup<F> {
+    FixedLookup(FixedLookup, [Expression<F>; 3]),
     BusMappingLookup(BusMappingLookup<F>),
 }
 
@@ -269,6 +288,7 @@ pub(crate) struct ExecutionStep {
 #[derive(Clone)]
 struct EvmCircuit<F> {
     selector: Selector,
+    fixed_table: [Column<Fixed>; 4],
     op_execution_gadget: OpExecutionGadget<F>,
 }
 
@@ -282,6 +302,18 @@ impl<F: FieldExt> EvmCircuit<F> {
         let columns = (0..Self::WIDTH)
             .map(|_| meta.advice_column())
             .collect::<Vec<_>>();
+
+        // fixed_table contains pre-built tables identified by tag including:
+        // - different size range tables
+        // - bitwise table
+        // - comparator table
+        // - ...
+        let fixed_table = [
+            meta.fixed_column(), // tag
+            meta.fixed_column(),
+            meta.fixed_column(),
+            meta.fixed_column(),
+        ];
 
         let mut selector_exp = Expression::Constant(F::zero());
         let mut cells = Vec::with_capacity(Self::WIDTH * Self::HEIGHT);
@@ -322,28 +354,155 @@ impl<F: FieldExt> EvmCircuit<F> {
         let op_execution_state_next =
             OpExecutionState::new(op_execution_state_next_cells);
 
+        // independent_lookups collect lookups by independent selectors, which
+        // means we can sum some of them together to save lookups.
+        let mut independent_lookups =
+            Vec::<(Expression<F>, Vec<Lookup<F>>)>::new();
+
         let op_execution_gadget = OpExecutionGadget::configure(
             meta,
+            r,
             selector_exp,
             op_execution_state_curr,
             op_execution_state_next,
             free_cells,
-            r,
+            &mut independent_lookups,
         );
 
         // TODO: call_initialization_gadget
 
-        // TODO: handle lookups
+        Self::configure_lookups(meta, &fixed_table, independent_lookups);
 
         EvmCircuit {
             selector,
+            fixed_table,
             op_execution_gadget,
         }
     }
 
+    fn configure_lookups(
+        meta: &mut ConstraintSystem<F>,
+        fixed_table: &[Column<Fixed>; 4],
+        independent_lookups: Vec<(Expression<F>, Vec<Lookup<F>>)>,
+    ) {
+        // TODO: call_lookups
+        // TODO: bytecode_lookups
+        // TODO: rw_lookups
+
+        let mut fixed_lookups = Vec::<[Expression<F>; 4]>::new();
+
+        for (lookup_selector, lookups) in independent_lookups {
+            let mut fixed_lookup_count = 0;
+
+            for lookup in lookups {
+                match lookup {
+                    Lookup::FixedLookup(tag, exps) => {
+                        let tag_exp =
+                            Expression::Constant(F::from_u64(tag as u64));
+
+                        if fixed_lookups.len() == fixed_lookup_count {
+                            fixed_lookups.push(
+                                [tag_exp]
+                                    .iter()
+                                    .chain(exps.iter())
+                                    .map(|exp| {
+                                        lookup_selector.clone() * exp.clone()
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        } else {
+                            for (acc, exp) in fixed_lookups[fixed_lookup_count]
+                                .iter_mut()
+                                .zip([tag_exp].iter().chain(exps.iter()))
+                            {
+                                *acc = acc.clone()
+                                    + lookup_selector.clone() * exp.clone();
+                            }
+                        }
+                        fixed_lookup_count += 1;
+                    }
+                    Lookup::BusMappingLookup(_) => {
+                        // TODO:
+                        unimplemented!()
+                    }
+                }
+            }
+        }
+
+        for fixed_lookup in fixed_lookups.iter() {
+            meta.lookup(|meta| {
+                fixed_lookup
+                    .iter()
+                    .zip(fixed_table.iter())
+                    .map(|(exp, fixed)| {
+                        (exp.clone(), meta.query_fixed(*fixed, Rotation::cur()))
+                    })
+                    .collect::<Vec<_>>()
+            });
+        }
+    }
+
+    fn load_fixed_tables(
+        &self,
+        layouter: &mut impl Layouter<F>,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "fixed table",
+            |mut region| {
+                let mut offest = 0;
+
+                // Noop
+                for (idx, column) in self.fixed_table.iter().enumerate() {
+                    region.assign_fixed(
+                        || format!("Noop: {}", idx),
+                        *column,
+                        offest,
+                        || Ok(F::zero()),
+                    )?;
+                }
+                offest += 1;
+
+                // Range256
+                for idx in 0..256 {
+                    region.assign_fixed(
+                        || "Range256: tag",
+                        self.fixed_table[0],
+                        offest,
+                        || Ok(F::from_u64(FixedLookup::Range256 as u64)),
+                    )?;
+                    region.assign_fixed(
+                        || "Range256: value",
+                        self.fixed_table[1],
+                        offest,
+                        || Ok(F::from_u64(idx as u64)),
+                    )?;
+                    for (idx, column) in
+                        self.fixed_table[2..].iter().enumerate()
+                    {
+                        region.assign_fixed(
+                            || format!("Range256: padding {}", idx),
+                            *column,
+                            offest,
+                            || Ok(F::zero()),
+                        )?;
+                    }
+                    offest += 1;
+                }
+
+                // TODO: BitwiseAnd
+                // TODO: BitwiseOr
+                // TODO: BitwiseXor
+
+                Ok(())
+            },
+        )
+    }
+
     fn assign(
         &self,
-        mut layouter: impl Layouter<F>,
+        layouter: &mut impl Layouter<F>,
         execution_steps: &[ExecutionStep],
     ) -> Result<(), Error> {
         layouter.assign_region(
@@ -428,9 +587,12 @@ mod test {
         fn synthesize(
             &self,
             config: Self::Config,
-            layouter: impl Layouter<F>,
+            mut layouter: impl Layouter<F>,
         ) -> Result<(), Error> {
-            config.evm_circuit.assign(layouter, &self.execution_steps)
+            config.evm_circuit.load_fixed_tables(&mut layouter)?;
+            config
+                .evm_circuit
+                .assign(&mut layouter, &self.execution_steps)
         }
     }
 }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -1,6 +1,6 @@
 //! The EVM circuit implementation.
 
-use bus_mapping::operation::Target;
+use bus_mapping::{evm::OpcodeId, operation::Target};
 use halo2::{
     arithmetic::FieldExt,
     circuit::{self, Layouter, Region},
@@ -302,7 +302,7 @@ enum Case {
 
 // TODO: use ExecutionStep from bus_mapping
 pub(crate) struct ExecutionStep {
-    opcode: u8,
+    opcode: OpcodeId,
     case: Case,
     values: Vec<[u8; 32]>,
 }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -16,7 +16,7 @@ use std::{convert::TryInto, iter};
 mod op_execution;
 use op_execution::{OpExecutionGadget, OpExecutionState};
 mod param;
-use param::{CIRCUIT_HEIGHT, CIRCUIT_WIDTH, NUM_CELL_OP_EXECTION_STATE};
+use param::{CIRCUIT_HEIGHT, CIRCUIT_WIDTH, NUM_CELL_OP_EXECUTION_STATE};
 
 #[derive(Clone, Debug)]
 pub(crate) enum CallField {
@@ -46,7 +46,7 @@ pub(crate) enum CallField {
     // Value in wei of call.
     Value,
     // If call succeeds or not in the future.
-    IsPersistant,
+    IsPersistent,
     // If call is within a static call.
     IsStatic,
     // If call is `CREATE*`. We lookup op from calldata when is create,
@@ -173,8 +173,8 @@ struct Constraint<F> {
 pub(crate) struct Cell<F> {
     // expression for constraint
     expression: Expression<F>,
-    // relative position to selector for synthesis
     column: Column<Advice>,
+    // relative position to selector for synthesis
     rotation: usize,
 }
 
@@ -460,7 +460,7 @@ impl<F: FieldExt> EvmCircuit<F> {
             vec![0.expr()]
         });
 
-        let num_cells_next_asseccible = NUM_CELL_OP_EXECTION_STATE;
+        let num_cells_next_asseccible = NUM_CELL_OP_EXECUTION_STATE;
 
         let cells_next =
             &mut cells_curr[..num_cells_next_asseccible].to_vec()[..];
@@ -477,11 +477,11 @@ impl<F: FieldExt> EvmCircuit<F> {
         });
 
         let op_execution_state_curr =
-            OpExecutionState::new(&cells_curr[..NUM_CELL_OP_EXECTION_STATE]);
+            OpExecutionState::new(&cells_curr[..NUM_CELL_OP_EXECUTION_STATE]);
         let op_execution_state_next =
-            OpExecutionState::new(&cells_next[..NUM_CELL_OP_EXECTION_STATE]);
+            OpExecutionState::new(&cells_next[..NUM_CELL_OP_EXECUTION_STATE]);
         let op_execution_free_cells =
-            cells_curr[NUM_CELL_OP_EXECTION_STATE..].to_vec();
+            cells_curr[NUM_CELL_OP_EXECUTION_STATE..].to_vec();
 
         let mut qs_op_execution = 0.expr();
         meta.create_gate(

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -10,6 +10,7 @@ use halo2::{
     },
     poly::Rotation,
 };
+use num::BigUint;
 use std::{convert::TryInto, iter};
 
 mod op_execution;
@@ -167,6 +168,7 @@ struct Constraint<F> {
     polys: Vec<Expression<F>>,
     lookups: Vec<Lookup<F>>,
 }
+
 #[derive(Clone, Debug)]
 pub(crate) struct Cell<F> {
     // expression for constraint
@@ -208,7 +210,7 @@ impl<F: FieldExt> Expr<F> for Cell<F> {
 struct Word<F> {
     // random linear combination expression of cells
     expression: Expression<F>,
-    // inner cells for syntesis
+    // inner cells for synthesis
     cells: [Cell<F>; 32],
 }
 
@@ -309,7 +311,7 @@ enum Case {
 pub(crate) struct ExecutionStep {
     opcode: OpcodeId,
     case: Case,
-    values: Vec<[u8; 32]>,
+    values: Vec<BigUint>,
 }
 
 // TODO: use Operation from bus_mapping

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -145,10 +145,9 @@ pub(crate) enum Lookup<F> {
 struct Constraint<F> {
     name: &'static str,
     selector: Expression<F>,
-    linear_combinations: Vec<Expression<F>>,
+    polys: Vec<Expression<F>>,
     lookups: Vec<Lookup<F>>,
 }
-
 #[derive(Clone, Debug)]
 pub(crate) struct Cell<F> {
     // expression for constraint

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -158,7 +158,7 @@ pub(crate) struct Cell<F> {
 }
 
 impl<F: FieldExt> Cell<F> {
-    fn exp(&self) -> Expression<F> {
+    fn expr(&self) -> Expression<F> {
         self.expression.clone()
     }
 
@@ -199,13 +199,13 @@ impl<F: FieldExt> Word<F> {
                 .iter()
                 .rev()
                 .fold(Expression::Constant(F::zero()), |acc, byte| {
-                    acc * r.clone() + byte.exp()
+                    acc * r.clone() + byte.expr()
                 }),
             cells: cells.to_owned().try_into().unwrap(),
         }
     }
 
-    fn exp(&self) -> Expression<F> {
+    fn expr(&self) -> Expression<F> {
         self.expression.clone()
     }
 
@@ -439,7 +439,7 @@ impl<F: FieldExt> EvmCircuit<F> {
             "Query synthetic selector for OpExecutionGadget",
             |meta| {
                 qs_op_execution = meta.query_selector(q_step)
-                    * op_execution_state_curr.is_executing.exp();
+                    * op_execution_state_curr.is_executing.expr();
 
                 vec![Expression::Constant(F::zero())]
             },

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -418,9 +418,10 @@ impl<F: FieldExt> EvmCircuit<F> {
             &mut cells_curr[..num_cells_next_asseccible].to_vec()[..];
         meta.create_gate("Query cells for next step", |meta| {
             for cell in cells_next.iter_mut() {
+                cell.rotation += CIRCUIT_HEIGHT;
                 cell.expression = meta.query_advice(
                     cell.column,
-                    Rotation((cell.rotation + CIRCUIT_HEIGHT) as i32),
+                    Rotation((cell.rotation) as i32),
                 );
             }
 

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -437,14 +437,6 @@ impl<F: FieldExt> EvmCircuit<F> {
             vec![0.expr()]
         });
 
-        // TODO: Enable this when switch to kzg branch and remove the failure
-        //       VerifyFailure::ConstraintPoison
-        // meta.create_gate("Query byte lookup as a synthetic selector", |meta| {
-        //     let expr = meta.query_advice(qs_byte_lookup, Rotation::cur());
-
-        //     vec![expr.clone() * (Expression::Constant(F::one()) - expr)]
-        // });
-
         let mut cells_curr = Vec::with_capacity(CIRCUIT_WIDTH * CIRCUIT_HEIGHT);
         meta.create_gate("Query cells for current step", |meta| {
             for h in 0..CIRCUIT_HEIGHT as i32 {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -1,1 +1,465 @@
 //! The EVM circuit implementation.
+
+use halo2::{
+    arithmetic::FieldExt,
+    circuit::{Cell, Layouter, Region},
+    plonk::{Advice, Column, ConstraintSystem, Error, Expression},
+    poly::Rotation,
+};
+use std::{collections::HashSet, convert::TryInto, iter::FromIterator};
+
+// immutable
+enum InterpreterContextKey {
+    // global counter at the end of call, used for locating reverting section
+    GlobalCounterEnd,
+    // caller’s unique identifier
+    CallerID,
+    // offset of calldata
+    CalldataOffset,
+    // size of calldata
+    CalldataSize,
+    // address of tx sender (EOA address)
+    TxOrigin,
+    // gas price of tx
+    GasPrice,
+    // depth of call, should ∈ [0,1024]
+    Depth,
+    // address of caller
+    CallerAddress,
+    // address of code which interpreter is executing, could differ from `address` when delegate call
+    CodeAddress,
+    // address of receiver
+    Address,
+    // gas given of call
+    GasAvailable,
+    // value in wei of call
+    Value,
+    // if call succeeds or not in the future
+    IsPersistant,
+    // if call is within a static call
+    IsStatic,
+    // more would be needed like:
+    // GasBaseFee,
+}
+
+// mutable
+enum InterpreterStateKey {
+    // global counter
+    GlobalCounter,
+    // program counter
+    ProgramCounter,
+    // stack pointer
+    StackPointer,
+    // memory size
+    MemeorySize,
+    // if call is `CREATE*`, if true we lookup op from calldata, otherwise we lookup code under address
+    IsCreate,
+    // gas counter
+    GasCounter,
+    // state trie write counter
+    StateWriteCounter,
+    // number of slot to continue the same op for
+    SlotTodo,
+    // last callee's unique identifier
+    CalleeID,
+    // offset of returndata
+    ReturndataOffset,
+    // size of returndata
+    ReturndataSize,
+}
+
+enum BusMappingLookup<F> {
+    InterpreterContext {
+        key: InterpreterContextKey,
+        value: Expression<F>,
+    },
+    InterpreterState {
+        key: InterpreterStateKey,
+        value: Expression<F>,
+        is_write: bool,
+    },
+    Stack {
+        // one can access its own stack, so id is no needed to be specify
+        // stack index is always deterministic respect to stack pointer, so an
+        // index offset is enough
+        index_offset: i32,
+        value: Expression<F>,
+        is_write: bool,
+    },
+    Memory {
+        // some op like CALLDATALOAD can peek caller's memeory, so we allow it
+        // to specify the id.
+        id: Expression<F>,
+        index: Expression<F>,
+        value: Expression<F>,
+        is_write: bool,
+    },
+    Storage {
+        address: Expression<F>,
+        location: Expression<F>,
+        value: Expression<F>,
+        is_write: bool,
+    },
+    // more would be needed like:
+    // Code,
+    // Block,
+    // Tx,
+    // TxCalldata,
+    // AccountNonce,
+    // AccountBalance,
+    // AccountCodeHash,
+    // AccountStorageRoot,
+}
+
+enum Lookup<F> {
+    RangeLookup(/* usize, Expression<F> */),
+    BusMappingLookup(BusMappingLookup<F>),
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+enum Case {
+    Success,
+    // out of gas
+    OutOfGas,
+    // call depth exceeded 1024
+    DepthOverflow,
+    // insufficient balance for transfer
+    InsufficientBalance,
+    // contract address collision
+    ContractAddressCollision,
+    // execution reverted
+    Reverted,
+    // max code size exceeded
+    MaxCodeSizeExceeded,
+    // invalid jump destination
+    InvalidJump,
+    // is_write protection
+    WriteProtection,
+    // return data out of bound
+    ReturnDataOutOfBounds,
+    // contract must not begin with 0xef due to EOF
+    InvalidBeginningCode,
+    // stack underflow
+    StackUnderflow(usize),
+    // stack overflow
+    StackOverflow(usize),
+    // invalid opcode
+    InvalidCode,
+}
+
+struct ExecutionResult<F> {
+    case: Case,
+    linear_constraints: Vec<Expression<F>>,
+    lookups: Vec<Lookup<F>>,
+}
+
+#[derive(Clone, Debug)]
+struct Allocation<F> {
+    // expression for configuration
+    exp: Expression<F>,
+    // relative position to selector for synthesis
+    column: Column<Advice>,
+    offset: usize,
+}
+
+impl<F: FieldExt> Allocation<F> {
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        value: Option<F>,
+    ) -> Result<Cell, Error> {
+        region.assign_advice(
+            || format!("assign allocation {:?}", self.column),
+            self.column,
+            offset + self.offset,
+            || value.ok_or(Error::SynthesisError),
+        )
+    }
+}
+
+// TODO: Integrate with evm_word
+#[derive(Clone, Debug)]
+struct Word<F> {
+    // random linear combination exp for configuration
+    exp: Expression<F>,
+    // inner allocations for syntesis
+    allocs: [Allocation<F>; 32],
+}
+
+impl<F: FieldExt> Word<F> {
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        /* value: [Option<u8>; 32] or U256 */
+    ) -> Result<Cell, Error> {
+        Err(Error::SynthesisError)
+    }
+}
+
+struct InterpreterState<F> {
+    // unique id for each interpreter, could be the global counter of the call beginning
+    id: Expression<F>,
+    global_counter: Expression<F>,
+    program_counter: Expression<F>,
+    stack_pointer: Expression<F>,
+    gas_counter: Expression<F>,
+    memory_size: Expression<F>,
+}
+
+struct InterpreterStateInstance {
+    id: usize,
+    global_counter: usize,
+    program_counter: usize,
+    stack_pointer: usize,
+    gas_counter: u64,
+    memory_size: usize,
+}
+
+trait OpGadget<F: FieldExt> {
+    fn cases() -> HashSet<Case>;
+
+    fn construct(words: &[Word<F>], all: &[Allocation<F>]) -> Self;
+
+    fn constraints(
+        &self,
+        interpreter_state_curr: &InterpreterState<F>,
+        interpreter_state_next: &InterpreterState<F>,
+    ) -> Vec<ExecutionResult<F>>;
+
+    fn transit(&self, interpreter_state: &mut InterpreterStateInstance);
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        /* TODO: execution_result: ExecutionResultInstance */
+    );
+
+    // TODO: figure out how the parsing api would be like
+}
+
+struct AddGadget<F> {
+    success: (Word<F>, Word<F>, Word<F>, [Allocation<F>; 32]),
+    out_of_gas: (Allocation<F>, Allocation<F>),
+}
+
+impl<F: FieldExt> OpGadget<F> for AddGadget<F> {
+    fn cases() -> HashSet<Case> {
+        HashSet::from_iter([Case::Success, Case::OutOfGas, Case::StackUnderflow(2)])
+    }
+
+    fn construct(words: &[Word<F>], all: &[Allocation<F>]) -> Self {
+        Self {
+            success: (
+                words[0].clone(),
+                words[1].clone(),
+                words[2].clone(),
+                all[96..128].to_owned().try_into().unwrap(),
+            ),
+            out_of_gas: (all[0].clone(), all[1].clone()),
+        }
+    }
+
+    fn constraints(
+        &self,
+        interpreter_state_curr: &InterpreterState<F>,
+        interpreter_state_next: &InterpreterState<F>,
+    ) -> Vec<ExecutionResult<F>> {
+        let success = {
+            let exp_256 = Expression::Constant(F::from_u64(1 << 8));
+
+            // interpreter state transition constraints
+            let interpreter_state_transition_constraints = vec![
+                interpreter_state_next.global_counter.clone()
+                    - (interpreter_state_curr.global_counter.clone()
+                        + Expression::Constant(F::from_u64(3))),
+                interpreter_state_next.stack_pointer.clone()
+                    - (interpreter_state_curr.stack_pointer.clone()
+                        + Expression::Constant(F::from_u64(1))),
+                interpreter_state_next.program_counter.clone()
+                    - (interpreter_state_curr.program_counter.clone()
+                        + Expression::Constant(F::from_u64(1))),
+                interpreter_state_next.gas_counter.clone()
+                    - (interpreter_state_curr.gas_counter.clone()
+                        + Expression::Constant(F::from_u64(3))),
+            ];
+
+            let (a, b, c, carry) = &self.success;
+            // add constraints
+            let mut add_constraints = vec![
+                (carry[0].exp.clone() * exp_256.clone() + c.exp.clone())
+                    - (a.allocs[0].exp.clone() + b.allocs[0].exp.clone()),
+            ];
+            for idx in 1..32 {
+                add_constraints.push(
+                    (carry[idx].exp.clone() * exp_256.clone() + c.exp.clone())
+                        - (a.allocs[idx].exp.clone()
+                            + b.allocs[idx].exp.clone()
+                            + carry[idx - 1].exp.clone()),
+                )
+            }
+
+            ExecutionResult {
+                case: Case::Success,
+                linear_constraints: [interpreter_state_transition_constraints, add_constraints]
+                    .concat(),
+                lookups: vec![
+                    Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                        index_offset: 1,
+                        value: a.exp.clone(),
+                        is_write: false,
+                    }),
+                    Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                        index_offset: 2,
+                        value: b.exp.clone(),
+                        is_write: false,
+                    }),
+                    Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                        index_offset: 1,
+                        value: c.exp.clone(),
+                        is_write: true,
+                    }),
+                ],
+            }
+        };
+
+        let out_of_gas = {
+            let (one, two, three) = (
+                Expression::Constant(F::from_u64(1)),
+                Expression::Constant(F::from_u64(2)),
+                Expression::Constant(F::from_u64(3)),
+            );
+            let (gas_available, gas_overdemand) = &self.out_of_gas;
+            ExecutionResult {
+                case: Case::OutOfGas,
+                linear_constraints: vec![
+                    interpreter_state_curr.gas_counter.clone() + three.clone()
+                        - (gas_available.exp.clone() + gas_overdemand.exp.clone()),
+                    (gas_overdemand.exp.clone() - one)
+                        * (gas_overdemand.exp.clone() - two)
+                        * (gas_overdemand.exp.clone() - three),
+                ],
+                lookups: vec![Lookup::BusMappingLookup(
+                    BusMappingLookup::InterpreterContext {
+                        key: InterpreterContextKey::GasAvailable,
+                        value: gas_available.exp.clone(),
+                    },
+                )],
+            }
+        };
+
+        vec![success, out_of_gas]
+    }
+
+    fn transit(&self, interpreter_state: &mut InterpreterStateInstance) {
+        interpreter_state.global_counter += 3;
+        interpreter_state.program_counter += 1;
+        interpreter_state.stack_pointer += 1;
+        interpreter_state.gas_counter += 3;
+    }
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        /* TODO: execution_result: ExecutionResultInstance */
+    ) {
+    }
+}
+
+struct EvmCircuit<F> {
+    add_gadget: AddGadget<F>,
+}
+
+impl<F: FieldExt> EvmCircuit<F> {
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        // TODO: figure out how many min cells required
+        let min_cells_required = 320;
+        let width = 32;
+        let height = min_cells_required / width + (min_cells_required % width != 0) as usize;
+
+        let columns = (0..width).map(|_| meta.advice_column()).collect::<Vec<_>>();
+        let mut allocations = Vec::with_capacity(width * height);
+        meta.create_gate("allocations", |meta| {
+            for w in 0..width {
+                for h in 0..height as i32 {
+                    allocations.push(meta.query_advice(columns[w], Rotation(h)));
+                }
+            }
+            vec![Expression::Constant(F::zero())]
+        });
+
+        // TODO: allocate op switch
+        // TODO: allocate case switch
+        // TODO: allocate ? word
+        // TODO: handle common error like StackUnderflow or StackOverflow
+
+        let add_gadget = AddGadget::construct(&[], &[]);
+
+        EvmCircuit { add_gadget }
+    }
+
+    fn assign(
+        &self,
+        mut layouter: impl Layouter<F>,
+        /* TODO: execution_results: Vec<ExecutionResultInstance> */
+    ) -> Result<(), Error> {
+        // for execution_result in execution_results {
+        //     self.opcode_gadgets[0]
+        // }
+        Ok(())
+    }
+}
+
+// DISCUSSION:
+// 1. How would ExecutionResultInstance be like? (it should be parse from the output of zkevm-test-vector)
+// enum BusMappingInstance {
+//     InterpreterContext {
+//         key: InterpreterContextKey,
+//         value: [u8; 32], /* U256 or Word */
+//     },
+//     InterpreterState {
+//         key: InterpreterStateKey,
+//         value: [u8; 32], /* U256 or Word */
+//         is_write: bool,
+//     },
+//     Stack {
+//         index: usize,
+//         value: [u8; 32], /* U256 or Word */
+//         is_write: bool,
+//     },
+//     MemoryWord {
+//         id: usize,
+//         index: usize,
+//         value: Vec<u8>,
+//         is_write: bool,
+//     },
+//     MemoryByte {
+//         id: usize,
+//         index: usize,
+//         value: u8,
+//         is_write: bool,
+//     },
+//     Storage {
+//         address: [u8; 20],  /* U160 or Address */
+//         location: [u8; 32], /* U160 or Address */
+//         value: [u8; 32],    /* U256 or Word */
+//         is_write: bool,
+//     },
+//     // Code,
+//     // Block,
+//     // Tx,
+//     // TxCalldata,
+//     // AccountNonce,
+//     // AccountBalance,
+//     // AccountCodeHash,
+//     // AccountStorageRoot,
+// }
+
+// struct ExecutionResultInstance {
+//     opcode: u8,
+//     case: Case,
+//     bas_mappings: Vec<BusMappingInstance>,
+// }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -249,7 +249,7 @@ enum Case {
     WriteProtection,
     // return data out of bound
     ReturnDataOutOfBounds,
-    // contract must not begin with 0xef due to EOF
+    // contract must not begin with 0xef due to EIP #3541 EVM Object Format (EOF)
     InvalidBeginningCode,
     // stack underflow
     StackUnderflow,

--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -41,14 +41,14 @@ struct CaseConfig {
     case: Case,
     num_word: usize,
     num_cell: usize,
-    will_resume: bool,
+    will_halt: bool,
 }
 
 impl CaseConfig {
     fn num_total_cell(&self) -> usize {
         32 * self.num_word
             + self.num_cell
-            + if self.will_resume {
+            + if self.will_halt {
                 NUM_CELL_RESUMPTION
             } else {
                 0
@@ -378,7 +378,7 @@ impl<F: FieldExt> OpExecutionGadget<F> {
                     .map(|idx| free_cells[idx].clone())
                     .collect();
 
-                let resumption = if case_config.will_resume {
+                let resumption = if case_config.will_halt {
                     Some(resumption.clone())
                 } else {
                     None

--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -1,0 +1,443 @@
+use super::{
+    Case, Cell, Constraint, ExecutionStep, OpExecutionStateInstance, Word,
+};
+use halo2::{
+    arithmetic::FieldExt,
+    circuit::Region,
+    plonk::{ConstraintSystem, Error, Expression},
+};
+use std::collections::HashMap;
+
+mod arithmetic;
+use arithmetic::AddGadget;
+
+#[derive(Debug)]
+struct CaseConfig {
+    case: Case,
+    num_word: usize,
+    num_cell: usize,
+    will_resume: bool,
+}
+
+impl CaseConfig {
+    fn total_cells<F: FieldExt>(&self) -> usize {
+        32 * self.num_word
+            + self.num_cell
+            + if self.will_resume {
+                Resumption::<F>::SIZE
+            } else {
+                0
+            }
+    }
+}
+
+#[derive(Debug)]
+struct CaseAllocation<'a, F> {
+    case_selector: &'a Cell<F>,
+    words: Vec<Word<F>>,
+    cells: &'a [Cell<F>],
+    resumption: Option<&'a Resumption<F>>,
+}
+
+#[derive(Clone, Debug)]
+struct Resumption<F> {
+    caller_id: Cell<F>,
+    gas_available: Cell<F>,
+}
+
+impl<F: FieldExt> Resumption<F> {
+    const SIZE: usize = 2;
+
+    fn new(cells: &[Cell<F>]) -> Self {
+        assert_eq!(cells.len(), Self::SIZE);
+
+        Self {
+            caller_id: cells[0].clone(),
+            gas_available: cells[1].clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct OpExecutionState<F> {
+    is_executing: Cell<F>,
+    global_counter: Cell<F>,
+    call_id: Cell<F>,
+    program_counter: Cell<F>,
+    stack_pointer: Cell<F>,
+    gas_counter: Cell<F>,
+    opcode: Cell<F>,
+}
+
+impl<F: FieldExt> OpExecutionState<F> {
+    pub(crate) const SIZE: usize = 7;
+
+    pub(crate) fn new(cells: &[Cell<F>]) -> Self {
+        assert_eq!(cells.len(), Self::SIZE);
+
+        Self {
+            is_executing: cells[0].clone(),
+            global_counter: cells[1].clone(),
+            call_id: cells[2].clone(),
+            program_counter: cells[3].clone(),
+            stack_pointer: cells[4].clone(),
+            gas_counter: cells[5].clone(),
+            opcode: cells[6].clone(),
+        }
+    }
+}
+
+trait OpGadget<F: FieldExt> {
+    const RESPONSIBLE_OPCODES: &'static [u8];
+
+    const CASE_CONFIGS: &'static [CaseConfig];
+
+    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self;
+
+    fn constraints(
+        &self,
+        op_execution_state_curr: &OpExecutionState<F>,
+        op_execution_state_next: &OpExecutionState<F>,
+    ) -> Vec<Constraint<F>>;
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        op_execution_state: &mut OpExecutionStateInstance,
+        execution_step: &ExecutionStep,
+    ) -> Result<(), Error>;
+}
+
+#[derive(Clone)]
+pub(crate) struct OpExecutionGadget<F> {
+    r: F,
+    op_execution_state_curr: OpExecutionState<F>,
+    op_execution_state_next: OpExecutionState<F>,
+    op_selectors: Vec<Cell<F>>,
+    free_cells: Vec<Cell<F>>,
+    resumption: Resumption<F>,
+    // TODO: use OpcodeId from bus_mapping
+    op_selector_idx_map: HashMap<u8, usize>,
+    default_values_map: HashMap<(usize, Case), Vec<(usize, F)>>,
+    add_gadget: AddGadget<F>,
+}
+
+impl<F: FieldExt> OpExecutionGadget<F> {
+    // FIXME: naive estimation, should be optmize to fit in the future
+    pub(crate) const NUM_OP_GADGETS: usize = 80;
+
+    pub(crate) fn configure(
+        meta: &mut ConstraintSystem<F>,
+        selector: Expression<F>,
+        op_execution_state_curr: OpExecutionState<F>,
+        op_execution_state_next: OpExecutionState<F>,
+        cells: &[Cell<F>],
+        r: F,
+    ) -> Self {
+        let (op_selectors, free_cells) = cells.split_at(Self::NUM_OP_GADGETS);
+        let resumption = Resumption::new(
+            &free_cells[free_cells.len() - Resumption::<F>::SIZE..],
+        );
+
+        let mut op_selector_idx_map = HashMap::new();
+        let mut default_values_map = HashMap::new();
+        let /* mut */ op_selector_idx = 0;
+
+        let mut constraints = vec![Constraint {
+            name: "op selectors",
+            selector: Expression::Constant(F::one()),
+            linear_combinations: bool_switches_constraints(op_selectors),
+            lookups: vec![],
+        }];
+
+        macro_rules! constrcut_op_gadget {
+            {} => {};
+            {$name:ident = $gadget:ident} => {
+                let $name = Self::constrcut_op_gadget::<$gadget::<F>>(
+                    &op_execution_state_curr,
+                    &op_execution_state_next,
+                    op_selectors,
+                    op_selector_idx,
+                    free_cells,
+                    &resumption,
+                    r,
+                    &mut op_selector_idx_map,
+                    &mut default_values_map,
+                    &mut constraints,
+                );
+            };
+            {$name:ident = $gadget:ident;} => {
+                constrcut_op_gadget!{$name = $gadget};
+            };
+            {$name:ident = $gadget:ident; $($tail:tt)+} => {
+                constrcut_op_gadget!{$name = $gadget};
+                op_selector_idx += 1;
+                constrcut_op_gadget!{$($tail)+};
+            };
+        }
+
+        constrcut_op_gadget! {
+            add_gadget = AddGadget;
+        }
+
+        for constraint in constraints.into_iter() {
+            let Constraint {
+                name,
+                selector: constraint_selector,
+                linear_combinations,
+                ..
+                // lookups,
+            } = constraint;
+
+            meta.create_gate(name, |_| {
+                let synthetic_selector = selector.clone() * constraint_selector;
+                linear_combinations
+                    .into_iter()
+                    .map(|poly| synthetic_selector.clone() * poly)
+                    .collect::<Vec<_>>()
+            });
+
+            // TODO: propagate lookups to top level with correct selector
+        }
+
+        Self {
+            op_execution_state_curr,
+            op_execution_state_next,
+            op_selectors: op_selectors.to_vec(),
+            free_cells: free_cells.to_vec(),
+            r,
+            op_selector_idx_map,
+            default_values_map,
+            resumption,
+            add_gadget,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn constrcut_op_gadget<O: OpGadget<F>>(
+        op_execution_state_curr: &OpExecutionState<F>,
+        op_execution_state_next: &OpExecutionState<F>,
+        op_selectors: &[Cell<F>],
+        op_selector_idx: usize,
+        free_cells: &[Cell<F>],
+        resumption: &Resumption<F>,
+        r: F,
+        op_selector_idx_map: &mut HashMap<u8, usize>,
+        default_values_map: &mut HashMap<(usize, Case), Vec<(usize, F)>>,
+        constraints: &mut Vec<Constraint<F>>,
+    ) -> O {
+        assert!(op_selector_idx < Self::NUM_OP_GADGETS);
+
+        let op_selector = op_selectors[op_selector_idx].clone();
+
+        // opcode should only be handled by one gadget
+        for opcode in O::RESPONSIBLE_OPCODES {
+            assert!(
+                op_selector_idx_map
+                    .insert(*opcode, op_selector_idx)
+                    .is_none(),
+                "opcode is already handled by another gadget"
+            );
+        }
+
+        let case_configs = O::CASE_CONFIGS;
+        let num_case = case_configs.len();
+        let case_selectors = &free_cells[..num_case];
+
+        constraints.push(Constraint {
+            name: "case selectors",
+            selector: op_selector.exp(),
+            linear_combinations: bool_switches_constraints(case_selectors),
+            lookups: vec![],
+        });
+
+        let case_allocations = case_configs
+            .iter()
+            .enumerate()
+            .map(|(case_selector_idx, case_config)| {
+                let mut offset = num_case;
+                let mut default_values = Vec::new();
+
+                // case selector values to assign
+                for idx in 0..case_configs.len() {
+                    default_values.push((
+                        idx,
+                        F::from_u64((idx == case_selector_idx) as u64),
+                    ));
+                }
+
+                let total_cells = num_case + case_config.total_cells::<F>();
+                assert!(
+                    total_cells <= free_cells.len(),
+                    "too many cells allocated"
+                );
+
+                // TODO: add word's cells into 8-bit range lookup
+
+                let num_cell_of_word = 32 * case_config.num_word;
+                let words = free_cells[offset..offset + num_cell_of_word]
+                    .chunks(32)
+                    .map(|free_cells| Word::encode(free_cells, r))
+                    .collect::<Vec<_>>();
+                offset += num_cell_of_word;
+
+                let cells = &free_cells[offset..offset + case_config.num_cell];
+                offset += case_config.num_cell;
+
+                let resumption = if case_config.will_resume {
+                    Some(resumption)
+                } else {
+                    None
+                };
+
+                let num_unused = free_cells.len() - total_cells;
+                for idx in offset..offset + num_unused {
+                    default_values.push((idx, F::zero()));
+                }
+
+                assert!(
+                    default_values_map
+                        .insert(
+                            (op_selector_idx, case_config.case),
+                            default_values
+                        )
+                        .is_none(),
+                    "duplicated case configured"
+                );
+
+                let case_selector = &case_selectors[case_selector_idx];
+                constraints.push(Constraint {
+                    name: "case unused",
+                    selector: op_selector.exp() * case_selector.exp(),
+                    linear_combinations: (offset..offset + num_unused)
+                        .map(|idx| free_cells[idx].exp())
+                        .collect(),
+                    lookups: vec![],
+                });
+
+                CaseAllocation {
+                    case_selector,
+                    words,
+                    cells,
+                    resumption,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let gadget = O::construct(case_allocations);
+
+        constraints.append(
+            &mut gadget
+                .constraints(op_execution_state_curr, op_execution_state_next)
+                .into_iter()
+                .map(|mut constraint| {
+                    constraint.selector =
+                        op_selector.exp() * constraint.selector.clone();
+                    constraint
+                })
+                .collect(),
+        );
+
+        gadget
+    }
+
+    pub(crate) fn assign_execution_step(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        op_execution_state: &mut OpExecutionStateInstance,
+        execution_step: Option<&ExecutionStep>,
+    ) -> Result<(), Error> {
+        assert!(op_execution_state.is_executing);
+
+        self.op_execution_state_curr.is_executing.assign(
+            region,
+            offset,
+            Some(F::one()),
+        )?;
+        self.op_execution_state_curr.global_counter.assign(
+            region,
+            offset,
+            Some(F::from_u64(op_execution_state.global_counter as u64)),
+        )?;
+        self.op_execution_state_curr.call_id.assign(
+            region,
+            offset,
+            Some(F::from_u64(op_execution_state.call_id as u64)),
+        )?;
+        self.op_execution_state_curr.program_counter.assign(
+            region,
+            offset,
+            Some(F::from_u64(op_execution_state.program_counter as u64)),
+        )?;
+        self.op_execution_state_curr.stack_pointer.assign(
+            region,
+            offset,
+            Some(F::from_u64(op_execution_state.stack_pointer as u64)),
+        )?;
+        self.op_execution_state_curr.gas_counter.assign(
+            region,
+            offset,
+            Some(F::from_u64(op_execution_state.gas_counter as u64)),
+        )?;
+
+        if let Some(execution_step) = execution_step {
+            self.op_execution_state_curr.opcode.assign(
+                region,
+                offset,
+                Some(F::from_u64(execution_step.opcode as u64)),
+            )?;
+
+            let &op_selector_idx = self
+                .op_selector_idx_map
+                .get(&execution_step.opcode)
+                .expect("opcode to be handled");
+            for (idx, op_selector) in self.op_selectors.iter().enumerate() {
+                op_selector.assign(
+                    region,
+                    offset,
+                    Some(F::from_u64((idx == op_selector_idx) as u64)),
+                )?;
+            }
+
+            let default_values = self
+                .default_values_map
+                .get(&(op_selector_idx, execution_step.case))
+                .expect("case to be handled");
+            for (idx, value) in default_values {
+                self.free_cells[*idx].assign(region, offset, Some(*value))?;
+            }
+
+            match execution_step.opcode {
+                1 | 3 => self.add_gadget.assign(
+                    region,
+                    offset,
+                    op_execution_state,
+                    execution_step,
+                )?,
+                _ => unimplemented!(),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn bool_switches_constraints<F: FieldExt>(
+    bool_switches: &[Cell<F>],
+) -> Vec<Expression<F>> {
+    let one = Expression::Constant(F::one());
+
+    let mut constraints = Vec::with_capacity(bool_switches.len() + 1);
+    let mut sum_to_one = Expression::Constant(F::zero());
+
+    for switch in bool_switches {
+        constraints.push(switch.exp() * (one.clone() - switch.exp()));
+        sum_to_one = sum_to_one + switch.exp();
+    }
+
+    constraints.push(one - sum_to_one);
+
+    constraints
+}

--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -15,9 +15,11 @@ use halo2::{
 use std::{collections::HashMap, ops::Range};
 
 mod arithmetic;
+mod comparator;
 mod push;
 
 use arithmetic::AddGadget;
+use comparator::LtGadget;
 use push::PushGadget;
 
 fn bool_switches_constraints<F: FieldExt>(
@@ -207,6 +209,7 @@ pub(crate) struct OpExecutionGadget<F> {
     preset_map: HashMap<(usize, Case), Preset<F>>,
     add_gadget: AddGadget<F>,
     push_gadget: PushGadget<F>,
+    lt_gadget: LtGadget<F>,
 }
 
 impl<F: FieldExt> OpExecutionGadget<F> {
@@ -262,6 +265,7 @@ impl<F: FieldExt> OpExecutionGadget<F> {
 
         construct_op_gadget!(add_gadget);
         construct_op_gadget!(push_gadget);
+        construct_op_gadget!(lt_gadget);
         let _ = qs_op_idx;
 
         for constraint in constraints.into_iter() {
@@ -299,6 +303,7 @@ impl<F: FieldExt> OpExecutionGadget<F> {
             resumption,
             add_gadget,
             push_gadget,
+            lt_gadget,
         }
     }
 
@@ -531,6 +536,12 @@ impl<F: FieldExt> OpExecutionGadget<F> {
                 )?,
                 // PUSH1, ..., PUSH32
                 OpcodeId(0x60..=0x7f) => self.push_gadget.assign(
+                    region,
+                    offset,
+                    core_state,
+                    execution_step,
+                )?,
+                OpcodeId::LT | OpcodeId::GT => self.lt_gadget.assign(
                     region,
                     offset,
                     core_state,

--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -138,10 +138,10 @@ impl<F: FieldExt> Resumption<F> {
 #[derive(Clone, Debug)]
 pub(crate) struct OpExecutionState<F> {
     pub is_executing: Cell<F>,
-    global_counter: Cell<F>,
-    call_id: Cell<F>,
-    program_counter: Cell<F>,
-    stack_pointer: Cell<F>,
+    pub global_counter: Cell<F>,
+    pub call_id: Cell<F>,
+    pub program_counter: Cell<F>,
+    pub stack_pointer: Cell<F>,
     gas_counter: Cell<F>,
     opcode: Cell<F>,
 }

--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -1,6 +1,6 @@
 use super::{
     param::{
-        CIRCUIT_HEIGHT, CIRCUIT_WIDTH, NUM_CELL_OP_EXECTION_STATE,
+        CIRCUIT_HEIGHT, CIRCUIT_WIDTH, NUM_CELL_OP_EXECUTION_STATE,
         NUM_CELL_OP_GADGET_SELECTOR, NUM_CELL_RESUMPTION,
     },
     Case, Cell, Constraint, CoreStateInstance, ExecutionStep, Lookup, Word,
@@ -153,7 +153,7 @@ pub(crate) struct OpExecutionState<F> {
 
 impl<F: FieldExt> OpExecutionState<F> {
     pub(crate) fn new(cells: &[Cell<F>]) -> Self {
-        assert_eq!(cells.len(), NUM_CELL_OP_EXECTION_STATE);
+        assert_eq!(cells.len(), NUM_CELL_OP_EXECUTION_STATE);
 
         Self {
             is_executing: cells[0].clone(),

--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -5,6 +5,7 @@ use super::{
     },
     Case, Cell, Constraint, CoreStateInstance, ExecutionStep, Lookup, Word,
 };
+use crate::util::Expr;
 use bus_mapping::evm::OpcodeId;
 use halo2::{
     arithmetic::FieldExt,
@@ -22,17 +23,15 @@ use push::PushGadget;
 fn bool_switches_constraints<F: FieldExt>(
     bool_switches: &[Cell<F>],
 ) -> Vec<Expression<F>> {
-    let one = Expression::Constant(F::one());
-
     let mut constraints = Vec::with_capacity(bool_switches.len() + 1);
-    let mut sum_to_one = Expression::Constant(F::zero());
+    let mut sum_to_one = 0.expr();
 
     for switch in bool_switches {
-        constraints.push(switch.expr() * (one.clone() - switch.expr()));
+        constraints.push(switch.expr() * (1.expr() - switch.expr()));
         sum_to_one = sum_to_one + switch.expr();
     }
 
-    constraints.push(one - sum_to_one);
+    constraints.push(1.expr() - sum_to_one);
 
     constraints
 }
@@ -235,7 +234,7 @@ impl<F: FieldExt> OpExecutionGadget<F> {
 
         let mut constraints = vec![Constraint {
             name: "op selectors",
-            selector: Expression::Constant(F::one()),
+            selector: 1.expr(),
             polys: bool_switches_constraints(qs_ops),
             lookups: vec![],
         }];
@@ -276,7 +275,7 @@ impl<F: FieldExt> OpExecutionGadget<F> {
 
             meta.create_gate(name, |_| {
                 if polys.is_empty() {
-                    return vec![Expression::Constant(F::zero())];
+                    return vec![0.expr()];
                 }
                 polys
                     .into_iter()

--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -1,7 +1,7 @@
 use super::{
     param::{
-        NUM_CELL_OP_EXECTION_STATE, NUM_CELL_OP_GADGET_SELECTOR,
-        NUM_CELL_RESUMPTION,
+        CIRCUIT_HEIGHT, CIRCUIT_WIDTH, NUM_CELL_OP_EXECTION_STATE,
+        NUM_CELL_OP_GADGET_SELECTOR, NUM_CELL_RESUMPTION,
     },
     Case, Cell, Constraint, CoreStateInstance, ExecutionStep, Lookup, Word,
 };
@@ -10,7 +10,7 @@ use halo2::{
     circuit::Region,
     plonk::{ConstraintSystem, Error, Expression},
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Range};
 
 mod arithmetic;
 use arithmetic::AddGadget;
@@ -42,7 +42,7 @@ struct CaseConfig {
 }
 
 impl CaseConfig {
-    fn total_cells(&self) -> usize {
+    fn num_total_cell(&self) -> usize {
         32 * self.num_word
             + self.num_cell
             + if self.will_resume {
@@ -51,14 +51,71 @@ impl CaseConfig {
                 0
             }
     }
+
+    // allocate indexes of cells for words, cells and unused. It assumes input
+    // free_cells are in order of rotation and then column index.
+    fn allocation_idxs<F: FieldExt>(
+        &self,
+        num_case: usize,
+        free_cells: &[Cell<F>],
+    ) -> (Vec<Range<usize>>, Vec<usize>, Vec<usize>) {
+        let num_free_cell = free_cells.len();
+        let num_total_cell = num_case + self.num_total_cell();
+        assert!(num_free_cell >= num_total_cell);
+
+        let num_unused = num_free_cell - num_total_cell;
+        let word_height = 32 / CIRCUIT_WIDTH;
+
+        let mut word_ranges = Vec::with_capacity(self.num_word);
+        let mut cell_idxs = Vec::with_capacity(self.num_cell + num_unused);
+
+        let mut begin_idx = num_case;
+        let mut rotation_range = Range::default();
+        for (idx, cell) in free_cells.iter().enumerate() {
+            // skip case selector
+            if idx < num_case {
+                continue;
+            }
+
+            let next_idx = idx + 1;
+            if next_idx == num_free_cell || word_ranges.len() == self.num_word {
+                cell_idxs.append(&mut (idx..num_free_cell).collect());
+                break;
+            }
+
+            // find cells in rectangle region for words
+            if rotation_range.contains(&cell.rotation) {
+                if next_idx - begin_idx == 32 {
+                    let next_cell = &free_cells[next_idx];
+                    word_ranges.push(begin_idx..next_idx);
+                    begin_idx = next_idx;
+                    rotation_range =
+                        next_cell.rotation..next_cell.rotation + word_height;
+                }
+            } else {
+                cell_idxs.append(&mut (begin_idx..idx).collect());
+                begin_idx = idx;
+                rotation_range = cell.rotation..cell.rotation + word_height;
+            }
+        }
+
+        assert_eq!(
+            word_ranges.len(),
+            self.num_word,
+            "not enough rectangle regions for words"
+        );
+
+        let (cell_idxs, unused_idxs) = cell_idxs.split_at(self.num_cell);
+        (word_ranges, cell_idxs.to_vec(), unused_idxs.to_vec())
+    }
 }
 
 #[derive(Debug)]
-struct CaseAllocation<'a, F> {
-    selector: &'a Cell<F>,
+struct CaseAllocation<F> {
+    selector: Cell<F>,
     words: Vec<Word<F>>,
-    cells: &'a [Cell<F>],
-    resumption: Option<&'a Resumption<F>>,
+    cells: Vec<Cell<F>>,
+    resumption: Option<Resumption<F>>,
 }
 
 #[derive(Clone, Debug)]
@@ -80,7 +137,7 @@ impl<F: FieldExt> Resumption<F> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct OpExecutionState<F> {
-    is_executing: Cell<F>,
+    pub is_executing: Cell<F>,
     global_counter: Cell<F>,
     call_id: Cell<F>,
     program_counter: Cell<F>,
@@ -127,44 +184,55 @@ trait OpGadget<F: FieldExt> {
     ) -> Result<(), Error>;
 }
 
+// Preset stores default values for each case of op gadget
+#[derive(Clone, Default)]
+struct Preset<F> {
+    qs_byte_lookups: [F; CIRCUIT_HEIGHT],
+    free_cells: Vec<(usize, F)>,
+}
+
 #[derive(Clone)]
 pub(crate) struct OpExecutionGadget<F> {
     r: F,
+    qs_byte_lookups: Vec<Cell<F>>,
     op_execution_state_curr: OpExecutionState<F>,
     op_execution_state_next: OpExecutionState<F>,
-    op_selectors: Vec<Cell<F>>,
+    qs_ops: Vec<Cell<F>>,
     free_cells: Vec<Cell<F>>,
     resumption: Resumption<F>,
     // TODO: use OpcodeId from bus_mapping
-    op_selector_idx_map: HashMap<u8, usize>,
-    default_values_map: HashMap<(usize, Case), Vec<(usize, F)>>,
+    qs_op_idx_map: HashMap<u8, usize>,
+    preset_map: HashMap<(usize, Case), Preset<F>>,
     add_gadget: AddGadget<F>,
 }
 
 impl<F: FieldExt> OpExecutionGadget<F> {
+    // TODO: refactor input type
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn configure(
         meta: &mut ConstraintSystem<F>,
         r: F,
-        q_step: Expression<F>,
+        qs_op_execution: Expression<F>,
+        qs_byte_lookups: Vec<Cell<F>>,
         op_execution_state_curr: OpExecutionState<F>,
         op_execution_state_next: OpExecutionState<F>,
         free_cells: Vec<Cell<F>>,
         independent_lookups: &mut Vec<(Expression<F>, Vec<Lookup<F>>)>,
     ) -> Self {
-        let (op_selectors, free_cells) =
+        let (qs_ops, free_cells) =
             free_cells.split_at(NUM_CELL_OP_GADGET_SELECTOR);
         let resumption = Resumption::new(
             &free_cells[free_cells.len() - NUM_CELL_RESUMPTION..],
         );
 
-        let mut op_selector_idx_map = HashMap::new();
-        let mut default_values_map = HashMap::new();
-        let /* mut */ op_selector_idx = 0;
+        let mut qs_op_idx_map = HashMap::new();
+        let mut preset_map = HashMap::new();
+        let /* mut */ qs_op_idx = 0;
 
         let mut constraints = vec![Constraint {
             name: "op selectors",
             selector: Expression::Constant(F::one()),
-            linear_combinations: bool_switches_constraints(op_selectors),
+            linear_combinations: bool_switches_constraints(qs_ops),
             lookups: vec![],
         }];
 
@@ -175,12 +243,12 @@ impl<F: FieldExt> OpExecutionGadget<F> {
                     r,
                     &op_execution_state_curr,
                     &op_execution_state_next,
-                    op_selectors,
-                    op_selector_idx,
+                    qs_ops,
+                    qs_op_idx,
                     free_cells,
                     &resumption,
-                    &mut op_selector_idx_map,
-                    &mut default_values_map,
+                    &mut qs_op_idx_map,
+                    &mut preset_map,
                     &mut constraints,
                 );
             };
@@ -189,7 +257,7 @@ impl<F: FieldExt> OpExecutionGadget<F> {
             };
             {$name:ident = $gadget:ident; $($tail:tt)+} => {
                 constrcut_op_gadget!{$name = $gadget};
-                op_selector_idx += 1;
+                qs_op_idx += 1;
                 constrcut_op_gadget!{$($tail)+};
             };
         }
@@ -201,13 +269,12 @@ impl<F: FieldExt> OpExecutionGadget<F> {
         for constraint in constraints.into_iter() {
             let Constraint {
                 name,
-                selector: constraint_selector,
+                selector: qs_constraint,
                 linear_combinations,
                 lookups,
             } = constraint;
 
-            let synthetic_selector =
-                q_step.clone() * constraint_selector.clone();
+            let qs = qs_op_execution.clone() * qs_constraint.clone();
 
             meta.create_gate(name, |_| {
                 if linear_combinations.is_empty() {
@@ -215,21 +282,22 @@ impl<F: FieldExt> OpExecutionGadget<F> {
                 }
                 linear_combinations
                     .into_iter()
-                    .map(|poly| synthetic_selector.clone() * poly)
+                    .map(|poly| qs.clone() * poly)
                     .collect::<Vec<_>>()
             });
 
-            independent_lookups.push((synthetic_selector, lookups));
+            independent_lookups.push((qs, lookups));
         }
 
         Self {
             r,
+            qs_byte_lookups,
             op_execution_state_curr,
             op_execution_state_next,
-            op_selectors: op_selectors.to_vec(),
+            qs_ops: qs_ops.to_vec(),
             free_cells: free_cells.to_vec(),
-            op_selector_idx_map,
-            default_values_map,
+            qs_op_idx_map,
+            preset_map,
             resumption,
             add_gadget,
         }
@@ -240,103 +308,100 @@ impl<F: FieldExt> OpExecutionGadget<F> {
         r: F,
         op_execution_state_curr: &OpExecutionState<F>,
         op_execution_state_next: &OpExecutionState<F>,
-        op_selectors: &[Cell<F>],
-        op_selector_idx: usize,
+        qs_ops: &[Cell<F>],
+        qs_op_idx: usize,
         free_cells: &[Cell<F>],
         resumption: &Resumption<F>,
-        op_selector_idx_map: &mut HashMap<u8, usize>,
-        default_values_map: &mut HashMap<(usize, Case), Vec<(usize, F)>>,
+        qs_op_idx_map: &mut HashMap<u8, usize>,
+        preset_map: &mut HashMap<(usize, Case), Preset<F>>,
         constraints: &mut Vec<Constraint<F>>,
     ) -> O {
-        assert!(op_selector_idx < NUM_CELL_OP_GADGET_SELECTOR);
+        assert!(qs_op_idx < NUM_CELL_OP_GADGET_SELECTOR);
 
-        let op_selector = op_selectors[op_selector_idx].clone();
+        let qs_op = &qs_ops[qs_op_idx];
 
         // opcode should only be handled by one gadget
         for opcode in O::RESPONSIBLE_OPCODES {
             assert!(
-                op_selector_idx_map
-                    .insert(*opcode, op_selector_idx)
-                    .is_none(),
+                qs_op_idx_map.insert(*opcode, qs_op_idx).is_none(),
                 "opcode is already handled by another gadget"
             );
         }
 
         let case_configs = O::CASE_CONFIGS;
         let num_case = case_configs.len();
-        let case_selectors = &free_cells[..num_case];
+        let qs_cases = &free_cells[..num_case];
 
         constraints.push(Constraint {
             name: "case selectors",
-            selector: op_selector.exp(),
-            linear_combinations: bool_switches_constraints(case_selectors),
+            selector: qs_op.exp(),
+            linear_combinations: bool_switches_constraints(qs_cases),
             lookups: vec![],
         });
 
         let case_allocations = case_configs
             .iter()
             .enumerate()
-            .map(|(case_selector_idx, case_config)| {
-                let mut offset = num_case;
-                let mut default_values = Vec::new();
+            .map(|(q_case_idx, case_config)| {
+                let mut preset = Preset::default();
 
                 // case selector values to assign
                 for idx in 0..case_configs.len() {
-                    default_values.push((
-                        idx,
-                        F::from_u64((idx == case_selector_idx) as u64),
-                    ));
+                    preset
+                        .free_cells
+                        .push((idx, F::from_u64((idx == q_case_idx) as u64)));
                 }
 
-                let total_cells = num_case + case_config.total_cells();
-                assert!(
-                    total_cells <= free_cells.len(),
-                    "too many cells allocated"
-                );
+                let (word_ranges, cell_idxs, unused_idxs) =
+                    case_config.allocation_idxs(num_case, free_cells);
 
-                let num_cell_of_word = 32 * case_config.num_word;
-                let words = free_cells[offset..offset + num_cell_of_word]
-                    .chunks(32)
-                    .map(|free_cells| Word::new(free_cells, r))
+                let words = word_ranges
+                    .into_iter()
+                    .map(|range| {
+                        for idx in range.clone() {
+                            preset.qs_byte_lookups[free_cells[idx].rotation] =
+                                F::one();
+                        }
+                        Word::new(&free_cells[range], r)
+                    })
                     .collect::<Vec<_>>();
-                offset += num_cell_of_word;
 
-                let cells = &free_cells[offset..offset + case_config.num_cell];
-                offset += case_config.num_cell;
+                // Use drain to move out reallocated free_cells
+                let cells = cell_idxs
+                    .into_iter()
+                    .map(|idx| free_cells[idx].clone())
+                    .collect();
 
                 let resumption = if case_config.will_resume {
-                    Some(resumption)
+                    Some(resumption.clone())
                 } else {
                     None
                 };
 
-                let num_unused = free_cells.len() - total_cells;
-                for idx in offset..offset + num_unused {
-                    default_values.push((idx, F::zero()));
+                for idx in unused_idxs.iter() {
+                    preset.free_cells.push((*idx, F::zero()));
                 }
 
                 assert!(
-                    default_values_map
-                        .insert(
-                            (op_selector_idx, case_config.case),
-                            default_values
-                        )
+                    preset_map
+                        .insert((qs_op_idx, case_config.case), preset)
                         .is_none(),
                     "duplicated case configured"
                 );
 
-                let case_selector = &case_selectors[case_selector_idx];
+                let qs_case = &qs_cases[q_case_idx];
                 constraints.push(Constraint {
                     name: "case unused",
-                    selector: op_selector.exp() * case_selector.exp(),
-                    linear_combinations: (offset..offset + num_unused)
+                    selector: qs_op.exp() * qs_case.exp(),
+                    linear_combinations: unused_idxs
+                        .into_iter()
                         .map(|idx| free_cells[idx].exp())
                         .collect(),
                     lookups: vec![],
                 });
 
                 CaseAllocation {
-                    selector: case_selector,
+                    selector: qs_case.clone(),
                     words,
                     cells,
                     resumption,
@@ -352,7 +417,7 @@ impl<F: FieldExt> OpExecutionGadget<F> {
                 .into_iter()
                 .map(|mut constraint| {
                     constraint.selector =
-                        op_selector.exp() * constraint.selector.clone();
+                        qs_op.exp() * constraint.selector.clone();
                     constraint
                 })
                 .collect(),
@@ -408,23 +473,31 @@ impl<F: FieldExt> OpExecutionGadget<F> {
                 Some(F::from_u64(execution_step.opcode as u64)),
             )?;
 
-            let &op_selector_idx = self
-                .op_selector_idx_map
+            let &qs_op_idx = self
+                .qs_op_idx_map
                 .get(&execution_step.opcode)
                 .expect("opcode to be handled");
-            for (idx, op_selector) in self.op_selectors.iter().enumerate() {
-                op_selector.assign(
+            for (idx, q_op) in self.qs_ops.iter().enumerate() {
+                q_op.assign(
                     region,
                     offset,
-                    Some(F::from_u64((idx == op_selector_idx) as u64)),
+                    Some(F::from_u64((idx == qs_op_idx) as u64)),
                 )?;
             }
 
-            let default_values = self
-                .default_values_map
-                .get(&(op_selector_idx, execution_step.case))
+            let preset = self
+                .preset_map
+                .get(&(qs_op_idx, execution_step.case))
                 .expect("case to be handled");
-            for (idx, value) in default_values {
+            for (cell, value) in self
+                .qs_byte_lookups
+                .iter()
+                .zip(preset.qs_byte_lookups.iter())
+            {
+                cell.assign(region, offset, Some(*value))?;
+            }
+
+            for (idx, value) in &preset.free_cells {
                 self.free_cells[*idx].assign(region, offset, Some(*value))?;
             }
 

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -1,0 +1,370 @@
+use super::super::{
+    BusMappingLookup, Case, Cell, Constraint, ExecutionStep, Lookup, Word,
+};
+use super::{
+    CaseAllocation, CaseConfig, OpExecutionState, OpExecutionStateInstance,
+    OpGadget,
+};
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
+use std::convert::TryInto;
+
+#[derive(Clone, Debug)]
+struct AddSuccessAllocation<F> {
+    case_selector: Cell<F>,
+    swap: Cell<F>,
+    a: Word<F>,
+    b: Word<F>,
+    c: Word<F>,
+    carry: [Cell<F>; 32],
+}
+
+#[derive(Clone, Debug)]
+pub struct AddGadget<F> {
+    success: AddSuccessAllocation<F>,
+    stack_underflow: Cell<F>, // case selector
+    out_of_gas: (
+        Cell<F>, // case selector
+        Cell<F>, // gas available
+    ),
+}
+
+impl<F: FieldExt> OpGadget<F> for AddGadget<F> {
+    // AddGadget verifies ADD and SUB at the same time by an extra swap flag,
+    // when it's ADD, we annotate stack as [a, b, ...] and [c, ...],
+    // when it's SUB, we annotate stack as [c, b, ...] and [a, ...].
+    // Then we verify if a + b - c is zero.
+    const RESPONSIBLE_OPCODES: &'static [u8] = &[1, 3];
+
+    const CASE_CONFIGS: &'static [CaseConfig] = &[
+        CaseConfig {
+            case: Case::Success,
+            num_word: 3,  // a + b + c
+            num_cell: 33, // 32 carry + swap
+            will_resume: false,
+        },
+        CaseConfig {
+            case: Case::StackUnderflow,
+            num_word: 0,
+            num_cell: 0,
+            will_resume: true,
+        },
+        CaseConfig {
+            case: Case::OutOfGas,
+            num_word: 0,
+            num_cell: 0,
+            will_resume: true,
+        },
+    ];
+
+    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self {
+        let [mut success, stack_underflow, out_of_gas]: [CaseAllocation<F>; 3] =
+            case_allocations.try_into().unwrap();
+        Self {
+            success: AddSuccessAllocation {
+                case_selector: success.case_selector.clone(),
+                swap: success.cells[0].clone(),
+                a: success.words.pop().unwrap(),
+                b: success.words.pop().unwrap(),
+                c: success.words.pop().unwrap(),
+                carry: success.cells[1..].to_owned().try_into().unwrap(),
+            },
+            stack_underflow: stack_underflow.case_selector.clone(),
+            out_of_gas: (
+                out_of_gas.case_selector.clone(),
+                out_of_gas.resumption.unwrap().gas_available.clone(),
+            ),
+        }
+    }
+
+    fn constraints(
+        &self,
+        op_execution_state_curr: &OpExecutionState<F>,
+        op_execution_state_next: &OpExecutionState<F>,
+    ) -> Vec<Constraint<F>> {
+        let (add, sub) = (
+            Expression::Constant(F::from_u64(1)),
+            Expression::Constant(F::from_u64(3)),
+        );
+        let opcode = op_execution_state_curr.opcode.exp();
+
+        let common = {
+            Constraint {
+                name: "AddGadget common",
+                selector: Expression::Constant(F::one()),
+                linear_combinations: vec![
+                    (opcode.clone() - add.clone())
+                        * (opcode.clone() - sub.clone()),
+                ],
+                lookups: vec![],
+            }
+        };
+
+        let success = {
+            let (one, exp_256) = (
+                Expression::Constant(F::one()),
+                Expression::Constant(F::from_u64(1 << 8)),
+            );
+
+            // interpreter state transition constraints
+            let op_execution_state_transition_constraints = vec![
+                op_execution_state_next.global_counter.exp()
+                    - (op_execution_state_curr.global_counter.exp()
+                        + Expression::Constant(F::from_u64(3))),
+                op_execution_state_next.stack_pointer.exp()
+                    - (op_execution_state_curr.stack_pointer.exp()
+                        + Expression::Constant(F::from_u64(1))),
+                op_execution_state_next.program_counter.exp()
+                    - (op_execution_state_curr.program_counter.exp()
+                        + Expression::Constant(F::from_u64(1))),
+                op_execution_state_next.gas_counter.exp()
+                    - (op_execution_state_curr.gas_counter.exp()
+                        + Expression::Constant(F::from_u64(3))),
+            ];
+
+            let AddSuccessAllocation {
+                case_selector,
+                swap,
+                a,
+                b,
+                c,
+                carry,
+            } = &self.success;
+
+            // swap a and c if it's SUB
+            let no_swap = one - swap.exp();
+            let swap_constraints = vec![
+                swap.exp() * no_swap.clone(),
+                swap.exp() * (opcode.clone() - sub),
+                no_swap.clone() * (opcode - add),
+            ];
+
+            // add constraints
+            let mut add_constraints = vec![
+                (carry[0].exp() * exp_256.clone() + c.cells[0].exp())
+                    - (a.cells[0].exp() + b.cells[0].exp()),
+            ];
+            for idx in 1..32 {
+                add_constraints.push(
+                    (carry[idx].exp() * exp_256.clone() + c.cells[idx].exp())
+                        - (a.cells[idx].exp()
+                            + b.cells[idx].exp()
+                            + carry[idx - 1].exp()),
+                )
+            }
+
+            #[allow(clippy::suspicious_operation_groupings)]
+            Constraint {
+                name: "AddGadget success",
+                selector: case_selector.exp(),
+                linear_combinations: [
+                    op_execution_state_transition_constraints,
+                    swap_constraints,
+                    add_constraints,
+                ]
+                .concat(),
+                lookups: vec![
+                    Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                        index_offset: 1,
+                        value: swap.exp() * c.exp() + no_swap.clone() * a.exp(),
+                        is_write: false,
+                    }),
+                    Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                        index_offset: 2,
+                        value: b.exp(),
+                        is_write: false,
+                    }),
+                    Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                        index_offset: 1,
+                        value: swap.exp() * a.exp() + no_swap * c.exp(),
+                        is_write: true,
+                    }),
+                ],
+            }
+        };
+
+        let stack_underflow = {
+            let (zero, minus_one) = (
+                Expression::Constant(F::from_u64(1024)),
+                Expression::Constant(F::from_u64(1023)),
+            );
+            let stack_pointer = op_execution_state_curr.stack_pointer.exp();
+            Constraint {
+                name: "AddGadget stack underflow",
+                selector: self.stack_underflow.exp(),
+                linear_combinations: vec![
+                    (stack_pointer.clone() - zero)
+                        * (stack_pointer - minus_one),
+                ],
+                lookups: vec![],
+            }
+        };
+
+        let out_of_gas = {
+            let (one, two, three) = (
+                Expression::Constant(F::from_u64(1)),
+                Expression::Constant(F::from_u64(2)),
+                Expression::Constant(F::from_u64(3)),
+            );
+            let (case_selector, gas_available) = &self.out_of_gas;
+            let gas_overdemand = op_execution_state_curr.gas_counter.exp()
+                + three.clone()
+                - gas_available.exp();
+            Constraint {
+                name: "AddGadget out of gas",
+                selector: case_selector.exp(),
+                linear_combinations: vec![
+                    (gas_overdemand.clone() - one)
+                        * (gas_overdemand.clone() - two)
+                        * (gas_overdemand - three),
+                ],
+                lookups: vec![],
+            }
+        };
+
+        vec![common, success, stack_underflow, out_of_gas]
+    }
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        op_execution_state: &mut OpExecutionStateInstance,
+        execution_step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        match execution_step.case {
+            Case::Success => self.assign_success(
+                region,
+                offset,
+                op_execution_state,
+                execution_step,
+            ),
+            Case::StackUnderflow => {
+                unimplemented!()
+            }
+            Case::OutOfGas => {
+                unimplemented!()
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<F: FieldExt> AddGadget<F> {
+    fn assign_success(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        op_execution_state: &mut OpExecutionStateInstance,
+        execution_step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        op_execution_state.global_counter += 3;
+        op_execution_state.program_counter += 1;
+        op_execution_state.stack_pointer += 1;
+        op_execution_state.gas_counter += 3;
+
+        self.success.swap.assign(
+            region,
+            offset,
+            Some(F::from_u64((execution_step.opcode == 3) as u64)),
+        )?;
+        self.success.a.assign(
+            region,
+            offset,
+            Some(execution_step.values[0]),
+        )?;
+        self.success.b.assign(
+            region,
+            offset,
+            Some(execution_step.values[1]),
+        )?;
+        self.success.c.assign(
+            region,
+            offset,
+            Some(execution_step.values[2]),
+        )?;
+        self.success
+            .carry
+            .iter()
+            .zip(execution_step.values[3].iter())
+            .map(|(alloc, byte)| {
+                alloc.assign(region, offset, Some(F::from_u64(*byte as u64)))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::super::{test::TestCircuit, Case, ExecutionStep};
+    use halo2::dev::MockProver;
+    use pasta_curves::pallas::Base;
+
+    macro_rules! try_test_circuit {
+        ($execution_steps:expr, $result:expr) => {{
+            let circuit = TestCircuit::<Base>::new($execution_steps);
+            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            assert_eq!(prover.verify(), $result);
+        }};
+    }
+
+    // TODO: use evm word
+    // TODO: add failure cases
+
+    #[test]
+    fn add_gadget() {
+        // ADD
+        try_test_circuit!(
+            vec![ExecutionStep {
+                opcode: 1,
+                case: Case::Success,
+                values: vec![
+                    [
+                        1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                    [
+                        4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                    [
+                        5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                    [
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ]
+                ],
+            }],
+            Ok(())
+        );
+        // SUB
+        try_test_circuit!(
+            vec![ExecutionStep {
+                opcode: 3,
+                case: Case::Success,
+                values: vec![
+                    [
+                        1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                    [
+                        4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                    [
+                        5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                    [
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ]
+                ],
+            }],
+            Ok(())
+        );
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -318,39 +318,76 @@ mod test {
 
     #[test]
     fn add_gadget() {
-        // FIXME: Add PUSH to avoid stack index like 1025 (stack index range is checked in state circuit)
         // ADD
         try_test_circuit!(
-            vec![ExecutionStep {
-                opcode: 1,
-                case: Case::Success,
-                values: vec![
-                    [
-                        1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            vec![
+                ExecutionStep {
+                    opcode: 98,
+                    case: Case::Success,
+                    values: vec![
+                        [
+                            1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ]
                     ],
-                    [
-                        4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                },
+                ExecutionStep {
+                    opcode: 98,
+                    case: Case::Success,
+                    values: vec![
+                        [
+                            4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ]
                     ],
-                    [
-                        5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                },
+                ExecutionStep {
+                    opcode: 1,
+                    case: Case::Success,
+                    values: vec![
+                        [
+                            1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ]
                     ],
-                    [
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    ]
-                ],
-            }],
+                }
+            ],
             vec![
                 Operation {
                     gc: 1,
                     target: Target::Stack,
-                    is_write: false,
+                    is_write: true,
                     values: [
                         Base::zero(),
-                        Base::from_u64(1024),
+                        Base::from_u64(1023),
                         Base::from_u64(1 + 2 + 3),
                         Base::zero(),
                     ]
@@ -358,10 +395,10 @@ mod test {
                 Operation {
                     gc: 2,
                     target: Target::Stack,
-                    is_write: false,
+                    is_write: true,
                     values: [
                         Base::zero(),
-                        Base::from_u64(1025),
+                        Base::from_u64(1022),
                         Base::from_u64(4 + 5 + 6),
                         Base::zero(),
                     ]
@@ -369,10 +406,32 @@ mod test {
                 Operation {
                     gc: 3,
                     target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 4,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(4 + 5 + 6),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 5,
+                    target: Target::Stack,
                     is_write: true,
                     values: [
                         Base::zero(),
-                        Base::from_u64(1025),
+                        Base::from_u64(1023),
                         Base::from_u64(5 + 7 + 9),
                         Base::zero(),
                     ]
@@ -382,36 +441,74 @@ mod test {
         );
         // SUB
         try_test_circuit!(
-            vec![ExecutionStep {
-                opcode: 3,
-                case: Case::Success,
-                values: vec![
-                    [
-                        1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            vec![
+                ExecutionStep {
+                    opcode: 98,
+                    case: Case::Success,
+                    values: vec![
+                        [
+                            5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ]
                     ],
-                    [
-                        4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                },
+                ExecutionStep {
+                    opcode: 98,
+                    case: Case::Success,
+                    values: vec![
+                        [
+                            4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ]
                     ],
-                    [
-                        5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                },
+                ExecutionStep {
+                    opcode: 3,
+                    case: Case::Success,
+                    values: vec![
+                        [
+                            1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                        [
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, //
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        ]
                     ],
-                    [
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    ]
-                ],
-            }],
+                }
+            ],
             vec![
                 Operation {
                     gc: 1,
                     target: Target::Stack,
-                    is_write: false,
+                    is_write: true,
                     values: [
                         Base::zero(),
-                        Base::from_u64(1024),
+                        Base::from_u64(1023),
                         Base::from_u64(5 + 7 + 9),
                         Base::zero(),
                     ]
@@ -419,10 +516,10 @@ mod test {
                 Operation {
                     gc: 2,
                     target: Target::Stack,
-                    is_write: false,
+                    is_write: true,
                     values: [
                         Base::zero(),
-                        Base::from_u64(1025),
+                        Base::from_u64(1022),
                         Base::from_u64(4 + 5 + 6),
                         Base::zero(),
                     ]
@@ -430,10 +527,32 @@ mod test {
                 Operation {
                     gc: 3,
                     target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 4,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(4 + 5 + 6),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 5,
+                    target: Target::Stack,
                     is_write: true,
                     values: [
                         Base::zero(),
-                        Base::from_u64(1025),
+                        Base::from_u64(1023),
                         Base::from_u64(1 + 2 + 3),
                         Base::zero(),
                     ]

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -42,19 +42,19 @@ impl<F: FieldExt> OpGadget<F> for AddGadget<F> {
             case: Case::Success,
             num_word: 3,  // a + b + c
             num_cell: 33, // 32 carry + swap
-            will_resume: false,
+            will_halt: false,
         },
         CaseConfig {
             case: Case::StackUnderflow,
             num_word: 0,
             num_cell: 0,
-            will_resume: true,
+            will_halt: true,
         },
         CaseConfig {
             case: Case::OutOfGas,
             num_word: 0,
             num_cell: 0,
-            will_resume: true,
+            will_halt: true,
         },
     ];
 

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -3,7 +3,7 @@ use super::super::{
     Lookup, Word,
 };
 use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
-use crate::util::Expr;
+use crate::util::{Expr, ToWord};
 use bus_mapping::evm::{GasCost, OpcodeId};
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 use std::{array, convert::TryInto};
@@ -264,22 +264,22 @@ impl<F: FieldExt> AddGadget<F> {
         self.success.a.assign(
             region,
             offset,
-            Some(execution_step.values[0]),
+            Some(execution_step.values[0].to_word()),
         )?;
         self.success.b.assign(
             region,
             offset,
-            Some(execution_step.values[1]),
+            Some(execution_step.values[1].to_word()),
         )?;
         self.success.c.assign(
             region,
             offset,
-            Some(execution_step.values[2]),
+            Some(execution_step.values[2].to_word()),
         )?;
         self.success
             .carry
             .iter()
-            .zip(execution_step.values[3].iter())
+            .zip(execution_step.values[3].to_word().iter())
             .map(|(alloc, carry)| {
                 alloc.assign(region, offset, Some(F::from_u64(*carry as u64)))
             })
@@ -295,6 +295,7 @@ mod test {
     };
     use bus_mapping::{evm::OpcodeId, operation::Target};
     use halo2::{arithmetic::FieldExt, dev::MockProver};
+    use num::BigUint;
     use pasta_curves::pallas::Base;
 
     macro_rules! try_test_circuit {
@@ -318,58 +319,26 @@ mod test {
                     opcode: OpcodeId::PUSH3,
                     case: Case::Success,
                     values: vec![
-                        [
-                            1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ]
+                        BigUint::from(0x03_02_01u64),
+                        BigUint::from(0x01_01_01u64)
                     ],
                 },
                 ExecutionStep {
                     opcode: OpcodeId::PUSH3,
                     case: Case::Success,
                     values: vec![
-                        [
-                            4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ]
+                        BigUint::from(0x06_05_04u64),
+                        BigUint::from(0x01_01_01u64)
                     ],
                 },
                 ExecutionStep {
                     opcode: OpcodeId::ADD,
                     case: Case::Success,
                     values: vec![
-                        [
-                            4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ]
+                        BigUint::from(0x06_05_04u64),
+                        BigUint::from(0x03_02_01u64),
+                        BigUint::from(0x09_07_05u64),
+                        BigUint::from(0u64) // carry
                     ],
                 }
             ],
@@ -439,58 +408,26 @@ mod test {
                     opcode: OpcodeId::PUSH3,
                     case: Case::Success,
                     values: vec![
-                        [
-                            5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ]
+                        BigUint::from(0x09_07_05u64),
+                        BigUint::from(0x01_01_01u64)
                     ],
                 },
                 ExecutionStep {
                     opcode: OpcodeId::PUSH3,
                     case: Case::Success,
                     values: vec![
-                        [
-                            4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ]
+                        BigUint::from(0x06_05_04u64),
+                        BigUint::from(0x01_01_01u64)
                     ],
                 },
                 ExecutionStep {
                     opcode: OpcodeId::SUB,
                     case: Case::Success,
                     values: vec![
-                        [
-                            4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            5, 7, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                        [
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, //
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        ]
+                        BigUint::from(0x06_05_04u64),
+                        BigUint::from(0x03_02_01u64),
+                        BigUint::from(0x09_07_05u64),
+                        BigUint::from(0u64) // carry
                     ],
                 }
             ],

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -3,6 +3,7 @@ use super::super::{
     Lookup, Word,
 };
 use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
+use bus_mapping::evm::OpcodeId;
 use halo2::{
     arithmetic::FieldExt,
     circuit::Region,
@@ -35,7 +36,8 @@ impl<F: FieldExt> OpGadget<F> for AddGadget<F> {
     // when it's ADD, we annotate stack as [a, b, ...] and [c, ...],
     // when it's SUB, we annotate stack as [c, b, ...] and [a, ...].
     // Then we verify if a + b - c is zero.
-    const RESPONSIBLE_OPCODES: &'static [u8] = &[1, 3];
+    const RESPONSIBLE_OPCODES: &'static [OpcodeId] =
+        &[OpcodeId::ADD, OpcodeId::SUB];
 
     const CASE_CONFIGS: &'static [CaseConfig] = &[
         CaseConfig {
@@ -266,7 +268,7 @@ impl<F: FieldExt> AddGadget<F> {
         self.success.swap.assign(
             region,
             offset,
-            Some(F::from_u64((execution_step.opcode == 3) as u64)),
+            Some(F::from_u64((execution_step.opcode == OpcodeId::SUB) as u64)),
         )?;
         self.success.a.assign(
             region,
@@ -300,7 +302,7 @@ mod test {
     use super::super::super::{
         test::TestCircuit, Case, ExecutionStep, Operation,
     };
-    use bus_mapping::operation::Target;
+    use bus_mapping::{evm::OpcodeId, operation::Target};
     use halo2::{arithmetic::FieldExt, dev::MockProver};
     use pasta_curves::pallas::Base;
 
@@ -322,7 +324,7 @@ mod test {
         try_test_circuit!(
             vec![
                 ExecutionStep {
-                    opcode: 98,
+                    opcode: OpcodeId::PUSH3,
                     case: Case::Success,
                     values: vec![
                         [
@@ -338,7 +340,7 @@ mod test {
                     ],
                 },
                 ExecutionStep {
-                    opcode: 98,
+                    opcode: OpcodeId::PUSH3,
                     case: Case::Success,
                     values: vec![
                         [
@@ -354,7 +356,7 @@ mod test {
                     ],
                 },
                 ExecutionStep {
-                    opcode: 1,
+                    opcode: OpcodeId::ADD,
                     case: Case::Success,
                     values: vec![
                         [
@@ -443,7 +445,7 @@ mod test {
         try_test_circuit!(
             vec![
                 ExecutionStep {
-                    opcode: 98,
+                    opcode: OpcodeId::PUSH3,
                     case: Case::Success,
                     values: vec![
                         [
@@ -459,7 +461,7 @@ mod test {
                     ],
                 },
                 ExecutionStep {
-                    opcode: 98,
+                    opcode: OpcodeId::PUSH3,
                     case: Case::Success,
                     values: vec![
                         [
@@ -475,7 +477,7 @@ mod test {
                     ],
                 },
                 ExecutionStep {
-                    opcode: 3,
+                    opcode: OpcodeId::SUB,
                     case: Case::Success,
                     values: vec![
                         [

--- a/zkevm-circuits/src/evm_circuit/op_execution/comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/comparator.rs
@@ -1,0 +1,968 @@
+use super::super::{
+    BusMappingLookup, Case, Cell, Constraint, CoreStateInstance, ExecutionStep,
+    FixedLookup, Lookup, Word,
+};
+use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
+use crate::util::{Expr, ToWord};
+use bus_mapping::evm::{GasCost, OpcodeId};
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
+use std::{array, convert::TryInto};
+
+#[derive(Clone, Debug)]
+struct LtSuccessAllocation<F> {
+    selector: Cell<F>,
+    // A 0/1 value. The gadget always checks if `a < b`. When the swap value is 0,
+    // the gadget performs opcode LT and treats top 2 stack values as `a, b`.
+    // Otherwise, the gadget performs opcode GT, and the top 2 stack values are
+    // interpreted as `b, a`.
+    swap: Cell<F>,
+    a: Word<F>,
+    b: Word<F>,
+    // A 0/1 value of opcode output.
+    result: Word<F>,
+    // Satisfy `a + c = b` and allow overflow at 256 bit
+    c: [Cell<F>; 32],
+    // The carry of the addition check `a + c = b` in 128 bit chunks.
+    carry: Cell<F>,
+    // The sum of all limbs in `c`.
+    sumc: Cell<F>,
+    // The inverse of `sumc`.
+    sumc_inv: Cell<F>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LtGadget<F> {
+    success: LtSuccessAllocation<F>,
+    stack_underflow: Cell<F>,
+    out_of_gas: (Cell<F>, Cell<F>),
+}
+
+impl<F: FieldExt> OpGadget<F> for LtGadget<F> {
+    const RESPONSIBLE_OPCODES: &'static [OpcodeId] =
+        &[OpcodeId::LT, OpcodeId::GT];
+
+    const CASE_CONFIGS: &'static [CaseConfig] = &[
+        CaseConfig {
+            case: Case::Success,
+            num_word: 3,
+            num_cell: 36, // 32 c + swap + carry + sumc + sumc_inv
+            will_halt: false,
+        },
+        CaseConfig {
+            case: Case::StackUnderflow,
+            num_word: 0,
+            num_cell: 0,
+            will_halt: true,
+        },
+        CaseConfig {
+            case: Case::OutOfGas,
+            num_word: 0,
+            num_cell: 0,
+            will_halt: true,
+        },
+    ];
+
+    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self {
+        let [mut success, stack_underflow, out_of_gas]: [CaseAllocation<F>; 3] =
+            case_allocations.try_into().unwrap();
+        Self {
+            success: LtSuccessAllocation {
+                selector: success.selector,
+                swap: success.cells.pop().unwrap(),
+                a: success.words.pop().unwrap(),
+                b: success.words.pop().unwrap(),
+                result: success.words.pop().unwrap(),
+                c: success
+                    .cells
+                    .drain(0..32)
+                    .collect::<Vec<Cell<F>>>()
+                    .try_into()
+                    .unwrap(),
+                carry: success.cells.pop().unwrap(),
+                sumc: success.cells.pop().unwrap(),
+                sumc_inv: success.cells.pop().unwrap(),
+            },
+            stack_underflow: stack_underflow.selector,
+            out_of_gas: (
+                out_of_gas.selector,
+                out_of_gas.resumption.unwrap().gas_available,
+            ),
+        }
+    }
+
+    fn constraints(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        state_next: &OpExecutionState<F>,
+    ) -> Vec<Constraint<F>> {
+        let OpExecutionState { opcode, .. } = &state_curr;
+
+        let common_polys = vec![
+            (opcode.expr() - OpcodeId::LT.expr())
+                * (opcode.expr() - OpcodeId::GT.expr()),
+        ];
+
+        let success = {
+            // interpreter state transition constraints
+            let state_transition_constraints = vec![
+                state_next.global_counter.expr()
+                    - (state_curr.global_counter.expr() + 3.expr()),
+                state_next.stack_pointer.expr()
+                    - (state_curr.stack_pointer.expr() + 1.expr()),
+                state_next.program_counter.expr()
+                    - (state_curr.program_counter.expr() + 1.expr()),
+                state_next.gas_counter.expr()
+                    - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
+            ];
+
+            let LtSuccessAllocation {
+                selector,
+                swap,
+                a,
+                b,
+                result,
+                c,
+                carry,
+                sumc,
+                sumc_inv,
+            } = &self.success;
+
+            // swap = 0/1
+            // swap = 0 <=> opcode = LT
+            // swap = 1 <=> opcode = GT
+            let no_swap = 1.expr() - swap.expr();
+            let swap_constraints = vec![
+                swap.expr() * no_swap.clone(),
+                swap.expr() * (opcode.expr() - OpcodeId::GT.expr()),
+                no_swap.clone() * (opcode.expr() - OpcodeId::LT.expr()),
+            ];
+
+            // The sum of c limbs
+            let sumc_expr =
+                c.iter().fold(0.expr(), |acc, byte| acc + byte.expr());
+            let sumc_is_zero_expr =
+                1.expr() - sumc_expr.clone() * sumc_inv.expr();
+            // same as is_zero gadget, currently we cannot use gadget inside OpGadget
+            let sumc_is_zero_constraints = vec![
+                sumc_expr.clone() * sumc_is_zero_expr.clone(),
+                sumc_inv.expr() * sumc_is_zero_expr.clone(),
+            ];
+            // sumc_expr == sumc_cell
+            // `result * (1 - sumc * sumc_inv) = 0`. This means `result = 1 <=> sumc_expr != 0`
+            let sumc_constraints = vec![
+                sumc_expr - sumc.expr(),
+                result.cells[0].expr() * sumc_is_zero_expr.clone(),
+            ];
+
+            // carry = 0/1
+            let mut lt_constraints =
+                vec![carry.expr() * (1.expr() - carry.expr())];
+            // a[15..0] + c[15..0] = carry * 256^16 + b[15..0]
+            let mut exponent = 1.expr();
+            let mut lhs = 0.expr();
+            let mut rhs = 0.expr();
+            #[allow(clippy::needless_range_loop)]
+            for idx in 0..16 {
+                lhs = lhs
+                    + (a.cells[idx].expr() + c[idx].expr()) * exponent.clone();
+                rhs = rhs + b.cells[idx].expr() * exponent.clone();
+                exponent = exponent * 256.expr();
+            }
+            rhs = rhs + carry.expr() * exponent;
+            lt_constraints.push(lhs - rhs);
+
+            // a[31..16] + c[31..16] + carry =
+            //     b[31..16] + (1 - result) * 256^16 * (1 - sumc_is_zero)
+            // a < b, a + c = b, result = 1, sumc_is_zero = 0
+            // a = b, a + c = b, result = 0, sumc_is_zero = 1
+            // a > b, a + c = b + 2^256, result = 0, sumc_is_zero = 0
+            // Note that, when result = 1, sumc != 0 is guaranteed by `sumc_constraints`,
+            // and so sumc_is_zero must be 0.
+            exponent = 1.expr();
+            lhs = carry.expr();
+            rhs = 0.expr();
+            #[allow(clippy::needless_range_loop)]
+            for idx in 16..32 {
+                lhs = lhs
+                    + (a.cells[idx].expr() + c[idx].expr()) * exponent.clone();
+                rhs = rhs + b.cells[idx].expr() * exponent.clone();
+                exponent = exponent * 256.expr();
+            }
+            rhs = rhs
+                + (1.expr() - result.cells[0].expr())
+                    * exponent
+                    * (1.expr() - sumc_is_zero_expr);
+            lt_constraints.push(lhs - rhs);
+
+            // result[0] = 0/1, result[1..32] = 0
+            let result_constraints = result
+                .cells
+                .iter()
+                .enumerate()
+                .map(|(idx, cell)| {
+                    if idx == 0 {
+                        cell.expr() * (1.expr() - cell.expr())
+                    } else {
+                        cell.expr()
+                    }
+                })
+                .collect();
+
+            // Check each cell in c in within 8-bit range
+            let c_range_lookups = c
+                .iter()
+                .map(|cell| {
+                    Lookup::FixedLookup(
+                        FixedLookup::Range256,
+                        [cell.expr(), 0.expr(), 0.expr()],
+                    )
+                })
+                .collect();
+
+            #[allow(clippy::suspicious_operation_groupings)]
+            let bus_mapping_lookups = vec![
+                Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                    index_offset: 0,
+                    value: swap.expr() * b.expr() + no_swap.clone() * a.expr(),
+                    is_write: false,
+                }),
+                Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                    index_offset: 1,
+                    value: swap.expr() * a.expr() + no_swap * b.expr(),
+                    is_write: false,
+                }),
+                Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                    index_offset: 1,
+                    value: result.expr(),
+                    is_write: true,
+                }),
+            ];
+
+            Constraint {
+                name: "LtGadget success",
+                selector: selector.expr(),
+                polys: [
+                    state_transition_constraints,
+                    swap_constraints,
+                    sumc_constraints,
+                    sumc_is_zero_constraints,
+                    lt_constraints,
+                    result_constraints,
+                ]
+                .concat(),
+                lookups: [c_range_lookups, bus_mapping_lookups].concat(),
+            }
+        };
+
+        let stack_underflow = {
+            let stack_pointer = state_curr.stack_pointer.expr();
+            Constraint {
+                name: "LtGadget stack underflow",
+                selector: self.stack_underflow.expr(),
+                polys: vec![
+                    (stack_pointer.clone() - 1024.expr())
+                        * (stack_pointer - 1023.expr()),
+                ],
+                lookups: vec![],
+            }
+        };
+
+        let out_of_gas = {
+            let (selector, gas_available) = &self.out_of_gas;
+            let gas_overdemand = state_curr.gas_counter.expr()
+                + GasCost::FASTEST.expr()
+                - gas_available.expr();
+            Constraint {
+                name: "LtGadget out of gas",
+                selector: selector.expr(),
+                polys: vec![
+                    (gas_overdemand.clone() - 1.expr())
+                        * (gas_overdemand.clone() - 2.expr())
+                        * (gas_overdemand - 3.expr()),
+                ],
+                lookups: vec![],
+            }
+        };
+
+        array::IntoIter::new([success, stack_underflow, out_of_gas])
+            .map(move |mut constraint| {
+                constraint.polys =
+                    [common_polys.clone(), constraint.polys].concat();
+                constraint
+            })
+            .collect()
+    }
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        core_state: &mut CoreStateInstance,
+        execution_step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        match execution_step.case {
+            Case::Success => {
+                self.assign_success(region, offset, core_state, execution_step)
+            }
+            Case::StackUnderflow => {
+                unimplemented!()
+            }
+            Case::OutOfGas => {
+                unimplemented!()
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<F: FieldExt> LtGadget<F> {
+    fn assign_success(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        core_state: &mut CoreStateInstance,
+        execution_step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        core_state.global_counter += 3;
+        core_state.program_counter += 1;
+        core_state.stack_pointer += 1;
+        core_state.gas_counter += 3;
+
+        self.success.swap.assign(
+            region,
+            offset,
+            Some(F::from_u64((execution_step.opcode == OpcodeId::GT) as u64)),
+        )?;
+        self.success.a.assign(
+            region,
+            offset,
+            Some(execution_step.values[0].to_word()),
+        )?;
+        self.success.b.assign(
+            region,
+            offset,
+            Some(execution_step.values[1].to_word()),
+        )?;
+        self.success.result.assign(
+            region,
+            offset,
+            Some(execution_step.values[2].to_word()),
+        )?;
+        self.success
+            .c
+            .iter()
+            .zip(execution_step.values[3].to_word().iter())
+            .map(|(alloc, value)| {
+                alloc.assign(region, offset, Some(F::from_u64(*value as u64)))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        self.success.carry.assign(
+            region,
+            offset,
+            Some(F::from_u64(
+                execution_step.values[4].to_bytes_le()[0] as u64,
+            )),
+        )?;
+        let sumc_digits = execution_step.values[5].to_u64_digits();
+        let sumc = F::from_u64(if sumc_digits.is_empty() {
+            0u64
+        } else {
+            sumc_digits[0]
+        });
+        let sumc_inv = sumc.invert().unwrap_or(F::zero());
+        self.success.sumc.assign(region, offset, Some(sumc))?;
+        self.success
+            .sumc_inv
+            .assign(region, offset, Some(sumc_inv))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::super::{
+        test::TestCircuit, Case, ExecutionStep, Operation,
+    };
+    use crate::util::ToWord;
+    use bus_mapping::{evm::OpcodeId, operation::Target};
+    use halo2::{arithmetic::FieldExt, dev::MockProver};
+    use num::BigUint;
+    use pasta_curves::pallas::Base;
+
+    macro_rules! try_test_circuit {
+        ($execution_step:expr, $operations:expr, $result:expr) => {{
+            let circuit =
+                TestCircuit::<Base>::new($execution_step, $operations);
+            let prover = MockProver::<Base>::run(9, &circuit, vec![]).unwrap();
+            assert_eq!(prover.verify(), $result);
+        }};
+    }
+
+    fn subtract(a: &BigUint, b: &BigUint) -> (BigUint, BigUint, BigUint) {
+        let a8s = a.to_word();
+        let b8s = b.to_word();
+        let mut c8s = [0u8; 32];
+        let mut sub_carry: i16 = 0;
+        let mut carry: u8 = 0;
+        for idx in 0..32 {
+            let tmp = a8s[idx] as i16 - b8s[idx] as i16 - sub_carry;
+            if tmp < 0 {
+                c8s[idx] = (tmp + (1 << 8)) as u8;
+                sub_carry = 1;
+            } else {
+                c8s[idx] = tmp as u8;
+                sub_carry = 0;
+            }
+        }
+        // compute the carry
+        for idx in 0..16 {
+            let tmp = b8s[idx] as i16 + c8s[idx] as i16 + carry as i16;
+            carry = (tmp >= (1 << 8)) as u8;
+        }
+        // compute the sum of all limbs in c8s
+        let mut sumc: u64 = 0;
+        for limb in c8s.iter() {
+            sumc += *limb as u64;
+        }
+        (
+            BigUint::from_bytes_le(&c8s),
+            BigUint::from(carry),
+            BigUint::from(sumc),
+        )
+    }
+
+    #[test]
+    fn lt_gadget() {
+        let a = BigUint::from(0x03_02_01u64);
+        let b = BigUint::from(0x09_07_05u64);
+        let mut result = [0u8; 32];
+
+        // LT: a < b, result = 1
+        let (c, carry, sumc) = subtract(&b, &a);
+        result[0] = 1;
+        try_test_circuit!(
+            vec![
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![a.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![b.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::LT,
+                    case: Case::Success,
+                    values: vec![
+                        a.clone(),
+                        b.clone(),
+                        BigUint::from_bytes_le(&result),
+                        c,
+                        carry,
+                        sumc,
+                    ],
+                }
+            ],
+            vec![
+                Operation {
+                    gc: 1,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 2,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 3,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 4,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 5,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1),
+                        Base::zero(),
+                    ]
+                }
+            ],
+            Ok(())
+        );
+
+        // LT: a = a, result = 0
+        let (c, carry, sumc) = subtract(&a, &a);
+        result[0] = 0;
+        try_test_circuit!(
+            vec![
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![a.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![a.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::LT,
+                    case: Case::Success,
+                    values: vec![
+                        a.clone(),
+                        a.clone(),
+                        BigUint::from_bytes_le(&result),
+                        c,
+                        carry,
+                        sumc,
+                    ],
+                }
+            ],
+            vec![
+                Operation {
+                    gc: 1,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 2,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 3,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 4,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 5,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(0),
+                        Base::zero(),
+                    ]
+                }
+            ],
+            Ok(())
+        );
+
+        // LT: b > a, result = 0
+        let (c, carry, sumc) = subtract(&a, &b);
+        result[0] = 0;
+        try_test_circuit!(
+            vec![
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![b.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![a.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::LT,
+                    case: Case::Success,
+                    values: vec![
+                        b.clone(),
+                        a.clone(),
+                        BigUint::from_bytes_le(&result),
+                        c,
+                        carry,
+                        sumc,
+                    ],
+                }
+            ],
+            vec![
+                Operation {
+                    gc: 1,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 2,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 3,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 4,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 5,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(0),
+                        Base::zero(),
+                    ]
+                }
+            ],
+            Ok(())
+        );
+
+        // GT: b > a, result = 1
+        let (c, carry, sumc) = subtract(&b, &a);
+        result[0] = 1;
+        try_test_circuit!(
+            vec![
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![b.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![a.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::GT,
+                    case: Case::Success,
+                    values: vec![
+                        a.clone(),
+                        b.clone(),
+                        BigUint::from_bytes_le(&result),
+                        c,
+                        carry,
+                        sumc,
+                    ],
+                }
+            ],
+            vec![
+                Operation {
+                    gc: 1,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 2,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 3,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 4,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 5,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1),
+                        Base::zero(),
+                    ]
+                }
+            ],
+            Ok(())
+        );
+
+        // GT: a = a, result = 0
+        let (c, carry, sumc) = subtract(&a, &a);
+        result[0] = 0;
+        try_test_circuit!(
+            vec![
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![a.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![a.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::GT,
+                    case: Case::Success,
+                    values: vec![
+                        a.clone(),
+                        a.clone(),
+                        BigUint::from_bytes_le(&result),
+                        c,
+                        carry,
+                        sumc,
+                    ],
+                }
+            ],
+            vec![
+                Operation {
+                    gc: 1,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 2,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 3,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 4,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 5,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(0),
+                        Base::zero(),
+                    ]
+                }
+            ],
+            Ok(())
+        );
+
+        // GT: a < b, result = 0
+        let (c, carry, sumc) = subtract(&a, &b);
+        result[0] = 0;
+        try_test_circuit!(
+            vec![
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![a.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::PUSH3,
+                    case: Case::Success,
+                    values: vec![b.clone(), BigUint::from(0x01_01_01u64)],
+                },
+                ExecutionStep {
+                    opcode: OpcodeId::GT,
+                    case: Case::Success,
+                    values: vec![
+                        b,
+                        a,
+                        BigUint::from_bytes_le(&result),
+                        c,
+                        carry,
+                        sumc,
+                    ],
+                }
+            ],
+            vec![
+                Operation {
+                    gc: 1,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 2,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 3,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1022),
+                        Base::from_u64(1 + 2 + 3),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 4,
+                    target: Target::Stack,
+                    is_write: false,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(5 + 7 + 9),
+                        Base::zero(),
+                    ]
+                },
+                Operation {
+                    gc: 5,
+                    target: Target::Stack,
+                    is_write: true,
+                    values: [
+                        Base::zero(),
+                        Base::from_u64(1023),
+                        Base::from_u64(0),
+                        Base::zero(),
+                    ]
+                }
+            ],
+            Ok(())
+        );
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/op_execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/push.rs
@@ -1,0 +1,307 @@
+use super::super::{
+    BusMappingLookup, Case, Cell, Constraint, CoreStateInstance, ExecutionStep,
+    FixedLookup, Lookup, Word,
+};
+use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
+use std::{array, convert::TryInto};
+
+#[derive(Clone, Debug)]
+struct PushSuccessAllocation<F> {
+    case_selector: Cell<F>,
+    word: Word<F>,
+    selectors: [Cell<F>; 32], /* whether its PUSH1, ..., or PUSH32 ([1, 1,
+                               * 0, ..., 0] means PUSH2) */
+}
+
+#[derive(Clone, Debug)]
+pub struct PushGadget<F> {
+    success: PushSuccessAllocation<F>,
+    stack_overflow: Cell<F>, // case selector
+    out_of_gas: (
+        Cell<F>, // case selector
+        Cell<F>, // gas available
+    ),
+}
+
+impl<F: FieldExt> OpGadget<F> for PushGadget<F> {
+    const RESPONSIBLE_OPCODES: &'static [u8] = &[
+        96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+        111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
+        125, 126, 127,
+    ];
+
+    const CASE_CONFIGS: &'static [CaseConfig] = &[
+        CaseConfig {
+            case: Case::Success,
+            num_word: 1,
+            num_cell: 32, // for PUSH selectors
+            will_resume: false,
+        },
+        CaseConfig {
+            case: Case::StackOverflow,
+            num_word: 0,
+            num_cell: 0,
+            will_resume: true,
+        },
+        CaseConfig {
+            case: Case::OutOfGas,
+            num_word: 0,
+            num_cell: 0,
+            will_resume: true,
+        },
+    ];
+
+    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self {
+        let [mut success, stack_overflow, out_of_gas]: [CaseAllocation<F>; 3] =
+            case_allocations.try_into().unwrap();
+        Self {
+            success: PushSuccessAllocation {
+                case_selector: success.selector.clone(),
+                word: success.words.pop().unwrap(),
+                selectors: success.cells.try_into().unwrap(),
+            },
+            stack_overflow: stack_overflow.selector,
+            out_of_gas: (
+                out_of_gas.selector,
+                out_of_gas.resumption.unwrap().gas_available,
+            ),
+        }
+    }
+
+    fn constraints(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        state_next: &OpExecutionState<F>,
+    ) -> Vec<Constraint<F>> {
+        let push1 = Expression::Constant(F::from_u64(96));
+        let OpExecutionState { opcode, .. } = &state_curr;
+
+        let zero = Expression::Constant(F::zero());
+        let common_lookups = vec![Lookup::FixedLookup(
+            FixedLookup::Range32,
+            [opcode.expr() - push1.clone(), zero.clone(), zero],
+        )];
+
+        let success = {
+            let (one, two) = (
+                Expression::Constant(F::one()),
+                Expression::Constant(F::from_u64(2)),
+            );
+
+            // interpreter state transition constraints
+            let state_transition_constraints = vec![
+                state_next.global_counter.expr()
+                    - (state_curr.global_counter.expr() + one.clone()),
+                state_next.program_counter.expr()
+                    - (state_curr.program_counter.expr() + opcode.expr()
+                        - push1.clone()
+                        + two),
+                state_next.stack_pointer.expr()
+                    - (state_curr.stack_pointer.expr() - one.clone()),
+                state_next.gas_counter.expr()
+                    - (state_curr.gas_counter.expr()
+                        + Expression::Constant(F::from_u64(3))),
+            ];
+
+            let PushSuccessAllocation {
+                case_selector,
+                word,
+                selectors,
+            } = &self.success;
+
+            let mut push_constraints = vec![];
+            for idx in 0..31 {
+                // selector can transit from 1 to 0 only once as [1, 1, 1, ...,
+                // 0, 0, 0]
+                if idx > 0 {
+                    let diff =
+                        selectors[idx - 1].expr() - selectors[idx].expr();
+                    push_constraints.push(diff.clone() * (one.clone() - diff));
+                }
+                // selectors needs to be 0 or 1
+                push_constraints.push(
+                    selectors[idx].expr()
+                        * (one.clone() - selectors[idx].expr()),
+                );
+                // word byte should be 0 when selector is 0
+                push_constraints.push(
+                    word.cells[idx].expr()
+                        * (one.clone() - selectors[idx].expr()),
+                );
+            }
+
+            let selectors_sum = selectors
+                .iter()
+                .fold(Expression::Constant(F::zero()), |sum, s| sum + s.expr());
+            push_constraints.push(selectors_sum - opcode.expr() + push1 - one);
+
+            let bus_mapping_lookups =
+                vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
+                    index_offset: -1,
+                    value: word.expr(),
+                    is_write: true,
+                })];
+
+            Constraint {
+                name: "PushGadget success",
+                selector: case_selector.expr(),
+                polys: [state_transition_constraints, push_constraints]
+                    .concat(),
+                lookups: bus_mapping_lookups,
+            }
+        };
+
+        let stack_overflow = {
+            let (zero, minus_one) = (
+                Expression::Constant(F::from_u64(1024)),
+                Expression::Constant(F::from_u64(1023)),
+            );
+            let stack_pointer = state_curr.stack_pointer.expr();
+            Constraint {
+                name: "PushGadget stack overflow",
+                selector: self.stack_overflow.expr(),
+                polys: vec![
+                    (stack_pointer.clone() - zero)
+                        * (stack_pointer - minus_one),
+                ],
+                lookups: vec![],
+            }
+        };
+
+        let out_of_gas = {
+            let (one, two, three) = (
+                Expression::Constant(F::from_u64(1)),
+                Expression::Constant(F::from_u64(2)),
+                Expression::Constant(F::from_u64(3)),
+            );
+            let (case_selector, gas_available) = &self.out_of_gas;
+            let gas_overdemand = state_curr.gas_counter.expr() + three.clone()
+                - gas_available.expr();
+            Constraint {
+                name: "PushGadget out of gas",
+                selector: case_selector.expr(),
+                polys: vec![
+                    (gas_overdemand.clone() - one)
+                        * (gas_overdemand.clone() - two)
+                        * (gas_overdemand - three),
+                ],
+                lookups: vec![],
+            }
+        };
+
+        array::IntoIter::new([success, stack_overflow, out_of_gas])
+            .map(move |mut constraint| {
+                constraint.lookups =
+                    [common_lookups.clone(), constraint.lookups].concat();
+                constraint
+            })
+            .collect()
+    }
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        core_state: &mut CoreStateInstance,
+        execution_step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        match execution_step.case {
+            Case::Success => {
+                self.assign_success(region, offset, core_state, execution_step)
+            }
+            Case::StackOverflow => {
+                unimplemented!()
+            }
+            Case::OutOfGas => {
+                unimplemented!()
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<F: FieldExt> PushGadget<F> {
+    fn assign_success(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        core_state: &mut CoreStateInstance,
+        execution_step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        core_state.global_counter += 1;
+        core_state.program_counter += (execution_step.opcode - 94) as usize;
+        core_state.stack_pointer -= 1;
+        core_state.gas_counter += 3;
+
+        self.success.word.assign(
+            region,
+            offset,
+            Some(execution_step.values[0]),
+        )?;
+        self.success
+            .selectors
+            .iter()
+            .zip(execution_step.values[1].iter())
+            .map(|(alloc, bit)| {
+                alloc.assign(region, offset, Some(F::from_u64(*bit as u64)))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::super::{
+        test::TestCircuit, Case, ExecutionStep, Operation,
+    };
+    use bus_mapping::operation::Target;
+    use halo2::{arithmetic::FieldExt, dev::MockProver};
+    use pasta_curves::pallas::Base;
+
+    macro_rules! try_test_circuit {
+        ($execution_steps:expr, $operations:expr, $result:expr) => {{
+            let circuit =
+                TestCircuit::<Base>::new($execution_steps, $operations);
+            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            assert_eq!(prover.verify(), $result);
+        }};
+    }
+
+    // TODO: use evm word
+    // TODO: add failure cases
+
+    #[test]
+    fn push_gadget() {
+        try_test_circuit!(
+            vec![ExecutionStep {
+                opcode: 97, // PUSH2
+                case: Case::Success,
+                values: vec![
+                    [
+                        2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                    [
+                        1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ]
+                ],
+            }],
+            vec![Operation {
+                gc: 1,
+                target: Target::Stack,
+                is_write: true,
+                values: [
+                    Base::zero(),
+                    Base::from_u64(1023),
+                    Base::from_u64(2 + 2),
+                    Base::zero(),
+                ]
+            }],
+            Ok(())
+        );
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/op_execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/push.rs
@@ -37,19 +37,19 @@ impl<F: FieldExt> OpGadget<F> for PushGadget<F> {
             case: Case::Success,
             num_word: 1,
             num_cell: 32, // for PUSH selectors
-            will_resume: false,
+            will_halt: false,
         },
         CaseConfig {
             case: Case::StackOverflow,
             num_word: 0,
             num_cell: 0,
-            will_resume: true,
+            will_halt: true,
         },
         CaseConfig {
             case: Case::OutOfGas,
             num_word: 0,
             num_cell: 0,
-            will_resume: true,
+            will_halt: true,
         },
     ];
 

--- a/zkevm-circuits/src/evm_circuit/op_execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/push.rs
@@ -3,7 +3,7 @@ use super::super::{
     FixedLookup, Lookup, Word,
 };
 use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
-use crate::util::Expr;
+use crate::util::{Expr, ToWord};
 use bus_mapping::evm::{GasCost, OpcodeId};
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 use std::{array, convert::TryInto};
@@ -273,12 +273,12 @@ impl<F: FieldExt> PushGadget<F> {
         self.success.word.assign(
             region,
             offset,
-            Some(execution_step.values[0]),
+            Some(execution_step.values[0].to_word()),
         )?;
         self.success
             .selectors
             .iter()
-            .zip(execution_step.values[1].iter())
+            .zip(execution_step.values[1].to_word().iter())
             .map(|(alloc, bit)| {
                 alloc.assign(region, offset, Some(F::from_u64(*bit as u64)))
             })
@@ -294,6 +294,7 @@ mod test {
     };
     use bus_mapping::{evm::OpcodeId, operation::Target};
     use halo2::{arithmetic::FieldExt, dev::MockProver};
+    use num::BigUint;
     use pasta_curves::pallas::Base;
 
     macro_rules! try_test_circuit {
@@ -315,14 +316,8 @@ mod test {
                 opcode: OpcodeId::PUSH2,
                 case: Case::Success,
                 values: vec![
-                    [
-                        2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    ],
-                    [
-                        1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    ]
+                    BigUint::from(0x02_03u64),
+                    BigUint::from(0x01_01u64),
                 ],
             }],
             vec![Operation {
@@ -332,7 +327,7 @@ mod test {
                 values: [
                     Base::zero(),
                     Base::from_u64(1023),
-                    Base::from_u64(2 + 2),
+                    Base::from_u64(2 + 3),
                     Base::zero(),
                 ]
             }],

--- a/zkevm-circuits/src/evm_circuit/op_execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/push.rs
@@ -158,35 +158,13 @@ impl<F: FieldExt> OpGadget<F> for PushGadget<F> {
                 selectors.iter().fold(0.expr(), |sum, s| sum + s.expr());
             push_constraints.push(selectors_sum - num_pushed);
 
-            let bus_mapping_lookups = [
-                // TODO: add 32 Bytecode lookups when supported
-                // selectors
-                //     .iter()
-                //     .zip(word.cells.iter())
-                //     .enumerate()
-                //     .map(|(idx, (selector, cell))| {
-                //         let OpExecutionState {
-                //             program_counter, ..
-                //         } = &state_curr;
-                //         Lookup::BusMappingLookup(BusMappingLookup::Bytecode {
-                //             hash: selector.expr() * hash,
-                //             index: selector.expr()
-                //                 * (program_counter.expr()
-                //                     + one.clone()
-                //                     + Expression::Constant(F::from_u64(
-                //                         idx as u64,
-                //                     ))),
-                //             value: cell.expr(),
-                //         })
-                //     })
-                //     .collect::<Vec<_>>(),
-                vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
+            let bus_mapping_lookups =
+                [vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: -1,
                     value: word.expr(),
                     is_write: true,
-                })],
-            ]
-            .concat();
+                })]]
+                .concat();
 
             Constraint {
                 name: "PushGadget success",

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -6,7 +6,7 @@ pub const CIRCUIT_HEIGHT: usize = 10;
 
 // Number of cells used for each purpose
 // TODO: pub const NUM_CELL_CALL_INITIALIZATION_STATE: usize = ;
-pub const NUM_CELL_OP_EXECTION_STATE: usize = 7;
+pub const NUM_CELL_OP_EXECUTION_STATE: usize = 7;
 // FIXME: naive estimation, should be optmize to fit in the future
 pub const NUM_CELL_OP_GADGET_SELECTOR: usize = 80;
 pub const NUM_CELL_RESUMPTION: usize = 2;

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,5 +1,6 @@
 // FIXME: decide a optimal circuit dimension in the future
 // Circuit dimension
+// NOTE: CIRCUIT_WIDTH should be divide 32 evenly for whole row byte lookup
 pub const CIRCUIT_WIDTH: usize = 32;
 pub const CIRCUIT_HEIGHT: usize = 10;
 

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,0 +1,11 @@
+// FIXME: decide a optimal circuit dimension in the future
+// Circuit dimension
+pub const CIRCUIT_WIDTH: usize = 32;
+pub const CIRCUIT_HEIGHT: usize = 10;
+
+// Number of cells used for each purpose
+// TODO: pub const NUM_CELL_CALL_INITIALIZATION_STATE: usize = ;
+pub const NUM_CELL_OP_EXECTION_STATE: usize = 7;
+// FIXME: naive estimation, should be optmize to fit in the future
+pub const NUM_CELL_OP_GADGET_SELECTOR: usize = 80;
+pub const NUM_CELL_RESUMPTION: usize = 2;

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod evm_circuit;
 pub mod gadget;
 pub mod state_circuit;
+pub mod util;
 
 #[cfg(test)]
 mod test_vectors;

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -1,0 +1,58 @@
+//! Common utility traits and functions.
+
+use bus_mapping::{
+    evm::{GasCost, OpcodeId},
+    operation::Target,
+};
+use halo2::{arithmetic::FieldExt, plonk::Expression};
+
+pub(crate) trait Expr<F: FieldExt> {
+    fn expr(&self) -> Expression<F>;
+}
+
+macro_rules! impl_unsigned_expr {
+    ($type:ty) => {
+        impl<F: FieldExt> Expr<F> for $type {
+            #[inline]
+            fn expr(&self) -> Expression<F> {
+                Expression::Constant(F::from_u64(*self as u64))
+            }
+        }
+    };
+    ($type:ty, $method:path) => {
+        impl<F: FieldExt> Expr<F> for $type {
+            #[inline]
+            fn expr(&self) -> Expression<F> {
+                Expression::Constant(F::from_u64($method(self) as u64))
+            }
+        }
+    };
+}
+
+macro_rules! impl_signed_expr {
+    ($type:ty) => {
+        impl<F: FieldExt> Expr<F> for $type {
+            #[inline]
+            fn expr(&self) -> Expression<F> {
+                Expression::Constant(
+                    F::from_u64(self.abs() as u64)
+                        * if self.is_negative() {
+                            -F::one()
+                        } else {
+                            F::one()
+                        },
+                )
+            }
+        }
+    };
+}
+
+impl_unsigned_expr!(bool);
+impl_unsigned_expr!(u8);
+impl_unsigned_expr!(u64);
+impl_unsigned_expr!(usize);
+impl_unsigned_expr!(Target);
+impl_unsigned_expr!(OpcodeId, OpcodeId::as_u8);
+impl_unsigned_expr!(GasCost, GasCost::as_u8);
+
+impl_signed_expr!(i32);

--- a/zkevm-circuits/src/util.rs
+++ b/zkevm-circuits/src/util.rs
@@ -1,10 +1,10 @@
 //! Common utility traits and functions.
-
 use bus_mapping::{
     evm::{GasCost, OpcodeId},
     operation::Target,
 };
 use halo2::{arithmetic::FieldExt, plonk::Expression};
+use num::BigUint;
 
 pub(crate) trait Expr<F: FieldExt> {
     fn expr(&self) -> Expression<F>;
@@ -56,3 +56,19 @@ impl_unsigned_expr!(OpcodeId, OpcodeId::as_u8);
 impl_unsigned_expr!(GasCost, GasCost::as_u8);
 
 impl_signed_expr!(i32);
+
+pub(crate) trait ToWord {
+    /// Convert the value into 32 8-bit bytes in little endian
+    fn to_word(&self) -> [u8; 32];
+}
+
+impl ToWord for BigUint {
+    #[inline]
+    fn to_word(&self) -> [u8; 32] {
+        let mut ret = [0u8; 32];
+        for (pos, v) in self.to_bytes_le().iter().enumerate() {
+            ret[pos] = *v
+        }
+        ret
+    }
+}


### PR DESCRIPTION
This PR aims to provides:

1. A flexible design of evm circuit
2. A trait for op gadget for us to implmenent without caring about the actual circuit layout
3. An example `AddGadget` for reference (Closes #9)

Todo:

- [x] Trait `OpGadget`
- [x] Check `linear_combinations` configured by `OpGadget`
- [x] Check `lookups` configured by `OpGadget`
  - [x] Word 8bit lookups
  - [x] Bus mapping lookups for stack and memory
- [x] `AddGadget` and `PushGadget` as examples.
- [x] ~~Feed `ExecutionStep` by crate `bus-mapping` into circuit~~ -> Next PR