### PR TITLE
Implement MLOAD/MSTORE opcodes

### DIFF
--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -288,6 +288,8 @@ impl GasCost {
     pub const SLOW: Self = Self(10);
     /// Constant cost for ext step
     pub const EXT: Self = Self(20);
+    /// Constant cost for every additional word when expanding memory
+    pub const MEMORY: Self = Self(3);
     /// Constant cost for a cold SLOAD
     pub const COLD_SLOAD_COST: Self = Self(2100);
     /// Constant cost for a cold account access

--- a/bus-mapping/src/evm/gas.rs
+++ b/bus-mapping/src/evm/gas.rs
@@ -16,10 +16,12 @@ impl GasCost {
     pub const SLOW: Self = Self(10);
     /// Constant cost for ext step
     pub const EXT: Self = Self(20);
+    /// Constant cost for every additional word when expanding memory
+    pub const MEMORY: Self = Self(3);
     /// Constant cost for a cold SLOAD
     pub const COLD_SLOAD_COST: Self = Self(2100);
     /// Constant cost for a cold account access
-    pub const COLD_ACCOUNT_ACCESS_COST: Self = Self(100);
+    pub const COLD_ACCOUNT_ACCESS_COST: Self = Self(2600);
     /// Constant cost for a warm storage read
     pub const WARM_STORAGE_READ_COST: Self = Self(100);
 }

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -18,7 +18,8 @@ static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
-    gas_delta: Some(GasCost::FASTEST.as_usize()),
+    gas_delta: Some(GasCost::FASTEST.as_u64()),
+    next_memory_size: None,
 };
 const NUM_POPPED: usize = 2;
 
@@ -166,7 +167,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
@@ -18,7 +18,8 @@ static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
-    gas_delta: Some(GasCost::FASTEST.as_usize()),
+    gas_delta: Some(GasCost::FASTEST.as_u64()),
+    next_memory_size: None,
 };
 const NUM_POPPED: usize = 2;
 
@@ -161,7 +162,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/comparator.rs
@@ -16,7 +16,8 @@ static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
-    gas_delta: Some(GasCost::FASTEST.as_usize()),
+    gas_delta: Some(GasCost::FASTEST.as_u64()),
+    next_memory_size: None,
 };
 const NUM_POPPED: usize = 2;
 
@@ -200,7 +201,7 @@ mod test {
         ($execution_step:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_step, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/dup.rs
@@ -18,7 +18,8 @@ static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(2), // 1 stack read + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(-1),
-    gas_delta: Some(GasCost::FASTEST.as_usize()),
+    gas_delta: Some(GasCost::FASTEST.as_u64()),
+    next_memory_size: None,
 };
 const NUM_PUSHED: usize = 1;
 
@@ -70,7 +71,7 @@ impl<F: FieldExt> DupSuccessCase<F> {
         let dup_offset = state_curr.opcode.expr() - OpcodeId::DUP1.expr();
 
         // Peek the value at `dup_offset` and push the value on the stack
-        cb.stack_lookup(dup_offset, self.value.expr(), false);
+        cb.stack_lookup(dup_offset, self.value.expr(), false.expr());
         cb.stack_push(self.value.expr());
 
         // State transitions
@@ -112,7 +113,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/jumpdest.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/jumpdest.rs
@@ -16,7 +16,8 @@ static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(0),
     pc_delta: Some(1),
     sp_delta: Some(0),
-    gas_delta: Some(GasCost::ONE.as_usize()),
+    gas_delta: Some(GasCost::ONE.as_u64()),
+    next_memory_size: None,
 };
 
 impl_op_gadget!(
@@ -89,7 +90,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
@@ -328,7 +328,7 @@ impl<F: FieldExt> MemoryStackUnderflowCase<F> {
         let is_mstore = self.is_mstore.constraints(
             &mut cb,
             state_curr.opcode.expr(),
-            OpcodeId::MLOAD.expr(),
+            OpcodeId::MSTORE.expr(),
         );
 
         // For MLOAD we only pop one value from the stack,

--- a/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
@@ -1,0 +1,614 @@
+use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
+use super::utils::constraint_builder::ConstraintBuilder;
+use super::utils::math_gadgets::{IsEqualGadget, IsZeroGadget, LtGadget};
+use super::utils::memory_gadgets::{
+    self, address_high, address_low, MemoryExpansionGadget,
+};
+use super::utils::{StateTransition, StateTransitionExpressions};
+use super::{
+    CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
+};
+use crate::evm_circuit::param::{MAX_MEMORY_SIZE_IN_BYTES, STACK_START_IDX};
+use crate::impl_op_gadget;
+use crate::util::{Expr, ToWord};
+use bus_mapping::evm::{GasCost, OpcodeId};
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region};
+use std::convert::TryInto;
+
+static STATE_TRANSITION: StateTransition = StateTransition {
+    gc_delta: Some(34), // 2 stack + 32 memory
+    pc_delta: Some(1),
+    sp_delta: None, // MLOAD: SP_DELTA_MLOAD, MSTORE: SP_DELTA_MSTORE
+    gas_delta: None, // GAS + memory_cost
+    next_memory_size: None, // mext_memory_size
+};
+const GAS: GasCost = GasCost::FASTEST;
+const SP_DELTA_MLOAD: i32 = 0;
+const SP_DELTA_MSTORE: i32 = 2;
+const NUM_POPPED_MLOAD: usize = 2;
+const NUM_POPPED_MSTORE: usize = 1;
+
+impl_op_gadget!(
+    #set[MLOAD, MSTORE]
+    MemoryGadget {
+        MemorySuccessCase(),
+        MemoryStackUnderflowCase(),
+        MemoryOutOfGasCase(),
+    }
+);
+
+#[derive(Clone, Debug)]
+struct MemorySuccessCase<F> {
+    case_selector: Cell<F>,
+    address: Word<F>,
+    value: Word<F>,
+    call_id: Cell<F>,
+    memory_expansion: MemoryExpansionGadget<F>,
+    is_mload: IsEqualGadget<F>,
+}
+
+impl<F: FieldExt> MemorySuccessCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::Success,
+        num_word: 2  // value + address
+            + MemoryExpansionGadget::<F>::NUM_WORDS
+            + IsEqualGadget::<F>::NUM_WORDS,
+        num_cell: 1  // call_id
+            + MemoryExpansionGadget::<F>::NUM_CELLS
+            + IsEqualGadget::<F>::NUM_CELLS,
+        will_halt: false,
+    };
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            case_selector: alloc.selector.clone(),
+            address: alloc.words.pop().unwrap(),
+            value: alloc.words.pop().unwrap(),
+            call_id: alloc.cells.pop().unwrap(),
+            memory_expansion: MemoryExpansionGadget::construct(alloc),
+            is_mload: IsEqualGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraint(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        state_next: &OpExecutionState<F>,
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::with_call_id(self.call_id.expr());
+
+        // Check if this is an MLOAD or an MSTORE
+        let is_mload = self.is_mload.constraints(
+            &mut cb,
+            state_curr.opcode.expr(),
+            OpcodeId::MLOAD.expr(),
+        );
+        let is_mstore = 1.expr() - is_mload.clone();
+
+        // Not all address bytes are used to calculate the gas cost for the memory access,
+        // so make sure this success case is disabled if any of those address bytes
+        // are actually used.
+        memory_gadgets::require_address_in_range(&mut cb, &self.address);
+        // Get the capped address value we will use in the memory calculations
+        let address = address_low::expr(&self.address);
+
+        // Calculate the next memory size and the gas cost for this memory access
+        let (next_memory_size, memory_cost) =
+            self.memory_expansion.constraints(
+                &mut cb,
+                state_curr.memory_size.expr(),
+                address.clone() + 32.expr(),
+            );
+
+        /* Stack operations */
+        // Pop the address from the stack
+        cb.stack_pop(self.address.expr());
+        // For MLOAD push the value to the stack
+        // FOR MSTORE pop the value from the stack
+        let stack_offset = cb.stack_offset.expr() - is_mload.clone();
+        cb.stack_lookup(stack_offset, self.value.expr(), is_mload);
+
+        /* Memory operations */
+        // Read/Write the value from memory at the specified address
+        cb.memory_lookup(
+            address,
+            self.value.cells.iter().map(|cell| cell.expr()).collect(),
+            is_mstore.clone(),
+        );
+
+        // State transitions
+        // - `sp_delta` needs to be increased by SP_DELTA_MLOAD/SP_DELTA_MSTORE
+        // - `gas_delta` needs to be increased by `GAS + memory_cost`
+        // - `next_memory_size` needs to be set to `next_memory_size`
+        let mut st = StateTransitionExpressions::new(STATE_TRANSITION.clone());
+        st.sp_delta = Some(is_mstore * 2.expr());
+        st.gas_delta = Some(GAS.expr() + memory_cost);
+        st.next_memory_size = Some(next_memory_size);
+        st.constraints(&mut cb, state_curr, state_next);
+
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
+    }
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        // Inputs/Outputs
+        self.address
+            .assign(region, offset, Some(step.values[0].to_word()))?;
+        self.value
+            .assign(region, offset, Some(step.values[1].to_word()))?;
+
+        // The call id of the current call context
+        self.call_id.assign(
+            region,
+            offset,
+            Some(F::from_u64(state.call_id as u64)),
+        )?;
+
+        // Check if this is an MLOAD or an MSTORE
+        let is_mload = self.is_mload.assign(
+            region,
+            offset,
+            F::from_u64(step.opcode.as_u8() as u64),
+            F::from_u64(OpcodeId::MLOAD.as_u8() as u64),
+        )?;
+
+        // Memory expansion
+        let address = address_low::value::<F>(step.values[0].to_word());
+        let (new_memory_size, memory_cost) = self.memory_expansion.assign(
+            region,
+            offset,
+            state.memory_size as u64,
+            address + 32,
+        )?;
+
+        // State transitions
+        let mut st = STATE_TRANSITION.clone();
+        st.sp_delta = Some(if is_mload == F::one() {
+            SP_DELTA_MLOAD
+        } else {
+            SP_DELTA_MSTORE
+        });
+        st.gas_delta = Some(GAS.as_u64() + (memory_cost as u64));
+        st.next_memory_size = Some(new_memory_size);
+        st.assign(state);
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MemoryOutOfGasCase<F> {
+    case_selector: Cell<F>,
+    gas_available: Cell<F>,
+    address: Word<F>,
+    address_in_range: IsZeroGadget<F>,
+    memory_expansion: MemoryExpansionGadget<F>,
+    insufficient_gas: LtGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 - 1 }>,
+}
+
+impl<F: FieldExt> MemoryOutOfGasCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::OutOfGas,
+        num_word: 1  // address
+            + IsZeroGadget::<F>::NUM_WORDS
+            + MemoryExpansionGadget::<F>::NUM_WORDS
+            + LtGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2-1}>::NUM_WORDS,
+        num_cell: IsZeroGadget::<F>::NUM_CELLS
+            + MemoryExpansionGadget::<F>::NUM_CELLS
+            + LtGadget::<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 - 1 }>::NUM_CELLS,
+        will_halt: true,
+    };
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            case_selector: alloc.selector.clone(),
+            gas_available: alloc.resumption.clone().unwrap().gas_available,
+            address: alloc.words.pop().unwrap(),
+            address_in_range: IsZeroGadget::construct(alloc),
+            memory_expansion: MemoryExpansionGadget::construct(alloc),
+            insufficient_gas: LtGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraint(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        _state_next: &OpExecutionState<F>,
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
+
+        // Get the capped address value we will use in the memory calculations
+        let address = address_low::expr(&self.address);
+        // Get the next memory size and the gas cost for this memory access
+        let (_, memory_cost) = self.memory_expansion.constraints(
+            &mut cb,
+            state_curr.memory_size.expr(),
+            address + 32.expr(),
+        );
+
+        // Check if the memory address is too large
+        let address_in_range = self
+            .address_in_range
+            .constraints(&mut cb, address_high::expr(&self.address));
+        // Check if the amount of gas available is less than the amount of gas required
+        let insufficient_gas = self.insufficient_gas.constraints(
+            &mut cb,
+            self.gas_available.expr(),
+            state_curr.gas_counter.expr() + GAS.expr() + memory_cost,
+        );
+
+        // Make sure we are out of gas
+        // Out of gas when either the address is too big and/or the amount of gas
+        // available is lower than what is required.
+        cb.require_zero(address_in_range * (1.expr() - insufficient_gas));
+
+        // Pop the address from the stack
+        // We still have to do this to verify the correctness of `address`
+        cb.stack_pop(self.address.expr());
+
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
+    }
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        // Inputs
+        self.address
+            .assign(region, offset, Some(step.values[0].to_word()))?;
+
+        // Address in range check
+        let address = address_low::value::<F>(step.values[0].to_word());
+        self.address_in_range.assign(
+            region,
+            offset,
+            (address as u64).into(),
+        )?;
+
+        // Memory expansion
+        let address = address_low::value::<F>(step.values[0].to_word());
+        let (_memory_size, memory_cost) = self.memory_expansion.assign(
+            region,
+            offset,
+            state.memory_size as u64,
+            address + 32,
+        )?;
+
+        // Gas insufficient check
+        // Get `gas_available` variable here once it's available
+        self.insufficient_gas.assign(
+            region,
+            offset,
+            F::from_u64(
+                state.gas_counter + GAS.as_u64() + (memory_cost as u64),
+            ),
+            F::from_bytes(&step.values[1].to_word()).unwrap(),
+        )?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MemoryStackUnderflowCase<F> {
+    case_selector: Cell<F>,
+    is_mstore: IsEqualGadget<F>,
+}
+
+impl<F: FieldExt> MemoryStackUnderflowCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::StackUnderflow,
+        num_word: IsEqualGadget::<F>::NUM_WORDS,
+        num_cell: IsEqualGadget::<F>::NUM_CELLS,
+        will_halt: true,
+    };
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            case_selector: alloc.selector.clone(),
+            is_mstore: IsEqualGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraint(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        _state_next: &OpExecutionState<F>,
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
+
+        // Check if this is an MLOAD or an MSTORE
+        let is_mstore = self.is_mstore.constraints(
+            &mut cb,
+            state_curr.opcode.expr(),
+            OpcodeId::MLOAD.expr(),
+        );
+
+        // For MLOAD we only pop one value from the stack,
+        // For MSTORE we pop two values from the stack.
+        let set =
+            vec![STACK_START_IDX.expr(), STACK_START_IDX.expr() - is_mstore];
+        cb.require_in_set(state_curr.stack_pointer.expr(), set);
+
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        _state: &mut CoreStateInstance,
+        step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        // Check if this is an MLOAD or an MSTORE
+        self.is_mstore.assign(
+            region,
+            offset,
+            F::from_u64(step.opcode.as_u8() as u64),
+            F::from_u64(OpcodeId::MSTORE.as_u8() as u64),
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::super::{
+        test::TestCircuit, Case, ExecutionStep, Operation,
+    };
+    use crate::util::ToWord;
+    use bus_mapping::{evm::OpcodeId, operation::Target};
+    use halo2::{arithmetic::FieldExt, dev::MockProver};
+    use num::BigUint;
+    use pasta_curves::pallas::Base;
+
+    macro_rules! try_test_circuit {
+        ($execution_steps:expr, $operations:expr, $result:expr) => {{
+            let circuit =
+                TestCircuit::<Base>::new($execution_steps, $operations);
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
+            assert_eq!(prover.verify(), $result);
+        }};
+    }
+
+    /// Helper to track gc
+    /// The `gc` parameter will be modified inside this macro.
+    macro_rules! advance_gc {
+        ($gc:ident) => {{
+            #[allow(unused_assignments, clippy::eval_order_dependence)]
+            {
+                *$gc += 1;
+                *$gc
+            }
+        }};
+    }
+
+    fn compress(bytes: [u8; 32]) -> Base {
+        bytes
+            .iter()
+            .fold(Base::zero(), |acc, val| acc + Base::from_u64(*val as u64))
+    }
+
+    fn mstore_ops(
+        operations: &mut Vec<Operation<Base>>,
+        gc: &mut usize,
+        stack_index: u64,
+        address: BigUint,
+        value: BigUint,
+    ) {
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: true,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(value.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: true,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index - 1),
+                compress(address.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: false,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index - 1),
+                compress(address.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: false,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(value.to_word()),
+                Base::zero(),
+            ],
+        });
+        for idx in 0..32 {
+            operations.push(Operation {
+                gc: advance_gc!(gc),
+                target: Target::Memory,
+                is_write: true,
+                values: [
+                    Base::zero(),
+                    Base::from_bytes(
+                        &(address.clone() + BigUint::from(idx as u64))
+                            .to_word(),
+                    )
+                    .unwrap(),
+                    Base::from_u64(
+                        value.to_bytes_le()[31 - idx as usize] as u64,
+                    ),
+                    Base::zero(),
+                ],
+            });
+        }
+    }
+
+    fn mload_ops(
+        operations: &mut Vec<Operation<Base>>,
+        gc: &mut usize,
+        stack_index: u64,
+        address: BigUint,
+        value: BigUint,
+    ) {
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: true,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(address.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: false,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(address.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: true,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(value.to_word()),
+                Base::zero(),
+            ],
+        });
+        for idx in 0..32 {
+            operations.push(Operation {
+                gc: advance_gc!(gc),
+                target: Target::Memory,
+                is_write: false,
+                values: [
+                    Base::zero(),
+                    Base::from_bytes(
+                        &(address.clone() + BigUint::from(idx as u64))
+                            .to_word(),
+                    )
+                    .unwrap(),
+                    Base::from_u64(
+                        value.to_bytes_le()[31 - idx as usize] as u64,
+                    ),
+                    Base::zero(),
+                ],
+            });
+        }
+    }
+
+    #[test]
+    fn memory_gadget() {
+        // Store/Load a value at address 0x12FFFF
+        let address_a = BigUint::from(0x12FFFFu64);
+        let value_a =
+            BigUint::from_bytes_be(&(1u8..33u8).collect::<Vec<u8>>()[..]);
+
+        // Load the memory at address_a + 16 as well
+        let address_b = address_a.clone() + BigUint::from(16u64);
+        let value_b = BigUint::from_bytes_be(
+            &value_a.to_bytes_be()[16..]
+                .to_vec()
+                .into_iter()
+                .chain(
+                    vec![0u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                        .into_iter(),
+                )
+                .collect::<Vec<u8>>()[..],
+        );
+
+        let all_ones = BigUint::from_bytes_le(&[1u8; 32]);
+
+        let execution_steps = vec![
+            ExecutionStep {
+                opcode: OpcodeId::PUSH32,
+                case: Case::Success,
+                values: vec![value_a.clone(), all_ones.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::PUSH32,
+                case: Case::Success,
+                values: vec![address_a.clone(), all_ones.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::MSTORE,
+                case: Case::Success,
+                values: vec![address_a.clone(), value_a.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::PUSH32,
+                case: Case::Success,
+                values: vec![address_a.clone(), all_ones.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::MLOAD,
+                case: Case::Success,
+                values: vec![address_a.clone(), value_a.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::PUSH32,
+                case: Case::Success,
+                values: vec![address_b.clone(), all_ones],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::MLOAD,
+                case: Case::Success,
+                values: vec![address_b.clone(), value_b.clone()],
+            },
+        ];
+
+        let mut gc = 0usize;
+        let mut operations = vec![];
+        mstore_ops(
+            &mut operations,
+            &mut gc,
+            1023u64,
+            address_a.clone(),
+            value_a.clone(),
+        );
+        mload_ops(&mut operations, &mut gc, 1023u64, address_a, value_a);
+        mload_ops(&mut operations, &mut gc, 1022u64, address_b, value_b);
+
+        try_test_circuit!(execution_steps, operations, Ok(()));
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
@@ -21,9 +21,9 @@ use std::convert::TryInto;
 static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(34), // 2 stack + 32 memory
     pc_delta: Some(1),
-    sp_delta: None, // MLOAD: SP_DELTA_MLOAD, MSTORE: SP_DELTA_MSTORE
-    gas_delta: None, // GAS + memory_cost
-    next_memory_size: None, // mext_memory_size
+    sp_delta: None,         // SP_DELTA_MLOAD/SP_DELTA_MSTORE
+    gas_delta: None,        // GAS + memory_cost
+    next_memory_size: None, // next_memory_size
 };
 const GAS: GasCost = GasCost::FASTEST;
 const SP_DELTA_MLOAD: i32 = 0;
@@ -52,9 +52,7 @@ struct MemorySuccessCase<F> {
 impl<F: FieldExt> MemorySuccessCase<F> {
     pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
         case: Case::Success,
-        num_word: 2  // value + address
-            + MemoryExpansionGadget::<F, MAX_GAS_SIZE_IN_BYTES>::NUM_WORDS
-            + IsEqualGadget::<F>::NUM_WORDS,
+        num_word: 2, // address + value,
         num_cell: MemoryExpansionGadget::<F, MAX_GAS_SIZE_IN_BYTES>::NUM_CELLS
             + IsEqualGadget::<F>::NUM_CELLS,
         will_halt: false,
@@ -190,10 +188,7 @@ struct MemoryOutOfGasCase<F> {
 impl<F: FieldExt> MemoryOutOfGasCase<F> {
     pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
         case: Case::OutOfGas,
-        num_word: 1  // address
-            + IsZeroGadget::<F>::NUM_WORDS
-            + MemoryExpansionGadget::<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 - 1}>::NUM_WORDS
-            + LtGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2-1}>::NUM_WORDS,
+        num_word: 1,  // address
         num_cell: IsZeroGadget::<F>::NUM_CELLS
             + MemoryExpansionGadget::<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 - 1}>::NUM_CELLS
             + LtGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2-1}>::NUM_CELLS,

--- a/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
@@ -55,8 +55,7 @@ impl<F: FieldExt> MemorySuccessCase<F> {
         num_word: 2  // value + address
             + MemoryExpansionGadget::<F, MAX_GAS_SIZE_IN_BYTES>::NUM_WORDS
             + IsEqualGadget::<F>::NUM_WORDS,
-        num_cell: 1  // call_id
-            + MemoryExpansionGadget::<F, MAX_GAS_SIZE_IN_BYTES>::NUM_CELLS
+        num_cell: MemoryExpansionGadget::<F, MAX_GAS_SIZE_IN_BYTES>::NUM_CELLS
             + IsEqualGadget::<F>::NUM_CELLS,
         will_halt: false,
     };

--- a/zkevm-circuits/src/evm_circuit/op_execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pc.rs
@@ -15,7 +15,8 @@ static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(1), // 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(-1),
-    gas_delta: Some(GasCost::QUICK.as_usize()),
+    gas_delta: Some(GasCost::QUICK.as_u64()),
+    next_memory_size: None,
 };
 const NUM_PUSHED: usize = 1;
 
@@ -110,7 +111,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
@@ -16,7 +16,8 @@ static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(1), // 1 stack pop
     pc_delta: Some(1),
     sp_delta: Some(1),
-    gas_delta: Some(GasCost::QUICK.as_usize()),
+    gas_delta: Some(GasCost::QUICK.as_u64()),
+    next_memory_size: None,
 };
 const NUM_POPPED: usize = 1;
 
@@ -100,7 +101,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/push.rs
@@ -15,9 +15,10 @@ use std::convert::TryInto;
 
 static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(1), // 1 stack push
-    pc_delta: None,
+    pc_delta: None,    // 1 + PUSHX
     sp_delta: Some(-1),
-    gas_delta: Some(GasCost::FASTEST.as_usize()),
+    gas_delta: Some(GasCost::FASTEST.as_u64()),
+    next_memory_size: None,
 };
 const NUM_PUSHED: usize = 1;
 
@@ -154,7 +155,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
@@ -20,7 +20,8 @@ static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
-    gas_delta: Some(GasCost::FAST.as_usize()),
+    gas_delta: Some(GasCost::FAST.as_u64()),
+    next_memory_size: None,
 };
 const NUM_POPPED: usize = 2;
 
@@ -234,7 +235,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/common_cases.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/common_cases.rs
@@ -3,18 +3,17 @@ use super::super::{
     ExecutionStep, OpExecutionState,
 };
 use super::constraint_builder::ConstraintBuilder;
+use crate::evm_circuit::param::STACK_START_IDX;
 use crate::util::Expr;
 use bus_mapping::evm::OpcodeId;
 use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region};
 
-pub const STACK_START_IDX: usize = 1024;
-
 #[derive(Clone, Debug)]
 pub(crate) struct OutOfGasCase<F> {
     case_selector: Cell<F>,
     gas_available: Cell<F>,
-    gas_used: usize,
+    gas_used: u64,
 }
 
 impl<F: FieldExt> OutOfGasCase<F> {
@@ -27,7 +26,7 @@ impl<F: FieldExt> OutOfGasCase<F> {
 
     pub(crate) fn construct(
         alloc: &mut CaseAllocation<F>,
-        gas_used: usize,
+        gas_used: u64,
     ) -> Self {
         Self {
             case_selector: alloc.selector.clone(),

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
@@ -381,6 +381,7 @@ impl<F: FieldExt, const NUM_BYTES: usize> ConstantDivisionGadget<F, NUM_BYTES> {
             self.quotient.expr() * self.divisor.expr(),
         );
 
+        // Return the quotient and the remainder
         (self.quotient.expr(), self.remainder.expr())
     }
 

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
@@ -1,6 +1,8 @@
-use super::super::utils;
 use super::super::CaseAllocation;
 use super::super::Cell;
+use super::constraint_builder::ConstraintBuilder;
+use super::select;
+use super::sum;
 use super::{from_bytes, get_range};
 use crate::evm_circuit::param::MAX_BYTES_FIELD;
 use crate::util::Expr;
@@ -8,9 +10,7 @@ use array_init::array_init;
 use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
 
-use super::constraint_builder::ConstraintBuilder;
-
-// Returns `1` when `value == 0`, and returns `0` otherwise.
+/// Returns `1` when `value == 0`, and returns `0` otherwise.
 #[derive(Clone, Debug)]
 pub struct IsZeroGadget<F> {
     pub(crate) inverse: Cell<F>,
@@ -52,7 +52,7 @@ impl<F: FieldExt> IsZeroGadget<F> {
     }
 }
 
-// Returns `1` when `lhs == rhs`, and returns `0` otherwise.
+/// Returns `1` when `lhs == rhs`, and returns `0` otherwise.
 #[derive(Clone, Debug)]
 pub struct IsEqualGadget<F> {
     pub(crate) is_zero: IsZeroGadget<F>,
@@ -85,6 +85,53 @@ impl<F: FieldExt> IsEqualGadget<F> {
         rhs: F,
     ) -> Result<F, Error> {
         self.is_zero.assign(region, offset, lhs - rhs)
+    }
+}
+
+/// Requires that the passed in value is within the specified range.
+/// `NUM_BYTES` is required to be `<= 31`.
+#[derive(Clone, Debug)]
+pub struct RangeCheckGadget<F, const NUM_BYTES: usize> {
+    parts: [Cell<F>; NUM_BYTES],
+}
+
+impl<F: FieldExt, const NUM_BYTES: usize> RangeCheckGadget<F, NUM_BYTES> {
+    pub const NUM_CELLS: usize = NUM_BYTES;
+    pub const NUM_WORDS: usize = 0;
+
+    pub const PART_SIZE: u64 = 256;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        assert!(NUM_BYTES <= 31, "number of bytes too large");
+        Self {
+            parts: array_init(|_| alloc.cells.pop().unwrap()),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        value: Expression<F>,
+    ) {
+        // Range check the parts using lookups
+        for part in self.parts.iter() {
+            cb.require_in_range(part.expr(), Self::PART_SIZE);
+        }
+        // Require that the reconstructed value from the parts equals the original value
+        cb.require_equal(value, from_bytes::expr(self.parts.to_vec()));
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        value: F,
+    ) -> Result<(), Error> {
+        let bytes = value.to_bytes();
+        for (idx, part) in self.parts.iter().enumerate() {
+            part.assign(region, offset, Some(F::from_u64(bytes[idx] as u64)))?;
+        }
+        Ok(())
     }
 }
 
@@ -207,7 +254,7 @@ impl<F: FieldExt, const NUM_BYTES: usize> ComparisonGadget<F, NUM_BYTES> {
         // eq
         let eq = self
             .eq
-            .constraints(cb, utils::sum::expr(&self.lt.diff_bytes()[..]));
+            .constraints(cb, sum::expr(&self.lt.diff_bytes()[..]));
 
         (lt, eq)
     }
@@ -223,9 +270,7 @@ impl<F: FieldExt, const NUM_BYTES: usize> ComparisonGadget<F, NUM_BYTES> {
         let (lt, diff) = self.lt.assign(region, offset, lhs, rhs)?;
 
         // eq
-        let eq =
-            self.eq
-                .assign(region, offset, utils::sum::value(&diff[..]))?;
+        let eq = self.eq.assign(region, offset, sum::value(&diff[..]))?;
 
         Ok((lt, eq))
     }
@@ -283,5 +328,122 @@ impl<F: FieldExt> PairSelectGadget<F> {
         self.is_a.assign(region, offset, Some(is_a))?;
 
         Ok((is_a, F::one() - is_a))
+    }
+}
+
+/// Returns (quotient: numerator/divisor, remainder: numerator%divisor),
+/// with `numerator` an expression and `divisor` a constant.
+/// Input requirements:
+/// - `quotient < 256**NUM_BYTES`
+/// - `quotient * divisor < field size`
+/// - `remainder < divisor` currently requires a lookup table for `divisor`
+#[derive(Clone, Debug)]
+pub struct ConstantDivisionGadget<F, const NUM_BYTES: usize> {
+    quotient: Cell<F>,
+    remainder: Cell<F>,
+    divisor: u64,
+    quotient_range_check: RangeCheckGadget<F, NUM_BYTES>,
+}
+
+impl<F: FieldExt, const NUM_BYTES: usize> ConstantDivisionGadget<F, NUM_BYTES> {
+    pub const NUM_CELLS: usize =
+        2 + RangeCheckGadget::<F, NUM_BYTES>::NUM_CELLS;
+    pub const NUM_WORDS: usize = RangeCheckGadget::<F, NUM_BYTES>::NUM_WORDS;
+
+    pub(crate) fn construct(
+        alloc: &mut CaseAllocation<F>,
+        divisor: u64,
+    ) -> Self {
+        Self {
+            quotient: alloc.cells.pop().unwrap(),
+            remainder: alloc.cells.pop().unwrap(),
+            divisor,
+            quotient_range_check: RangeCheckGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        numerator: Expression<F>,
+    ) -> (Expression<F>, Expression<F>) {
+        // Require that remainder < divisor
+        cb.require_in_range(self.remainder.expr(), self.divisor);
+
+        // Require that quotient < 2**NUM_BYTES
+        // so we can't have any overflow when doing `quotient * divisor`.
+        self.quotient_range_check
+            .constraints(cb, self.quotient.expr());
+
+        // Check if the division was done correctly
+        cb.require_equal(
+            numerator - self.remainder.expr(),
+            self.quotient.expr() * self.divisor.expr(),
+        );
+
+        (self.quotient.expr(), self.remainder.expr())
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        numerator: u128,
+    ) -> Result<(u128, u128), Error> {
+        let divisor = self.divisor as u128;
+        let quotient = numerator / divisor;
+        let remainder = numerator % divisor;
+        self.quotient
+            .assign(region, offset, Some(F::from_u128(quotient)))?;
+        self.remainder
+            .assign(region, offset, Some(F::from_u128(remainder)))?;
+
+        self.quotient_range_check.assign(
+            region,
+            offset,
+            F::from_u128(quotient),
+        )?;
+
+        Ok((quotient, remainder))
+    }
+}
+
+/// Returns `rhs` when `lhs < rhs`, and returns `lhs` otherwise.
+/// lhs and rhs `< 256**NUM_BYTES`
+/// `NUM_BYTES` is required to be `<= 31`.
+#[derive(Clone, Debug)]
+pub struct MaxGadget<F, const NUM_BYTES: usize> {
+    lt: LtGadget<F, NUM_BYTES>,
+}
+
+impl<F: FieldExt, const NUM_BYTES: usize> MaxGadget<F, NUM_BYTES> {
+    pub const NUM_CELLS: usize = LtGadget::<F, NUM_BYTES>::NUM_CELLS;
+    pub const NUM_WORDS: usize = LtGadget::<F, NUM_BYTES>::NUM_WORDS;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            lt: LtGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        lhs: Expression<F>,
+        rhs: Expression<F>,
+    ) -> Expression<F> {
+        let lt = self.lt.constraints(cb, lhs.clone(), rhs.clone());
+        select::expr(lt, rhs, lhs)
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        lhs: F,
+        rhs: F,
+    ) -> Result<F, Error> {
+        let (lt, _) = self.lt.assign(region, offset, lhs, rhs)?;
+        Ok(select::value(lt, rhs, lhs))
     }
 }

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/memory_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/memory_gadgets.rs
@@ -1,0 +1,229 @@
+use super::super::CaseAllocation;
+use super::super::Word;
+use super::constraint_builder::ConstraintBuilder;
+use super::math_gadgets::{ConstantDivisionGadget, MaxGadget};
+use super::{Address, MemorySize};
+use crate::evm_circuit::param::MAX_MEMORY_SIZE_IN_BYTES;
+use crate::util::Expr;
+use bus_mapping::evm::GasCost;
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
+
+/// Decodes the usable part of an address stored in a Word
+pub(crate) mod address_low {
+    use super::super::super::Word;
+    use super::super::Address;
+    use crate::evm_circuit::{
+        op_execution::utils::from_bytes, param::NUM_ADDRESS_BYTES_USED,
+    };
+    use halo2::{arithmetic::FieldExt, plonk::Expression};
+
+    pub(crate) fn expr<F: FieldExt>(address: &Word<F>) -> Expression<F> {
+        from_bytes::expr(address.cells[0..NUM_ADDRESS_BYTES_USED].to_vec())
+    }
+
+    pub(crate) fn value<F: FieldExt>(address: [u8; 32]) -> Address {
+        from_bytes::value::<F>(address[0..NUM_ADDRESS_BYTES_USED].to_vec())
+            .get_lower_128() as Address
+    }
+}
+
+/// The sum of bytes of the address that are unused for most calculations on the address
+pub(crate) mod address_high {
+    use super::super::super::Word;
+    use crate::evm_circuit::{
+        op_execution::utils::sum, param::NUM_ADDRESS_BYTES_USED,
+    };
+    use halo2::{arithmetic::FieldExt, plonk::Expression};
+
+    pub(crate) fn expr<F: FieldExt>(address: &Word<F>) -> Expression<F> {
+        sum::expr(&address.cells[NUM_ADDRESS_BYTES_USED..32].to_vec())
+    }
+
+    pub(crate) fn value<F: FieldExt>(address: [u8; 32]) -> F {
+        sum::value::<F>(&address[NUM_ADDRESS_BYTES_USED..32].to_vec())
+    }
+}
+
+/// If any of the MSBs are non-zero we're always out of gas
+pub(crate) fn require_address_in_range<F: FieldExt>(
+    cb: &mut ConstraintBuilder<F>,
+    address: &Word<F>,
+) {
+    cb.require_zero(address_high::expr(address));
+}
+
+/// Calculates the memory size required for a memory access at the specified address.
+/// `memory_size = ceil(address/32) = floor((address + 31) / 32)`
+#[derive(Clone, Debug)]
+pub(crate) struct MemorySizeGadget<F> {
+    memory_size: ConstantDivisionGadget<F, MAX_MEMORY_SIZE_IN_BYTES>,
+}
+
+impl<F: FieldExt> MemorySizeGadget<F> {
+    pub const NUM_CELLS: usize =
+        ConstantDivisionGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_CELLS;
+    pub const NUM_WORDS: usize =
+        ConstantDivisionGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_WORDS;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            memory_size: ConstantDivisionGadget::construct(alloc, 32),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        address: Expression<F>,
+    ) -> Expression<F> {
+        let (quotient, _remainder) =
+            self.memory_size.constraints(cb, address + 31.expr());
+        quotient
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        address: Address,
+    ) -> Result<MemorySize, Error> {
+        let (quotient, _) =
+            self.memory_size
+                .assign(region, offset, (address as u128) + 31)?;
+        Ok(quotient as MemorySize)
+    }
+}
+
+/// Returns (new memory size, memory gas cost) for a memory access.
+/// If the memory needs to be expanded this will result in an extra gas cost.
+/// This gas cost is the difference between the next and current memory costs:
+/// `memory_cost = Gmem * memory_size + floor(memory_size * memory_size / 512)`
+#[derive(Clone, Debug)]
+pub(crate) struct MemoryExpansionGadget<F> {
+    address_memory_size: MemorySizeGadget<F>,
+    next_memory_size: MaxGadget<F, MAX_MEMORY_SIZE_IN_BYTES>,
+    curr_quad_memory_cost:
+        ConstantDivisionGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 }>,
+    next_quad_memory_cost:
+        ConstantDivisionGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 }>,
+}
+
+impl<F: FieldExt> MemoryExpansionGadget<F> {
+    pub const NUM_CELLS: usize = MemorySizeGadget::<F>::NUM_CELLS
+        + MaxGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_CELLS
+        + ConstantDivisionGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2}>::NUM_CELLS * 2;
+    pub const NUM_WORDS: usize = MemorySizeGadget::<F>::NUM_WORDS
+        + MaxGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_WORDS
+        + ConstantDivisionGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2}>::NUM_WORDS * 2;
+
+    pub const GAS_MEM: GasCost = GasCost::MEMORY;
+    pub const QUAD_COEFF_DIV: u64 = 512u64;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            address_memory_size: MemorySizeGadget::construct(alloc),
+            next_memory_size: MaxGadget::construct(alloc),
+            curr_quad_memory_cost: ConstantDivisionGadget::construct(
+                alloc,
+                Self::QUAD_COEFF_DIV,
+            ),
+            next_quad_memory_cost: ConstantDivisionGadget::construct(
+                alloc,
+                Self::QUAD_COEFF_DIV,
+            ),
+        }
+    }
+
+    /// Input requirements:
+    /// - `curr_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+    /// - `address` needs to be `< 32 * 256**MAX_MEMORY_SIZE_IN_BYTES`
+    /// Output ranges:
+    /// - `next_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES*`
+    /// - `memory_gas_cost <= 0x80000002fefffffffd < 256**(MAX_MEMORY_SIZE_IN_BYTES*2-1)`
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        curr_memory_size: Expression<F>,
+        address: Expression<F>,
+    ) -> (Expression<F>, Expression<F>) {
+        // Calculate the memory size of the memory access
+        // `address_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+        let address_memory_size =
+            self.address_memory_size.constraints(cb, address);
+
+        // The memory size needs to be updated if this memory access
+        // requires expanding the memory.
+        // `next_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+        let next_memory_size = self.next_memory_size.constraints(
+            cb,
+            address_memory_size,
+            curr_memory_size.clone(),
+        );
+
+        // Calculate the quad memory cost for the current and next memory size.
+        let (curr_quad_memory_cost, _) =
+            self.curr_quad_memory_cost.constraints(
+                cb,
+                curr_memory_size.clone() * curr_memory_size.clone(),
+            );
+        let (next_quad_memory_cost, _) =
+            self.next_quad_memory_cost.constraints(
+                cb,
+                next_memory_size.clone() * next_memory_size.clone(),
+            );
+
+        // Calculate the gas cost for the memory expansion.
+        // This gas cost is the difference between the next and current memory costs.
+        // `memory_cost <= 0x80000002fefffffffd < 256**(2*MAX_MEMORY_SIZE_IN_BYTES-1)`
+        let memory_gas_cost = (next_memory_size.clone() - curr_memory_size)
+            * Self::GAS_MEM.expr()
+            + (next_quad_memory_cost - curr_quad_memory_cost);
+
+        // Return the new memory size and the memory expansion gas cost
+        (next_memory_size, memory_gas_cost)
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        curr_memory_size: MemorySize,
+        address: Address,
+    ) -> Result<(MemorySize, u128), Error> {
+        // Calculate the active memory size
+        let address_memory_size =
+            self.address_memory_size.assign(region, offset, address)?;
+
+        // Calculate the next memory size
+        let next_memory_size = self
+            .next_memory_size
+            .assign(
+                region,
+                offset,
+                F::from_u64(address_memory_size),
+                F::from_u64(curr_memory_size),
+            )?
+            .get_lower_128() as MemorySize;
+
+        // Calculate the quad gas cost for the memory size
+        let (curr_quad_memory_cost, _) = self.curr_quad_memory_cost.assign(
+            region,
+            offset,
+            (curr_memory_size as u128) * (curr_memory_size as u128),
+        )?;
+        let (next_quad_memory_cost, _) = self.next_quad_memory_cost.assign(
+            region,
+            offset,
+            (next_memory_size as u128) * (next_memory_size as u128),
+        )?;
+
+        // Calculate the gas cost for the expansian
+        let memory_cost = (next_memory_size - curr_memory_size) as u128
+            * (Self::GAS_MEM.as_u64() as u128)
+            + (next_quad_memory_cost - curr_quad_memory_cost);
+
+        // Return the new memory size and the memory expansion gas cost
+        Ok((next_memory_size, memory_cost))
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -17,7 +17,7 @@ pub const NUM_CELL_RESUMPTION: usize = 2;
 pub const MAX_BYTES_FIELD: usize = 31;
 
 pub const STACK_START_IDX: usize = 1024;
-pub const MAX_SIZE_GAS_IN_BYTES: usize = 8;
+pub const MAX_GAS_SIZE_IN_BYTES: usize = 8;
 // Number of bytes that will be used of the address word.
 // If any of the other more signficant bytes are used it will
 // always result in an out-of-gas error.

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -6,7 +6,7 @@ pub const CIRCUIT_HEIGHT: usize = 10;
 
 // Number of cells used for each purpose
 // TODO: pub const NUM_CELL_CALL_INITIALIZATION_STATE: usize = ;
-pub const NUM_CELL_OP_EXECUTION_STATE: usize = 7;
+pub const NUM_CELL_OP_EXECUTION_STATE: usize = 8;
 // FIXME: naive estimation, should be optmize to fit in the future
 pub const NUM_CELL_OP_GADGET_SELECTOR: usize = 80;
 pub const NUM_CELL_RESUMPTION: usize = 2;
@@ -15,3 +15,11 @@ pub const NUM_CELL_RESUMPTION: usize = 2;
 /// can be broken down into without causing the value it
 /// represents to overflow a single field element.
 pub const MAX_BYTES_FIELD: usize = 31;
+
+pub const STACK_START_IDX: usize = 1024;
+pub const MAX_SIZE_GAS_IN_BYTES: usize = 8;
+// Number of bytes that will be used of the address word.
+// If any of the other more signficant bytes are used it will
+// always result in an out-of-gas error.
+pub const NUM_ADDRESS_BYTES_USED: usize = 5;
+pub const MAX_MEMORY_SIZE_IN_BYTES: usize = 5;


### PR DESCRIPTION
Spec: https://github.com/appliedzkp/zkevm-specs/pull/61

Currently the value ranges in the memory size/cost calculations can get quite big because of no early range limitation (except only using the 5 LSBs of the address). Perhaps an earlier check that limits the size a little bit more earlier could save a couple of lookups. But let me know what you think of the current implementation. The testing is also quite limited for now because it's currently not easy to verify all the values against expected ones.

Does not currently implement `MSTORE8`. My idea is to implement this opcode in the same `MemoryGadget` because very few changes are needed. The only challenge is that ideally we can just do the 32 memory lookups to the same single memory write in the busmapping, but for that I need to be able to explicitly assign the `gc` in the busmapping lookup. Because of this complication I think it makes sense to do that in a future PR if this is deemed a good idea. @han0110  
EDIT: Implementation of this can be found here: https://github.com/Brechtpd/zkevm-circuits/pull/1