### PR TITLE
Change Memory layout to be byte-based 

### DIFF
--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -68,6 +68,18 @@ impl FromStr for EvmWord {
     }
 }
 
+impl From<EvmWord> for [u8; 32] {
+    fn from(word: EvmWord) -> Self {
+        word.to_bytes()
+    }
+}
+
+impl From<EvmWord> for Vec<u8> {
+    fn from(word: EvmWord) -> Self {
+        word.to_bytes().to_vec()
+    }
+}
+
 impl_from_big_uint_wrappers!(
     EvmWord = EvmWord,
     (u8, u16, u32, u64, u128, usize)
@@ -82,6 +94,11 @@ impl EvmWord {
         array[..bytes.len()].copy_from_slice(&bytes[0..bytes.len()]);
 
         array
+    }
+
+    /// Generate an `EvmWord` from a slice of bytes.
+    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Self {
+        EvmWord(BigUint::from_bytes_le(bytes.as_ref()))
     }
 
     /// Returns the underlying representation of the `EvmWord` as a [`BigUint`].

--- a/bus-mapping/src/evm/memory.rs
+++ b/bus-mapping/src/evm/memory.rs
@@ -2,7 +2,10 @@
 use super::EvmWord;
 use crate::Error;
 use core::convert::{TryFrom, TryInto};
-use core::ops::{Index, IndexMut};
+use core::ops::{
+    Add, AddAssign, Index, IndexMut, Mul, MulAssign, Range, RangeFrom,
+    RangeFull, RangeTo, RangeToInclusive, Sub, SubAssign,
+};
 use core::str::FromStr;
 
 /// Represents a `MemoryAddress` of the EVM.
@@ -10,16 +13,6 @@ use core::str::FromStr;
 /// All `From` basic implementations assume that
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct MemoryAddress(pub(crate) usize);
-
-impl TryFrom<EvmWord> for MemoryAddress {
-    type Error = Error;
-
-    fn try_from(word: EvmWord) -> Result<Self, Self::Error> {
-        let addr: usize =
-            word.0.try_into().map_err(|_| Error::MemAddressParsing)?;
-        Ok(MemoryAddress(addr))
-    }
-}
 
 impl MemoryAddress {
     /// Returns the zero address for Memory targets.
@@ -35,6 +28,24 @@ impl MemoryAddress {
         array[..bytes.len()].copy_from_slice(&bytes[0..bytes.len()]);
 
         array
+    }
+
+    /// Generate a MemoryAddress from the provided set of bytes.
+    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Self {
+        let mut array = [0u8; core::mem::size_of::<usize>()];
+        array[..]
+            .copy_from_slice(&bytes.as_ref()[..core::mem::size_of::<usize>()]);
+        MemoryAddress::from(usize::from_le_bytes(array))
+    }
+}
+
+impl TryFrom<EvmWord> for MemoryAddress {
+    type Error = Error;
+
+    fn try_from(word: EvmWord) -> Result<Self, Self::Error> {
+        let addr: usize =
+            word.0.try_into().map_err(|_| Error::MemAddressParsing)?;
+        Ok(MemoryAddress(addr))
     }
 }
 
@@ -54,13 +65,85 @@ impl FromStr for MemoryAddress {
     }
 }
 
+impl Add<&MemoryAddress> for &MemoryAddress {
+    type Output = MemoryAddress;
+
+    fn add(self, rhs: &MemoryAddress) -> Self::Output {
+        MemoryAddress(self.0 + rhs.0)
+    }
+}
+
+define_add_variants!(
+    LHS = MemoryAddress,
+    RHS = MemoryAddress,
+    Output = MemoryAddress
+);
+
+impl<'b> AddAssign<&'b MemoryAddress> for MemoryAddress {
+    fn add_assign(&mut self, _rhs: &'b MemoryAddress) {
+        *self = *self + _rhs;
+    }
+}
+
+define_add_assign_variants!(LHS = MemoryAddress, RHS = MemoryAddress);
+
+impl Sub<&MemoryAddress> for &MemoryAddress {
+    type Output = MemoryAddress;
+
+    fn sub(self, rhs: &MemoryAddress) -> Self::Output {
+        MemoryAddress(self.0 - rhs.0)
+    }
+}
+
+define_sub_variants!(
+    LHS = MemoryAddress,
+    RHS = MemoryAddress,
+    Output = MemoryAddress
+);
+
+impl<'b> SubAssign<&'b MemoryAddress> for MemoryAddress {
+    fn sub_assign(&mut self, _rhs: &'b MemoryAddress) {
+        *self = *self - _rhs;
+    }
+}
+
+define_sub_assign_variants!(LHS = MemoryAddress, RHS = MemoryAddress);
+
+impl Mul<&MemoryAddress> for &MemoryAddress {
+    type Output = MemoryAddress;
+
+    fn mul(self, rhs: &MemoryAddress) -> Self::Output {
+        MemoryAddress(self.0 * rhs.0)
+    }
+}
+
+define_mul_variants!(
+    LHS = MemoryAddress,
+    RHS = MemoryAddress,
+    Output = MemoryAddress
+);
+
+impl<'b> MulAssign<&'b MemoryAddress> for MemoryAddress {
+    fn mul_assign(&mut self, _rhs: &'b MemoryAddress) {
+        *self = *self * _rhs;
+    }
+}
+
+define_mul_assign_variants!(LHS = MemoryAddress, RHS = MemoryAddress);
+
 /// Represents a snapshot of the EVM memory state at a certain
 /// execution step height.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Memory(pub(crate) Vec<EvmWord>);
+pub struct Memory(pub(crate) Vec<u8>);
+
+impl From<Vec<u8>> for Memory {
+    fn from(vec: Vec<u8>) -> Self {
+        Memory(vec)
+    }
+}
 
 impl Index<MemoryAddress> for Memory {
-    type Output = EvmWord;
+    type Output = u8;
     fn index(&self, index: MemoryAddress) -> &Self::Output {
         // MemoryAddress is in base 16. Therefore since the vec is not, we need to shift the addr.
         &self.0[index.0 >> 5]
@@ -74,19 +157,100 @@ impl IndexMut<MemoryAddress> for Memory {
     }
 }
 
+impl Index<Range<MemoryAddress>> for Memory {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: Range<MemoryAddress>) -> &Self::Output {
+        &self.0[..][convert_range(index)]
+    }
+}
+
+impl Index<RangeFull> for Memory {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, _index: RangeFull) -> &Self::Output {
+        &self.0[..]
+    }
+}
+
+impl Index<RangeTo<MemoryAddress>> for Memory {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: RangeTo<MemoryAddress>) -> &Self::Output {
+        &self.0[..][convert_range_to(index)]
+    }
+}
+
+impl Index<RangeFrom<MemoryAddress>> for Memory {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: RangeFrom<MemoryAddress>) -> &Self::Output {
+        &self.0[..][convert_range_from(index)]
+    }
+}
+
+impl Index<RangeToInclusive<MemoryAddress>> for Memory {
+    type Output = [u8];
+
+    #[inline]
+    fn index(&self, index: RangeToInclusive<MemoryAddress>) -> &Self::Output {
+        &self.0[..][convert_range_to_inclusive(index)]
+    }
+}
+
+fn convert_range(range: Range<MemoryAddress>) -> Range<usize> {
+    Range {
+        start: range.start.0,
+        end: range.end.0,
+    }
+}
+
+fn convert_range_from(range: RangeFrom<MemoryAddress>) -> RangeFrom<usize> {
+    RangeFrom {
+        start: range.start.0,
+    }
+}
+
+fn convert_range_to(range: RangeTo<MemoryAddress>) -> RangeTo<usize> {
+    RangeTo { end: range.end.0 }
+}
+
+fn convert_range_to_inclusive(
+    range: RangeToInclusive<MemoryAddress>,
+) -> RangeToInclusive<usize> {
+    RangeToInclusive { end: range.end.0 }
+}
+
 impl Memory {
     /// Generate an empty instance of EVM memory.
     pub const fn empty() -> Memory {
         Memory(Vec::new())
     }
 
-    /// Generate an new instance of EVM memory given a `Vec<EvmWord>`.
-    pub fn new(words: Vec<EvmWord>) -> Memory {
+    /// Generate an new instance of EVM memory given a `Vec<u8>`.
+    pub fn new(words: Vec<u8>) -> Memory {
         Memory(words)
     }
 
+    /// Pushes a set of bytes or an [`EvmWord`] in the last `Memory` position.
+    pub fn push<T: AsRef<[u8]>>(&mut self, input: T) {
+        self.0.extend(input.as_ref())
+    }
+
     /// Returns the last memory address written at this execution step height.
-    pub fn last_addr(&self) -> MemoryAddress {
-        (self.0.len() << 4).into()
+    pub fn last_filled_addr(&self) -> MemoryAddress {
+        self.0.len().into()
+    }
+
+    /// Reads an entire [`EvmWord`] which starts at the provided [`MemoryAddress`] `addr` and
+    /// finnishes at `addr + 32`.
+    pub fn read_word(&self, addr: MemoryAddress) -> EvmWord {
+        EvmWord::from_bytes(
+            &self[addr..addr + MemoryAddress::from(32)].as_ref(),
+        )
     }
 }

--- a/bus-mapping/src/evm/opcodes/mload.rs
+++ b/bus-mapping/src/evm/opcodes/mload.rs
@@ -52,7 +52,7 @@ impl Opcode for Mload {
         // First mem read
         //
         let mem_read_addr: MemoryAddress = stack_value_read.try_into()?;
-        let mem_read_value = next_steps[0].memory()[mem_read_addr].clone();
+        let mem_read_value = next_steps[0].memory().read_word(mem_read_addr);
 
         // Read operation at memory address: stack_read.value
         let mem_read = MemoryOp::new(

--- a/bus-mapping/src/exec_trace.rs
+++ b/bus-mapping/src/exec_trace.rs
@@ -378,11 +378,15 @@ mod trace_tests {
 
         // The memory is the same in both steps as none of them touches the
         // memory of the EVM.
-        let mem_map = Memory(vec![
-            EvmWord::from(0u8),
-            EvmWord::from(0u8),
-            EvmWord::from(0x80u8),
-        ]);
+        let mem_map = Memory(
+            EvmWord::from(0u8)
+                .to_bytes()
+                .iter()
+                .chain(&EvmWord::from(0u8).to_bytes())
+                .chain(&EvmWord::from(0x80u8).to_bytes())
+                .copied()
+                .collect(),
+        );
 
         // Generate Step1 corresponding to PUSH1 40
         let mut step_1 = ExecutionStep {

--- a/bus-mapping/src/exec_trace/exec_step.rs
+++ b/bus-mapping/src/exec_trace/exec_step.rs
@@ -36,7 +36,7 @@ impl ExecutionStep {
     /// Generate a new `ExecutionStep` from it's fields but with an empty
     /// bus-mapping instance vec.
     pub fn new(
-        memory: Vec<EvmWord>,
+        memory: Vec<u8>,
         stack: Vec<EvmWord>,
         instruction: OpcodeId,
         gas_info: GasInfo,
@@ -45,7 +45,7 @@ impl ExecutionStep {
         gc: GlobalCounter,
     ) -> Self {
         ExecutionStep {
-            memory: Memory::new(memory),
+            memory: Memory::from(memory),
             stack: Stack::new(stack),
             instruction,
             gas_info,

--- a/bus-mapping/src/macros.rs
+++ b/bus-mapping/src/macros.rs
@@ -19,3 +19,119 @@ macro_rules! impl_from_usize_wrappers {
         })*
     };
 }
+
+// ----------------------------------- //
+//            Ops traits               //
+// ----------------------------------- //
+
+/// Define borrow and non-borrow variants of `Add`.
+/// Requires the impl of Add<&RHS> for &LHS
+macro_rules! define_add_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> core::ops::Add<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn add(self, rhs: &'b $rhs) -> $out {
+                &self + rhs
+            }
+        }
+
+        impl<'a> core::ops::Add<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn add(self, rhs: $rhs) -> $out {
+                self + &rhs
+            }
+        }
+
+        impl core::ops::Add<$rhs> for $lhs {
+            type Output = $out;
+            fn add(self, rhs: $rhs) -> $out {
+                &self + &rhs
+            }
+        }
+    };
+}
+
+/// Define non-borrow variants of `AddAssign`.
+macro_rules! define_add_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl core::ops::AddAssign<$rhs> for $lhs {
+            fn add_assign(&mut self, rhs: $rhs) {
+                *self += &rhs;
+            }
+        }
+    };
+}
+
+/// Define borrow and non-borrow variants of `Sub`.
+macro_rules! define_sub_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> core::ops::Sub<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn sub(self, rhs: &'b $rhs) -> $out {
+                &self - rhs
+            }
+        }
+
+        impl<'a> core::ops::Sub<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn sub(self, rhs: $rhs) -> $out {
+                self - &rhs
+            }
+        }
+
+        impl core::ops::Sub<$rhs> for $lhs {
+            type Output = $out;
+            fn sub(self, rhs: $rhs) -> $out {
+                &self - &rhs
+            }
+        }
+    };
+}
+
+/// Define non-borrow variants of `SubAssign`.
+macro_rules! define_sub_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl core::ops::SubAssign<$rhs> for $lhs {
+            fn sub_assign(&mut self, rhs: $rhs) {
+                *self -= &rhs;
+            }
+        }
+    };
+}
+
+/// Define borrow and non-borrow variants of `Mul`.
+macro_rules! define_mul_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> core::ops::Mul<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn mul(self, rhs: &'b $rhs) -> $out {
+                &self * rhs
+            }
+        }
+
+        impl<'a> core::ops::Mul<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn mul(self, rhs: $rhs) -> $out {
+                self * &rhs
+            }
+        }
+
+        impl core::ops::Mul<$rhs> for $lhs {
+            type Output = $out;
+            fn mul(self, rhs: $rhs) -> $out {
+                &self * &rhs
+            }
+        }
+    };
+}
+
+/// Define non-borrow variants of `MulAssign`.
+macro_rules! define_mul_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl core::ops::MulAssign<$rhs> for $lhs {
+            fn mul_assign(&mut self, rhs: $rhs) {
+                *self *= &rhs;
+            }
+        }
+    };
+}

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -62,22 +62,22 @@ pub struct MemoryOp {
     rw: RW,
     gc: GlobalCounter,
     addr: MemoryAddress,
-    value: EvmWord,
+    value: Vec<u8>,
 }
 
 impl MemoryOp {
     /// Create a new instance of a `MemoryOp` from it's components.
-    pub const fn new(
+    pub fn new<T: Into<Vec<u8>>>(
         rw: RW,
         gc: GlobalCounter,
         addr: MemoryAddress,
-        value: EvmWord,
+        value: T,
     ) -> MemoryOp {
         MemoryOp {
             rw,
             gc,
             addr,
-            value,
+            value: value.into(),
         }
     }
 
@@ -102,8 +102,8 @@ impl MemoryOp {
         &self.addr
     }
 
-    /// Returns the [`EvmWord`] read or written by this operation.
-    pub const fn value(&self) -> &EvmWord {
+    /// Returns the bytes read or written by this operation.
+    pub fn value(&self) -> &[u8] {
         &self.value
     }
 }

--- a/zkevm-circuits/src/state_circuit/state.rs
+++ b/zkevm-circuits/src/state_circuit/state.rs
@@ -723,8 +723,10 @@ impl<
         for (index, op) in ops.iter().enumerate() {
             let address = F::from_bytes(&op.address().to_bytes()).unwrap();
             let gc = usize::from(op.gc());
-            let v_bytes = op.value().to_bytes();
-            let val = F::from_bytes(&v_bytes).unwrap();
+            let v_bytes = op.value();
+            let mut bytes = [0u8; 32];
+            bytes.copy_from_slice(v_bytes);
+            let val = F::from_bytes(&bytes).unwrap();
 
             let mut target = 1;
             if index > 0 {


### PR DESCRIPTION
While keeping the compatibility between bytes and `EvmWord` the `Memory`
will not work based on bytes internally to allow for unaligned memory
read and write operations which are required by some Opcodes.

- Change Memory layout to wrap over `Vec<u8>` instead of `Vec<EvmWord>`.
- Implement Indexing operations over Memory via `MemoryAddress`.
- Implement/derive arithmetic ops for `MemoryAddress`.
- Change `MemoryOp` to contain as value `Vec<u8>`.
- Refactor tests in order to create the `Memory` instances on the new
  way required.

Resolves: #33