### PR TITLE
Implement byte-conversion for `EvmWord` & `MemoryAddress`

### DIFF
--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -65,6 +65,15 @@ impl MemoryAddress {
     pub fn zero() -> MemoryAddress {
         MEM_ADDR_ZERO.clone()
     }
+
+    /// Return the little-endian byte representation of the word as a 32-byte
+    /// array.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&self.0.to_bytes_le());
+
+        array
+    }
 }
 
 impl From<MemoryAddress> for BigUint {
@@ -152,4 +161,15 @@ macro_rules! impl_from_basic_types {
     };
 }
 
-impl_from_basic_types!(u8, u16, u32, u64, u128);
+impl_from_basic_types!(u8, u16, u32, u64, u128, usize);
+
+impl EvmWord {
+    /// Return the little-endian byte representation of the word as a 32-byte
+    /// array.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&self.0.to_bytes_le());
+
+        array
+    }
+}

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -172,4 +172,9 @@ impl EvmWord {
 
         array
     }
+
+    /// Returns the underlying representation of the `EvmWord` as a [`BigUint`].
+    pub fn as_big_uint(&self) -> &BigUint {
+        &self.0
+    }
 }


### PR DESCRIPTION
As suggested by @miha-stopar. Until we don't have the specific Scalar/Field structs we're going to be using, we need to deal with `EvmWord`-like structs which are nothing else than a wrapper over `BigUint`.

Therefore, we at least should provide a way to convert these `EvmWord`s into byte arrays so that we can do tmp conversions.