### PR TITLE
ExecutionTrace API extension

### DIFF
--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -13,6 +13,4 @@ serde = {version = "1.0.127", features = ["derive"] }
 num = "0.4"
 halo2 = "0.0"
 lazy_static = "1.4"
-
-[dev-dependencies]
 serde_json = "1.0.66"

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     EvmWordParsing,
     /// Error while trying to convert to an incorrect `OpcodeId`.
     InvalidOpConversion,
+    /// Serde de/serialization error.
+    SerdeError,
 }
 
 impl Display for Error {

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -141,3 +141,15 @@ impl FromStr for EvmWord {
         ))
     }
 }
+
+macro_rules! impl_from_basic_types {
+    ($($t:ty),*) => {
+        $(impl From<$t> for EvmWord {
+            fn from(item: $t) -> EvmWord {
+                EvmWord(BigUint::from(item))
+            }
+        })*
+    };
+}
+
+impl_from_basic_types!(u8, u16, u32, u64, u128);

--- a/bus-mapping/src/exec_trace.rs
+++ b/bus-mapping/src/exec_trace.rs
@@ -2,8 +2,8 @@
 //! execution traces.
 pub(crate) mod exec_step;
 use crate::evm::EvmWord;
-use crate::operation::Target;
 use crate::operation::{container::OperationContainer, Operation};
+use crate::operation::{MemoryOp, StackOp, StorageOp, Target};
 use core::ops::{Index, IndexMut};
 pub use exec_step::ExecutionStep;
 use pasta_curves::arithmetic::FieldExt;
@@ -187,6 +187,27 @@ impl<F: FieldExt> ExecutionTrace<F> {
     /// for.
     pub fn container(&self) -> &OperationContainer {
         &self.container
+    }
+
+    /// Returns an ordered `Vec` containing all the [`StackOp`]s of the actual
+    /// `ExecutionTrace` so that they can be directly included in the State
+    /// proof.
+    pub fn sorted_stack_ops(&self) -> Vec<StackOp> {
+        self.container.sorted_stack()
+    }
+
+    /// Returns an ordered `Vec` containing all the [`MemoryOp`]s of the actual
+    /// `ExecutionTrace` so that they can be directly included in the State
+    /// proof.
+    pub fn sorted_memory_ops(&self) -> Vec<MemoryOp> {
+        self.container.sorted_memory()
+    }
+
+    /// Returns an ordered `Vec` containing all the [`StorageOp`]s of the actual
+    /// `ExecutionTrace` so that they can be directly included in the State
+    /// proof.
+    pub fn sorted_storage_ops(&self) -> Vec<StorageOp> {
+        self.container.sorted_storage()
     }
 
     /// Registers an [`Operation`] into the [`OperationContainer`] and then adds

--- a/bus-mapping/src/exec_trace.rs
+++ b/bus-mapping/src/exec_trace.rs
@@ -156,8 +156,29 @@ impl<F: FieldExt> ExecutionTrace<F> {
         .build()
     }
 
+    /// Returns an ordered `Vec` containing all the [`StackOp`]s of the actual
+    /// `ExecutionTrace` so that they can be directly included in the State
+    /// proof.
+    pub fn sorted_stack_ops(&self) -> Vec<StackOp> {
+        self.container.sorted_stack()
+    }
+
+    /// Returns an ordered `Vec` containing all the [`MemoryOp`]s of the actual
+    /// `ExecutionTrace` so that they can be directly included in the State
+    /// proof.
+    pub fn sorted_memory_ops(&self) -> Vec<MemoryOp> {
+        self.container.sorted_memory()
+    }
+
+    /// Returns an ordered `Vec` containing all the [`StorageOp`]s of the actual
+    /// `ExecutionTrace` so that they can be directly included in the State
+    /// proof.
+    pub fn sorted_storage_ops(&self) -> Vec<StorageOp> {
+        self.container.sorted_storage()
+    }
+
     /// Traverses the trace step by step, and for each [`ExecutionStep`]:
-    /// 1. Sets the correct [`GlobalCounter`].
+    /// 1. Sets the correct [`GlobalCounter`](crate::evm::GlobalCounter).
     /// 2. Generates the corresponding [`Operation`]s and stores them inside the
     /// [`OperationContainer`] instance stored inside of the trace + adds the
     /// [`OperationRef`]s obtained from the container addition into each
@@ -182,34 +203,6 @@ impl<F: FieldExt> ExecutionTrace<F> {
         self
     }
 
-    /// Returns a reference to the [`OperationContainer`] which stores all the
-    /// [`Operation`]s for the instance of ExecutionTrace that is called
-    /// for.
-    pub fn container(&self) -> &OperationContainer {
-        &self.container
-    }
-
-    /// Returns an ordered `Vec` containing all the [`StackOp`]s of the actual
-    /// `ExecutionTrace` so that they can be directly included in the State
-    /// proof.
-    pub fn sorted_stack_ops(&self) -> Vec<StackOp> {
-        self.container.sorted_stack()
-    }
-
-    /// Returns an ordered `Vec` containing all the [`MemoryOp`]s of the actual
-    /// `ExecutionTrace` so that they can be directly included in the State
-    /// proof.
-    pub fn sorted_memory_ops(&self) -> Vec<MemoryOp> {
-        self.container.sorted_memory()
-    }
-
-    /// Returns an ordered `Vec` containing all the [`StorageOp`]s of the actual
-    /// `ExecutionTrace` so that they can be directly included in the State
-    /// proof.
-    pub fn sorted_storage_ops(&self) -> Vec<StorageOp> {
-        self.container.sorted_storage()
-    }
-
     /// Registers an [`Operation`] into the [`OperationContainer`] and then adds
     /// a reference to the stored operation ([`OperationRef`]) inside the
     /// bus-mapping instance of the [`ExecutionStep`] located at `exec_step_idx`
@@ -225,16 +218,16 @@ impl<F: FieldExt> ExecutionTrace<F> {
             .push(op_ref);
     }
 
-    /// Returns a mutable reference to the [`OperationContainer`] instance that
-    /// the `ExecutionTrace` holds.
-    fn container_mut(&mut self) -> &mut OperationContainer {
-        &mut self.container
-    }
-
     /// Returns a mutable reference to the [`ExecutionStep`] vector instance
     /// that the `ExecutionTrace` holds.
     fn entries_mut(&mut self) -> &mut Vec<ExecutionStep> {
         &mut self.entries
+    }
+
+    /// Returns a mutable reference to the [`OperationContainer`] instance that
+    /// the `ExecutionTrace` holds.
+    fn container_mut(&mut self) -> &mut OperationContainer {
+        &mut self.container
     }
 }
 

--- a/bus-mapping/src/exec_trace/exec_step.rs
+++ b/bus-mapping/src/exec_trace/exec_step.rs
@@ -101,7 +101,7 @@ impl ExecutionStep {
 
     /// Sets the global counter of the [`Instruction`] execution to the one sent
     /// in the params.
-    pub fn set_gc(&mut self, gc: impl Into<GlobalCounter>) {
+    pub(crate) fn set_gc(&mut self, gc: impl Into<GlobalCounter>) {
         self.gc = gc.into()
     }
 
@@ -111,7 +111,9 @@ impl ExecutionStep {
     }
 
     /// Returns a mutable reference to the bus-mapping instance.
-    pub fn bus_mapping_instance_mut(&mut self) -> &mut Vec<OperationRef> {
+    pub(crate) fn bus_mapping_instance_mut(
+        &mut self,
+    ) -> &mut Vec<OperationRef> {
         &mut self.bus_mapping_instance
     }
 
@@ -123,7 +125,7 @@ impl ExecutionStep {
     ///
     /// ## Returns the #operations added by the
     /// [`OpcodeId`](crate::evm::OpcodeId) into the container.
-    pub fn gen_associated_ops<F: FieldExt>(
+    pub(crate) fn gen_associated_ops<F: FieldExt>(
         &mut self,
         container: &mut OperationContainer,
     ) -> usize {

--- a/bus-mapping/src/exec_trace/exec_step.rs
+++ b/bus-mapping/src/exec_trace/exec_step.rs
@@ -210,15 +210,15 @@ mod tests {
             let mut mem_map = BTreeMap::new();
             mem_map.insert(
                 MemoryAddress(BigUint::from(0x00u8)),
-                EvmWord(BigUint::from(0u8)),
+                EvmWord::from(0u8),
             );
             mem_map.insert(
                 MemoryAddress(BigUint::from(0x20u8)),
-                EvmWord(BigUint::from(0u8)),
+                EvmWord::from(0u8),
             );
             mem_map.insert(
                 MemoryAddress(BigUint::from(0x40u8)),
-                EvmWord(BigUint::from(0x80u8)),
+                EvmWord::from(0x80u8),
             );
 
             ExecutionStep::new(

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -44,8 +44,8 @@
 //! [`OperationContainer`](crate::operation::container::OperationContainer) with
 //! all of the Memory, Stack and Storage ops performed by the provided trace.
 //!
-//! ```rust,ignore
-//! use bus_mapping::{ExecutionTrace, ExecutionStep, BlockConstants, Error};
+//! ```rust
+//! use bus_mapping::{ExecutionTrace, ExecutionStep, BlockConstants, Error, evm::EvmWord};
 //! use pasta_curves::arithmetic::FieldExt;
 //! use num::BigUint;
 //!
@@ -80,7 +80,7 @@
 //! "#;
 //!
 //! let block_ctants = BlockConstants::new(
-//!     EvmWord(BigUint::from(0u8)),
+//!     EvmWord::from(0u8),
 //!     pasta_curves::Fp::zero(),
 //!     pasta_curves::Fp::zero(),
 //!     pasta_curves::Fp::zero(),
@@ -90,21 +90,17 @@
 //!     pasta_curves::Fp::zero(),
 //! );
 //!
-//! // XXX: This will change once we include a better API for ExecutionStep.
-//! let trace_loaded =
-//!     serde_json::from_str::<Vec<ParsedExecutionStep>>(input_trace)
-//!         .expect("Error on parsing")
-//!         .iter()
-//!         .enumerate()
-//!         .map(|(idx, step)| {
-//!             ExecutionStep::try_from((step, GlobalCounter(idx)))
-//!         })
-//!         .collect::<Result<Vec<ExecutionStep>, Error>>()
-//!         .expect("Error on conversion");
-//!
 //! // Here we have the ExecutionTrace completelly formed with all of the data to witness structured.
-//! let obtained_exec_trace =
-//!     ExecutionTrace::new(trace_loaded, block_ctants);
+//! let obtained_exec_trace = ExecutionTrace::from_trace_bytes(
+//!     input_trace.as_bytes(),
+//!     block_ctants,
+//! ).expect("Error on trace generation");
+//!
+//! // Get an ordered vector with all of the Stack operations of this trace.
+//! let stack_ops = obtained_exec_trace.sorted_stack_ops();
+//!
+//! // You can also iterate over the steps of the trace and witness the EVM Proof.
+//! obtained_exec_trace.steps().iter();
 //! ```
 //!
 //! Assume we have the following trace:
@@ -180,6 +176,7 @@
 
 extern crate alloc;
 mod error;
+#[macro_use]
 pub mod evm;
 pub mod exec_trace;
 pub mod operation;

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -401,7 +401,7 @@ mod operation_tests {
             RW::WRITE,
             GlobalCounter(1usize),
             StackAddress::from(1024),
-            EvmWord(BigUint::from(0x40u8)),
+            EvmWord::from(0x40u8),
         );
 
         let stack_op_as_operation = Operation::from(stack_op.clone());
@@ -410,7 +410,7 @@ mod operation_tests {
             RW::WRITE,
             GlobalCounter(1usize),
             MemoryAddress(BigUint::from(0x40u8)),
-            EvmWord(BigUint::from(0x40u8)),
+            EvmWord::from(0x40u8),
         );
 
         let memory_op_as_operation = Operation::from(memory_op.clone());

--- a/bus-mapping/src/operation/container.rs
+++ b/bus-mapping/src/operation/container.rs
@@ -42,7 +42,8 @@ impl OperationContainer {
         OperationRef::from((op.target(), self.0.len()))
     }
 
-    /// Given a [`MemoryRef`] return the actual [`Operation`] it is refering to.
+    /// Given a [`OperationRef`] return the actual [`Operation`] it is refering
+    /// to.
     pub(crate) fn fetch_op(&self, reference: OperationRef) -> &Operation {
         self.0.get(reference.as_usize()).expect("it should not be possible to have a ref to a non-existent operation")
     }

--- a/bus-mapping/src/operation/container.rs
+++ b/bus-mapping/src/operation/container.rs
@@ -42,6 +42,11 @@ impl OperationContainer {
         OperationRef::from((op.target(), self.0.len()))
     }
 
+    /// Given a [`MemoryRef`] return the actual [`Operation`] it is refering to.
+    pub(crate) fn fetch_op(&self, reference: OperationRef) -> &Operation {
+        self.0.get(reference.as_usize()).expect("it should not be possible to have a ref to a non-existent operation")
+    }
+
     /// Returns a sorted vector of all of the [`MemoryOp`]s contained inside of
     /// the container.
     pub fn sorted_memory(&self) -> Vec<MemoryOp> {


### PR DESCRIPTION
- Add an API to collect sorted Mem/Stack/Storage Operations 
- Add an API to fetch Container ops from refs
- Add getters for Stack/Storage & Memory ops in trace

Closes: #35 