### PR TITLE
Externalize Circuit-related logic to zkevm-circuits

### DIFF
--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -6,14 +6,12 @@ use crate::{
     exec_trace::ExecutionStep, operation::container::OperationContainer,
 };
 use core::fmt::Debug;
-use halo2::{arithmetic::FieldExt, plonk::ConstraintSystem};
 use ids::OpcodeId;
 
 /// Generic opcode trait which defines the logic of the
 /// [`Operation`](crate::operation::Operation) that should be generated for an
 /// [`ExecutionStep`](crate::exec_trace::ExecutionStep) depending of the
-/// [`OpcodeId`] it contains. And also the generation of the constraints and
-/// ZK-Circuit related definitions associated to the opcode itself.
+/// [`OpcodeId`] it contains.
 pub trait Opcode: Debug {
     /// Generate the associated [`MemoryOp`](crate::operation::MemoryOp)s,
     /// [`StackOp`](crate::operation::StackOp)s, and
@@ -24,14 +22,6 @@ pub trait Opcode: Debug {
         exec_step: &mut ExecutionStep,
         container: &mut OperationContainer,
     ) -> usize;
-
-    /// Generate the constraints associated to an Opcode and add them inside a
-    /// [`ConstraintSystem`] instance.
-    fn add_constraints<F: FieldExt>(
-        &self,
-        exec_step: &ExecutionStep,
-        cs: &mut ConstraintSystem<F>,
-    );
 }
 
 // This is implemented for OpcodeId so that we can downcast the responsabilities
@@ -49,17 +39,6 @@ impl Opcode for OpcodeId {
             OpcodeId::PUSH1 => {
                 Push1 {}.gen_associated_ops(exec_step, container)
             }
-            _ => unimplemented!(),
-        }
-    }
-
-    fn add_constraints<F: FieldExt>(
-        &self,
-        exec_step: &ExecutionStep,
-        cs: &mut ConstraintSystem<F>,
-    ) {
-        match *self {
-            OpcodeId::PUSH1 => Push1 {}.add_constraints(exec_step, cs),
             _ => unimplemented!(),
         }
     }

--- a/bus-mapping/src/evm/opcodes/push.rs
+++ b/bus-mapping/src/evm/opcodes/push.rs
@@ -5,7 +5,6 @@ use crate::{
     exec_trace::ExecutionStep,
     operation::{container::OperationContainer, StackOp, RW},
 };
-use halo2::{arithmetic::FieldExt, plonk::ConstraintSystem};
 
 /// Number of ops that PUSH1 adds to the container & busmapping
 const PUSH1_OP_NUM: usize = 1;
@@ -36,14 +35,5 @@ impl Opcode for Push1 {
             .push(container.insert(op));
 
         PUSH1_OP_NUM
-    }
-
-    #[allow(unused_variables)]
-    fn add_constraints<F: FieldExt>(
-        &self,
-        exec_step: &ExecutionStep,
-        cs: &mut ConstraintSystem<F>,
-    ) {
-        unimplemented!()
     }
 }


### PR DESCRIPTION
As discussed with @han0110 we should externalize all of
the Constraint-System/circuit related stuff to zkevm-circuits
in order to reduce circular depency issuesand make
the overall solution simpler.

Resolves: #49