### PR TITLE
Update README.md to point to spec repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Circuits for zkEVM
 
-WIP spec: https://github.com/appliedzkp/zkevm-specs
+[![CI checks](https://github.com/appliedzkp/zkevm-circuits/actions/workflows/ci.yml/badge.svg)](https://github.com/appliedzkp/zkevm-circuits/actions/workflows/ci.yml)
+
+Check out the work in progress [specification](https://github.com/appliedzkp/zkevm-specs) to learn how it works.
+
+
+## Getting started
+
+`make test-all`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Circuits for zkEVM
 
-WIP spec: https://hackmd.io/Hy_nqH4yTOmjjS9nbOArgw
+WIP spec: https://github.com/appliedzkp/zkevm-specs


### PR DESCRIPTION
We originally started wtih a hackmd for spec. After we moved the spec to github. Just updateing the readme to point to the new spec. 