### PR TITLE
Remove warning and fix some typos

### DIFF
--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     OpcodeParsing,
     /// Error while parsing a `MemoryAddress`.
     MemAddressParsing,
+    /// Error while parsing a `StackAddress`.
+    StackAddressParsing,
     /// Error while parsing an `EvmWord`.
     EvmWordParsing,
     /// Error while trying to convert to an incorrect `OpcodeId`.

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -88,7 +88,7 @@ impl FromStr for MemoryAddress {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(MemoryAddress(
             BigUint::from_str_radix(s, 16)
-                .map_err(|_| Error::EvmWordParsing)?,
+                .map_err(|_| Error::MemAddressParsing)?,
         ))
     }
 }
@@ -123,14 +123,14 @@ impl FromStr for StackAddress {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(StackAddress(
             BigUint::from_str_radix(s, 16)
-                .map_err(|_| Error::EvmWordParsing)
+                .map_err(|_| Error::StackAddressParsing)
                 .map(|biguint| {
                     biguint
                         .try_into()
-                        .map_err(|_| Error::EvmWordParsing)
+                        .map_err(|_| Error::StackAddressParsing)
                         .expect("Map_err should be applied")
                 })
-                .map_err(|_| Error::EvmWordParsing)?,
+                .map_err(|_| Error::StackAddressParsing)?,
         ))
     }
 }

--- a/bus-mapping/src/evm/opcodes/ids.rs
+++ b/bus-mapping/src/evm/opcodes/ids.rs
@@ -477,6 +477,7 @@ impl FromStr for OpcodeId {
             "STATICCALL" => OpcodeId::STATICCALL,
             "SELFDESTRUCT" => OpcodeId::SELFDESTRUCT,
             "CHAINID" => OpcodeId::CHAINID,
+            "BASEFEE" => OpcodeId::BASEFEE,
             _ => return Err(Error::OpcodeParsing),
         })
     }

--- a/bus-mapping/src/exec_trace.rs
+++ b/bus-mapping/src/exec_trace.rs
@@ -107,11 +107,11 @@ impl<F: FieldExt> BlockConstants<F> {
 /// format for now).
 ///
 /// 2. Generate and provide an iterator over all of the
-/// [`Instruction`](crate::evm::Instruction)s of the trace and apply it's
+/// [`Instruction`](crate::evm::Instruction)s of the trace and apply its
 /// respective constraints into a provided a mutable reference to a
 /// [`ConstraintSystyem`](halo2::plonk::ConstraintSystem).
 ///
-/// 3. Generate and provide and ordered list of all of the
+/// 3. Generate and provide an ordered list of all of the
 /// [`StackOp`](crate::operation::StackOp)s,
 /// [`MemoryOp`](crate::operation::MemoryOp)s and
 /// [`StorageOp`](crate::operation::StorageOp)s that each

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -168,7 +168,7 @@
 // Temporary until we have more of the crate implemented.
 #![allow(dead_code)]
 // Catch documentation errors caused by code changes.
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_docs)]
 //#![deny(unsafe_code)] Allowed now until we find a
 // better way to handle downcasting from Operation into it's variants.

--- a/bus-mapping/src/operation/container.rs
+++ b/bus-mapping/src/operation/container.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use std::convert::TryInto;
 
 /// The `OperationContainer` is meant to store all of the [`Operation`]s that an
-/// [`ExecutionTrace`](crate::exec_trace::ExecutionTrace) performs during it's
+/// [`ExecutionTrace`](crate::exec_trace::ExecutionTrace) performs during its
 /// execution.
 ///
 /// Once an operation is inserted into the container, it returns an

--- a/zkevm-circuits/src/lib.rs
+++ b/zkevm-circuits/src/lib.rs
@@ -4,7 +4,7 @@
 // Temporary until we have more of the crate implemented.
 #![allow(dead_code)]
 // Catch documentation errors caused by code changes.
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]


### PR DESCRIPTION
Remove the `broken_intra_doc_links ` warning and fix some typos.