### PR TITLE
Labeler and release draft

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,10 @@
+# Add 'zkevm-circuits' label to any change to files within the zkevm-circuits dir EXCEPT for the evm_circuit sub-folder
+zkevm-circuits:
+  - any: ['zkevm-circuits/**/*', '!zkevm-circuits/evm_circuit/**/*']
+# Add 'opcodes' to any changes within 'evm_circuit' folder or any subfolders
+opcode:
+  - zkevm-circuits/evm_circuit/**/*
+bus-mapping:
+  - bus-mapping/**/*
+keccak:
+  - keccak256/**/*

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,15 @@
+categories:
+  - title: 'Changes in the zkevm-circuits'
+    label: 'zkevm-circuits'
+  - title: 'Changes in the bus-mapping'
+    label: 'bus-mapping'
+  - title: 'Changes in Opcodes'
+    label: 'opcode'
+  - title: 'Changes in Keccak'
+    label: 'keccak'
+version-resolver:
+  default: minor
+prerelease: true
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Problem

We want to cut releases for the repo so that people working on the testing have some versions to track.

It would be great to inform in the release draft that what features or changes we added in that release

### Solution

1. We use the auto labeler to label PRs that are related to "zkevm-circuit" (core-API), "opcodes", "busmapping", or "keccak".
2. We use the release drafter to automatically generate reports that sort PRs under each label.

Example release would look like this https://github.com/thehubbleproject/hubble-contracts/releases/tag/v0.10.0