### PR TITLE
fix release drafter

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
### Problem

The wrong branch is configured so that the release drafter is never triggered.

My bad, sorry 🙈 .

