### PR TITLE
Refactor all opcodes to use the constraint builder + other utils

### DIFF
--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -268,7 +268,7 @@ pub struct GasCost(u64);
 impl GasCost {
     /// Constant cost for free step
     pub const ZERO: Self = Self(0);
-    /// Constant cost for jumpdest step, only it takes one gas
+    /// Constant cost for jumpdest step, only takes one gas
     pub const ONE: Self = Self(1);
     /// Constant cost for quick step
     pub const QUICK: Self = Self(2);

--- a/bus-mapping/src/evm/opcodes/ids.rs
+++ b/bus-mapping/src/evm/opcodes/ids.rs
@@ -479,6 +479,11 @@ impl OpcodeId {
             OpcodeId::SELFDESTRUCT => 0xffu8,
         }
     }
+
+    /// Returns the `OpcodeId` as a `u64`.
+    pub const fn as_u64(&self) -> u64 {
+        self.as_u8() as u64
+    }
 }
 
 impl FromStr for OpcodeId {

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -1,289 +1,154 @@
-use super::super::{
-    BusMappingLookup, Case, Cell, Constraint, CoreStateInstance, ExecutionStep,
-    Lookup, Word,
+use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
+use super::utils;
+use super::utils::common_cases::{OutOfGasCase, StackUnderflowCase};
+use super::utils::constraint_builder::ConstraintBuilder;
+use super::utils::math_gadgets::PairSelectGadget;
+use super::{
+    CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
 };
-use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
+use crate::evm_circuit::op_execution::utils::select;
+use crate::impl_op_gadget;
 use crate::util::{Expr, ToWord};
+use array_init::array_init;
 use bus_mapping::evm::{GasCost, OpcodeId};
-use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
-use std::{array, convert::TryInto};
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region};
+use std::convert::TryInto;
+
+static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+    gc_delta: Some(3),
+    pc_delta: Some(1),
+    sp_delta: Some(1),
+    gas_delta: Some(GasCost::FASTEST.as_usize()),
+};
+const NUM_POPPED: usize = 2;
+
+impl_op_gadget!(
+    #set[ADD, SUB]
+    AddGadget {
+        AddSuccessCase(),
+        StackUnderflowCase(NUM_POPPED),
+        OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
+    }
+);
 
 #[derive(Clone, Debug)]
-struct AddSuccessAllocation<F> {
-    selector: Cell<F>,
-    swap: Cell<F>,
+struct AddSuccessCase<F> {
+    case_selector: Cell<F>,
     a: Word<F>,
     b: Word<F>,
     c: Word<F>,
     carry: [Cell<F>; 32],
+    swap: PairSelectGadget<F>,
 }
 
-#[derive(Clone, Debug)]
-pub struct AddGadget<F> {
-    success: AddSuccessAllocation<F>,
-    stack_underflow: Cell<F>, // case selector
-    out_of_gas: (
-        Cell<F>, // case selector
-        Cell<F>, // gas available
-    ),
-}
+// AddGadget verifies ADD and SUB at the same time by an extra swap flag,
+// when it's ADD, we annotate stack as [a, b, ...] and [c, ...],
+// when it's SUB, we annotate stack as [a, c, ...] and [b, ...].
+// Then we verify if a + b is equal to c.
+impl<F: FieldExt> AddSuccessCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::Success,
+        num_word: 3,                                     // a + b + c
+        num_cell: 32 + PairSelectGadget::<F>::NUM_CELLS, // 32 carry + swap
+        will_halt: false,
+    };
 
-impl<F: FieldExt> OpGadget<F> for AddGadget<F> {
-    // AddGadget verifies ADD and SUB at the same time by an extra swap flag,
-    // when it's ADD, we annotate stack as [a, b, ...] and [c, ...],
-    // when it's SUB, we annotate stack as [a, c, ...] and [b, ...].
-    // Then we verify if a + b is equal to c.
-    const RESPONSIBLE_OPCODES: &'static [OpcodeId] =
-        &[OpcodeId::ADD, OpcodeId::SUB];
-
-    const CASE_CONFIGS: &'static [CaseConfig] = &[
-        CaseConfig {
-            case: Case::Success,
-            num_word: 3,  // a + b + c
-            num_cell: 33, // 32 carry + swap
-            will_halt: false,
-        },
-        CaseConfig {
-            case: Case::StackUnderflow,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-        CaseConfig {
-            case: Case::OutOfGas,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-    ];
-
-    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self {
-        let [mut success, stack_underflow, out_of_gas]: [CaseAllocation<F>; 3] =
-            case_allocations.try_into().unwrap();
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
         Self {
-            success: AddSuccessAllocation {
-                selector: success.selector,
-                swap: success.cells.pop().unwrap(),
-                a: success.words.pop().unwrap(),
-                b: success.words.pop().unwrap(),
-                c: success.words.pop().unwrap(),
-                carry: success.cells.try_into().unwrap(),
-            },
-            stack_underflow: stack_underflow.selector,
-            out_of_gas: (
-                out_of_gas.selector,
-                out_of_gas.resumption.unwrap().gas_available,
-            ),
+            case_selector: alloc.selector.clone(),
+            a: alloc.words.pop().unwrap(),
+            b: alloc.words.pop().unwrap(),
+            c: alloc.words.pop().unwrap(),
+            carry: array_init(|_| alloc.cells.pop().unwrap()),
+            swap: PairSelectGadget::construct(alloc),
         }
     }
 
-    fn constraints(
+    pub(crate) fn constraint(
         &self,
         state_curr: &OpExecutionState<F>,
         state_next: &OpExecutionState<F>,
-    ) -> Vec<Constraint<F>> {
-        let OpExecutionState { opcode, .. } = &state_curr;
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
 
-        let common_polys = vec![
-            (opcode.expr() - OpcodeId::ADD.expr())
-                * (opcode.expr() - OpcodeId::SUB.expr()),
-        ];
+        // Swap b and c if it's SUB
+        let (swap, _) = self.swap.constraints(
+            &mut cb,
+            state_curr.opcode.expr(),
+            OpcodeId::SUB.expr(),
+            OpcodeId::ADD.expr(),
+        );
 
-        let success = {
-            // interpreter state transition constraints
-            let state_transition_constraints = vec![
-                state_next.global_counter.expr()
-                    - (state_curr.global_counter.expr() + 3.expr()),
-                state_next.program_counter.expr()
-                    - (state_curr.program_counter.expr() + 1.expr()),
-                state_next.stack_pointer.expr()
-                    - (state_curr.stack_pointer.expr() + 1.expr()),
-                state_next.gas_counter.expr()
-                    - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
-            ];
+        // Do the addition per byte with carry
+        for idx in 0..32 {
+            // carry needs to be boolean
+            cb.require_boolean(self.carry[idx].expr());
 
-            let AddSuccessAllocation {
-                selector,
-                swap,
-                a,
-                b,
-                c,
-                carry,
-            } = &self.success;
+            // carry_out * 256 + c == a + b + carry_in
+            cb.require_equal(
+                self.carry[idx].expr() * 256.expr() + self.c.cells[idx].expr(),
+                self.a.cells[idx].expr()
+                    + self.b.cells[idx].expr()
+                    + if idx == 0 {
+                        // first carry_in is always 0
+                        0.expr()
+                    } else {
+                        self.carry[idx - 1].expr()
+                    },
+            );
+        }
 
-            // swap b and c if it's SUB
-            let no_swap = 1.expr() - swap.expr();
-            let swap_constraints = vec![
-                swap.expr() * no_swap.clone(),
-                swap.expr() * (opcode.expr() - OpcodeId::SUB.expr()),
-                no_swap.clone() * (opcode.expr() - OpcodeId::ADD.expr()),
-            ];
+        // ADD: Pop a and b from the stack, push c on the stack
+        // SUB: Pop a and c from the stack, push b on the stack
+        cb.stack_pop(self.a.expr());
+        cb.stack_pop(select::expr(swap.clone(), self.c.expr(), self.b.expr()));
+        cb.stack_push(select::expr(swap, self.b.expr(), self.c.expr()));
 
-            // add constraints
-            let add_constraints = {
-                let mut constraints = Vec::with_capacity(64);
+        // State transitions
+        STATE_TRANSITION.constraints(&mut cb, state_curr, state_next);
 
-                for idx in 0..32 {
-                    // 256 * carry_out + c
-                    let lhs =
-                        carry[idx].expr() * 256.expr() + c.cells[idx].expr();
-                    // a + b + carry_in
-                    let rhs = a.cells[idx].expr()
-                        + b.cells[idx].expr()
-                        + if idx == 0 {
-                            // first carry_in is always 0
-                            0.expr()
-                        } else {
-                            carry[idx - 1].expr()
-                        };
-
-                    // carry range check
-                    constraints.push(
-                        carry[idx].expr() * (1.expr() - carry[idx].expr()),
-                    );
-                    // equality check
-                    constraints.push(lhs - rhs)
-                }
-
-                constraints
-            };
-
-            #[allow(clippy::suspicious_operation_groupings)]
-            let bus_mapping_lookups = vec![
-                Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: 0.expr(),
-                    value: a.expr(),
-                    is_write: false,
-                }),
-                Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: 1.expr(),
-                    value: swap.expr() * c.expr() + no_swap.clone() * b.expr(),
-                    is_write: false,
-                }),
-                Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: 1.expr(),
-                    value: swap.expr() * b.expr() + no_swap * c.expr(),
-                    is_write: true,
-                }),
-            ];
-
-            Constraint {
-                name: "AddGadget success",
-                selector: selector.expr(),
-                polys: [
-                    state_transition_constraints,
-                    swap_constraints,
-                    add_constraints,
-                ]
-                .concat(),
-                lookups: bus_mapping_lookups,
-            }
-        };
-
-        let stack_underflow = {
-            let OpExecutionState { stack_pointer, .. } = &state_curr;
-            Constraint {
-                name: "AddGadget stack underflow",
-                selector: self.stack_underflow.expr(),
-                polys: vec![
-                    (stack_pointer.expr() - 1024.expr())
-                        * (stack_pointer.expr() - 1023.expr()),
-                ],
-                lookups: vec![],
-            }
-        };
-
-        let out_of_gas = {
-            let (selector, gas_available) = &self.out_of_gas;
-            let gas_overdemand = state_curr.gas_counter.expr()
-                + GasCost::FASTEST.expr()
-                - gas_available.expr();
-            Constraint {
-                name: "AddGadget out of gas",
-                selector: selector.expr(),
-                polys: vec![
-                    (gas_overdemand.clone() - 1.expr())
-                        * (gas_overdemand.clone() - 2.expr())
-                        * (gas_overdemand - 3.expr()),
-                ],
-                lookups: vec![],
-            }
-        };
-
-        array::IntoIter::new([success, stack_underflow, out_of_gas])
-            .map(move |mut constraint| {
-                constraint.polys =
-                    [common_polys.clone(), constraint.polys].concat();
-                constraint
-            })
-            .collect()
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
     }
 
     fn assign(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
     ) -> Result<(), Error> {
-        match execution_step.case {
-            Case::Success => {
-                self.assign_success(region, offset, core_state, execution_step)
-            }
-            Case::StackUnderflow => {
-                // TODO:
-                unimplemented!()
-            }
-            Case::OutOfGas => {
-                // TODO:
-                unimplemented!()
-            }
-            _ => unreachable!(),
-        }
-    }
-}
+        // Inputs and output
+        self.a
+            .assign(region, offset, Some(step.values[0].to_word()))?;
+        self.b
+            .assign(region, offset, Some(step.values[1].to_word()))?;
+        self.c
+            .assign(region, offset, Some(step.values[2].to_word()))?;
 
-impl<F: FieldExt> AddGadget<F> {
-    fn assign_success(
-        &self,
-        region: &mut Region<'_, F>,
-        offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
-    ) -> Result<(), Error> {
-        core_state.global_counter += 3;
-        core_state.program_counter += 1;
-        core_state.stack_pointer += 1;
-        core_state.gas_counter += 3;
+        // Swap
+        self.swap.assign(
+            region,
+            offset,
+            F::from_u64(step.opcode as u64),
+            F::from_u64(OpcodeId::SUB.as_u8() as u64),
+            F::from_u64(OpcodeId::ADD.as_u8() as u64),
+        )?;
 
-        self.success.swap.assign(
-            region,
-            offset,
-            Some(F::from_u64((execution_step.opcode == OpcodeId::SUB) as u64)),
-        )?;
-        self.success.a.assign(
-            region,
-            offset,
-            Some(execution_step.values[0].to_word()),
-        )?;
-        self.success.b.assign(
-            region,
-            offset,
-            Some(execution_step.values[1].to_word()),
-        )?;
-        self.success.c.assign(
-            region,
-            offset,
-            Some(execution_step.values[2].to_word()),
-        )?;
-        self.success
-            .carry
+        // Generate carry values
+        self.carry
             .iter()
-            .zip(execution_step.values[3].to_word().iter())
+            .zip(step.values[3].to_word().iter())
             .map(|(alloc, carry)| {
                 alloc.assign(region, offset, Some(F::from_u64(*carry as u64)))
             })
             .collect::<Result<Vec<_>, _>>()?;
+
+        // State transitions
+        STATE_TRANSITION.assign(state);
+
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -16,7 +16,7 @@ use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
 static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
-    gc_delta: Some(3),
+    gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
     gas_delta: Some(GasCost::FASTEST.as_usize()),
@@ -133,8 +133,8 @@ impl<F: FieldExt> AddSuccessCase<F> {
             region,
             offset,
             F::from_u64(step.opcode as u64),
-            F::from_u64(OpcodeId::SUB.as_u8() as u64),
-            F::from_u64(OpcodeId::ADD.as_u8() as u64),
+            F::from_u64(OpcodeId::SUB.as_u64()),
+            F::from_u64(OpcodeId::ADD.as_u64()),
         )?;
 
         // Generate carry values

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -1,12 +1,11 @@
 use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
-use super::utils;
 use super::utils::common_cases::{OutOfGasCase, StackUnderflowCase};
 use super::utils::constraint_builder::ConstraintBuilder;
 use super::utils::math_gadgets::PairSelectGadget;
+use super::utils::{select, StateTransition};
 use super::{
     CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
 };
-use crate::evm_circuit::op_execution::utils::select;
 use crate::impl_op_gadget;
 use crate::util::{Expr, ToWord};
 use array_init::array_init;
@@ -15,7 +14,7 @@ use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
-static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),

--- a/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
@@ -14,18 +14,20 @@ use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
-const GC_DELTA: usize = 3;
-const PC_DELTA: usize = 1;
-const SP_DELTA: usize = 1;
-const GAS: GasCost = GasCost::FASTEST;
+static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+    gc_delta: Some(3),
+    pc_delta: Some(1),
+    sp_delta: Some(1),
+    gas_delta: Some(GasCost::FASTEST.as_usize()),
+};
 const NUM_POPPED: usize = 2;
 
 impl_op_gadget!(
-    [BYTE]
+    #set[BYTE]
     ByteGadget {
         ByteSuccessCase(),
         StackUnderflowCase(NUM_POPPED),
-        OutOfGasCase(GAS.as_usize()),
+        OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
     }
 );
 
@@ -102,13 +104,7 @@ impl<F: FieldExt> ByteSuccessCase<F> {
         cb.stack_push(selected_byte);
 
         // State transitions
-        utils::StateTransitions {
-            gc_delta: Some(GC_DELTA.expr()),
-            sp_delta: Some(SP_DELTA.expr()),
-            pc_delta: Some(PC_DELTA.expr()),
-            gas_delta: Some(GAS.expr()),
-        }
-        .constraints(&mut cb, state_curr, state_next);
+        STATE_TRANSITION.constraints(&mut cb, state_curr, state_next);
 
         // Generate the constraint
         cb.constraint(self.case_selector.expr(), name)
@@ -121,17 +117,20 @@ impl<F: FieldExt> ByteSuccessCase<F> {
         state: &mut CoreStateInstance,
         step: &ExecutionStep,
     ) -> Result<(), Error> {
+        // Inputs/Outputs
         self.index
             .assign(region, offset, Some(step.values[0].to_word()))?;
         self.value
             .assign(region, offset, Some(step.values[1].to_word()))?;
 
+        // Set `is_msb_sum_zero`
         self.is_msb_sum_zero.assign(
             region,
             offset,
             utils::sum::value(&step.values[0].to_word()[1..32]),
         )?;
 
+        // Set `is_byte_selected`
         for i in 0..32 {
             self.is_byte_selected[i].assign(
                 region,
@@ -141,10 +140,8 @@ impl<F: FieldExt> ByteSuccessCase<F> {
             )?;
         }
 
-        state.global_counter += GC_DELTA;
-        state.program_counter += PC_DELTA;
-        state.stack_pointer += SP_DELTA;
-        state.gas_counter += GAS.as_usize();
+        // State transitions
+        STATE_TRANSITION.assign(state);
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
@@ -1,8 +1,8 @@
 use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
-use super::utils;
 use super::utils::common_cases::{OutOfGasCase, StackUnderflowCase};
 use super::utils::constraint_builder::ConstraintBuilder;
 use super::utils::math_gadgets::{IsEqualGadget, IsZeroGadget};
+use super::utils::{sum, StateTransition};
 use super::{
     CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
 };
@@ -14,7 +14,7 @@ use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
-static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
@@ -72,7 +72,7 @@ impl<F: FieldExt> ByteSuccessCase<F> {
         // so we can use that as an additional condition when to copy the byte value.
         let msb_sum_zero = self
             .is_msb_sum_zero
-            .constraints(&mut cb, utils::sum::expr(&self.index.cells[1..32]));
+            .constraints(&mut cb, sum::expr(&self.index.cells[1..32]));
 
         // Now we just need to check that `result[0]` is the sum of all copied bytes.
         // We go byte by byte and check if `idx == index[0]`.
@@ -127,7 +127,7 @@ impl<F: FieldExt> ByteSuccessCase<F> {
         self.is_msb_sum_zero.assign(
             region,
             offset,
-            utils::sum::value(&step.values[0].to_word()[1..32]),
+            sum::value(&step.values[0].to_word()[1..32]),
         )?;
 
         // Set `is_byte_selected`

--- a/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
@@ -15,7 +15,7 @@ use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
 static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
-    gc_delta: Some(3),
+    gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
     gas_delta: Some(GasCost::FASTEST.as_usize()),

--- a/zkevm-circuits/src/evm_circuit/op_execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/dup.rs
@@ -15,9 +15,9 @@ use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
 static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
-    gc_delta: Some(2), // stack read + stack write
+    gc_delta: Some(2), // 1 stack read + 1 stack push
     pc_delta: Some(1),
-    sp_delta: Some(1),
+    sp_delta: Some(-1),
     gas_delta: Some(GasCost::FASTEST.as_usize()),
 };
 const NUM_PUSHED: usize = 1;
@@ -30,7 +30,7 @@ impl_op_gadget!(
     ]
     DupGadget {
         DupSuccessCase(),
-        RangeStackUnderflowCase(OpcodeId::DUP1.as_u64(), 16),
+        RangeStackUnderflowCase(OpcodeId::DUP1.as_u64(), 16, 0),
         StackOverflowCase(NUM_PUSHED),
         OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/dup.rs
@@ -1,251 +1,97 @@
-use super::super::{
-    BusMappingLookup, Case, Cell, Constraint, CoreStateInstance, ExecutionStep,
-    FixedLookup, Lookup, Word,
+use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
+use super::utils;
+use super::utils::common_cases::{
+    OutOfGasCase, RangeStackUnderflowCase, StackOverflowCase,
 };
-use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
+use super::utils::constraint_builder::ConstraintBuilder;
+use super::{
+    CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
+};
+use crate::impl_op_gadget;
 use crate::util::{Expr, ToWord};
 use bus_mapping::evm::{GasCost, OpcodeId};
-use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
-use std::{array, convert::TryInto};
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region};
+use std::convert::TryInto;
+
+static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+    gc_delta: Some(2), // stack read + stack write
+    pc_delta: Some(1),
+    sp_delta: Some(1),
+    gas_delta: Some(GasCost::FASTEST.as_usize()),
+};
+const NUM_PUSHED: usize = 1;
+
+impl_op_gadget!(
+    #range
+    [
+        DUP1,  DUP2,  DUP3,  DUP4,  DUP5,  DUP6,  DUP7,  DUP8,
+        DUP9, DUP10, DUP11, DUP12, DUP13, DUP14, DUP15, DUP16,
+    ]
+    DupGadget {
+        DupSuccessCase(),
+        RangeStackUnderflowCase(OpcodeId::DUP1.as_u64(), 16),
+        StackOverflowCase(NUM_PUSHED),
+        OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
+    }
+);
 
 #[derive(Clone, Debug)]
-struct DupSuccessAllocation<F> {
+struct DupSuccessCase<F> {
     case_selector: Cell<F>,
-    word: Word<F>, // target word to dup （witness）
+    value: Word<F>,
 }
 
-#[derive(Clone, Debug)]
-pub struct DupGadget<F> {
-    success: DupSuccessAllocation<F>,
-    stack_overflow: Cell<F>, // case selector
-    stack_underflow: Cell<F>,
-    out_of_gas: (
-        Cell<F>, // case selector
-        Cell<F>, // gas available
-    ),
-}
+impl<F: FieldExt> DupSuccessCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::Success,
+        num_word: 1, // value
+        num_cell: 0,
+        will_halt: false,
+    };
 
-impl<F: FieldExt> OpGadget<F> for DupGadget<F> {
-    const RESPONSIBLE_OPCODES: &'static [OpcodeId] = &[
-        OpcodeId::DUP1,
-        OpcodeId::DUP2,
-        OpcodeId::DUP3,
-        OpcodeId::DUP4,
-        OpcodeId::DUP5,
-        OpcodeId::DUP6,
-        OpcodeId::DUP7,
-        OpcodeId::DUP8,
-        OpcodeId::DUP9,
-        OpcodeId::DUP10,
-        OpcodeId::DUP11,
-        OpcodeId::DUP12,
-        OpcodeId::DUP13,
-        OpcodeId::DUP14,
-        OpcodeId::DUP15,
-        OpcodeId::DUP16,
-    ];
-
-    const CASE_CONFIGS: &'static [CaseConfig] = &[
-        CaseConfig {
-            case: Case::Success,
-            num_word: 1,
-            num_cell: 16, // for DUP selectors
-            will_halt: false,
-        },
-        CaseConfig {
-            case: Case::StackOverflow,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-        CaseConfig {
-            case: Case::StackUnderflow,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-        CaseConfig {
-            case: Case::OutOfGas,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-    ];
-
-    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self {
-        let [mut success, stack_overflow, stack_underflow, out_of_gas]: [CaseAllocation<F>; 4] =
-            case_allocations.try_into().unwrap();
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
         Self {
-            success: DupSuccessAllocation {
-                case_selector: success.selector.clone(),
-                word: success.words.pop().unwrap(),
-            },
-            stack_overflow: stack_overflow.selector,
-            stack_underflow: stack_underflow.selector,
-            out_of_gas: (
-                out_of_gas.selector,
-                out_of_gas.resumption.unwrap().gas_available,
-            ),
+            case_selector: alloc.selector.clone(),
+            value: alloc.words.pop().unwrap(),
         }
     }
 
-    fn constraints(
+    pub(crate) fn constraint(
         &self,
         state_curr: &OpExecutionState<F>,
         state_next: &OpExecutionState<F>,
-    ) -> Vec<Constraint<F>> {
-        let OpExecutionState { opcode, .. } = &state_curr;
-        // use num_duplicated to represents 'x' value of 'dupx'
-        let num_duplicated = opcode.expr() - OpcodeId::DUP1.expr() + 1.expr();
-        // lookup in range 16 for dup
-        let common_lookups = vec![Lookup::FixedLookup(
-            FixedLookup::Range16,
-            [opcode.expr() - OpcodeId::DUP1.expr(), 0.expr(), 0.expr()],
-        )];
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
 
-        let success = {
-            // interpreter state transition constraints
-            let state_transition_constraints = vec![
-                state_next.global_counter.expr()
-                    - (state_curr.global_counter.expr() + 2.expr()),
-                state_next.program_counter.expr()
-                    - (state_curr.program_counter.expr() + 1.expr()),
-                // dupx contains one time push operation
-                state_next.stack_pointer.expr()
-                    - (state_curr.stack_pointer.expr() - 1.expr()),
-                state_next.gas_counter.expr()
-                    - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
-            ];
+        // The stack index we have to peek, deduced from the 'x' value of 'dupx'
+        let dup_offset = state_curr.opcode.expr() - OpcodeId::DUP1.expr();
 
-            let DupSuccessAllocation {
-                case_selector,
-                word,
-            } = &self.success;
+        // Peek the value at `dup_offset` and push the value on the stack
+        cb.stack_lookup(dup_offset, self.value.expr(), false);
+        cb.stack_push(self.value.expr());
 
-            let bus_mapping_lookups = [
-                // TODO: add 32 Bytecode lookups when supported
-                vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: num_duplicated.clone() - 1.expr(),
-                    value: word.expr(),
-                    is_write: false,
-                })],
-                vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: (-1).expr(), // fixed as DUP decreases the stack pointer
-                    value: word.expr(),
-                    is_write: true,
-                })],
-            ]
-            .concat();
+        // State transitions
+        STATE_TRANSITION.constraints(&mut cb, state_curr, state_next);
 
-            Constraint {
-                name: "DupGadget success",
-                selector: case_selector.expr(),
-                polys: [state_transition_constraints].concat(),
-                lookups: bus_mapping_lookups, //vec![]
-            }
-        };
-
-        let stack_overflow = {
-            let stack_pointer = state_curr.stack_pointer.expr();
-            Constraint {
-                name: "DupGadget stack overflow",
-                selector: self.stack_overflow.expr(),
-                polys: vec![stack_pointer],
-                lookups: vec![],
-            }
-        };
-
-        let stack_pointer = state_curr.stack_pointer.expr();
-        let diff = num_duplicated + stack_pointer - 1025.expr();
-        // diff's maxium is 15 when stack_pointer = 1024 and num_duplicated = 16,
-        // the minimum is 0 when num_duplicated + stack_pointer = 1025 , i.e. stack_point = 1020, num_duplicated = 5
-        let stack_underflow = {
-            Constraint {
-                name: "DupGadget stack underflow",
-                selector: self.stack_underflow.expr(),
-                polys: vec![],
-                lookups: vec![Lookup::FixedLookup(
-                    FixedLookup::Range16,
-                    [diff, 0.expr(), 0.expr()],
-                )],
-            }
-        };
-
-        let out_of_gas = {
-            let (one, two, three) = (1.expr(), 2.expr(), 3.expr());
-            let (case_selector, gas_available) = &self.out_of_gas;
-            let gas_overdemand = state_curr.gas_counter.expr()
-                + GasCost::FASTEST.expr()
-                - gas_available.expr();
-            Constraint {
-                name: "DupGadget out of gas",
-                selector: case_selector.expr(),
-                polys: vec![
-                    (gas_overdemand.clone() - one)
-                        * (gas_overdemand.clone() - two)
-                        * (gas_overdemand - three),
-                ],
-                lookups: vec![],
-            }
-        };
-
-        array::IntoIter::new([
-            success,
-            stack_overflow,
-            stack_underflow,
-            out_of_gas,
-        ])
-        .map(move |mut constraint| {
-            constraint.lookups =
-                [common_lookups.clone(), constraint.lookups].concat();
-            constraint
-        })
-        .collect()
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
     }
 
     fn assign(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
     ) -> Result<(), Error> {
-        match execution_step.case {
-            Case::Success => {
-                self.assign_success(region, offset, core_state, execution_step)
-            }
-            Case::StackOverflow => {
-                unimplemented!()
-            }
-            Case::StackUnderflow => {
-                unimplemented!()
-            }
-            Case::OutOfGas => {
-                unimplemented!()
-            }
-            _ => unreachable!(),
-        }
-    }
-}
+        // Input
+        self.value
+            .assign(region, offset, Some(step.values[0].to_word()))?;
 
-impl<F: FieldExt> DupGadget<F> {
-    fn assign_success(
-        &self,
-        region: &mut Region<'_, F>,
-        offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
-    ) -> Result<(), Error> {
-        core_state.global_counter += 2; // read + write operation
-        core_state.program_counter += 1;
-        core_state.stack_pointer -= 1;
-        core_state.gas_counter += 3;
-
-        self.success.word.assign(
-            region,
-            offset,
-            Some(execution_step.values[0].to_word()),
-        )?;
+        // State transitions
+        STATE_TRANSITION.assign(state);
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pc.rs
@@ -11,18 +11,20 @@ use bus_mapping::evm::{GasCost, OpcodeId};
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 use std::convert::TryInto;
 
-const GC_DELTA: usize = 1;
-const PC_DELTA: usize = 1;
-const SP_DELTA: i32 = -1;
-const GAS: GasCost = GasCost::QUICK;
+static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+    gc_delta: Some(1),
+    pc_delta: Some(1),
+    sp_delta: Some(-1),
+    gas_delta: Some(GasCost::QUICK.as_usize()),
+};
 const NUM_PUSHED: usize = 1;
 
 impl_op_gadget!(
-    [PC]
+    #set[PC]
     PcGadget {
         PcSuccessCase(),
         StackOverflowCase(NUM_PUSHED),
-        OutOfGasCase(GAS.as_usize()),
+        OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
     }
 );
 
@@ -72,13 +74,8 @@ impl<F: FieldExt> PcSuccessCase<F> {
         // Push the result on the stack
         cb.stack_push(self.pc.expr());
 
-        utils::StateTransitions {
-            gc_delta: Some(GC_DELTA.expr()),
-            sp_delta: Some(SP_DELTA.expr()),
-            pc_delta: Some(PC_DELTA.expr()),
-            gas_delta: Some(GAS.expr()),
-        }
-        .constraints(&mut cb, state_curr, state_next);
+        // State transitions
+        STATE_TRANSITION.constraints(&mut cb, state_curr, state_next);
 
         // Generate the constraint
         cb.constraint(self.case_selector.expr(), name)
@@ -88,19 +85,15 @@ impl<F: FieldExt> PcSuccessCase<F> {
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
     ) -> Result<(), Error> {
-        core_state.global_counter += 1;
-        core_state.program_counter += 1;
-        core_state.stack_pointer -= 1;
-        core_state.gas_counter += GasCost::QUICK.as_usize();
+        // Input
+        self.pc
+            .assign(region, offset, Some(step.values[0].to_word()))?;
 
-        self.pc.assign(
-            region,
-            offset,
-            Some(execution_step.values[0].to_word()),
-        )?;
+        // State transitions
+        STATE_TRANSITION.assign(state);
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pc.rs
@@ -1,9 +1,9 @@
 use super::super::{
     Case, Cell, Constraint, CoreStateInstance, ExecutionStep, Word,
 };
-use super::utils;
 use super::utils::common_cases::{OutOfGasCase, StackOverflowCase};
 use super::utils::constraint_builder::ConstraintBuilder;
+use super::utils::{from_bytes, sum, StateTransition};
 use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
 use crate::impl_op_gadget;
 use crate::util::{Expr, ToWord};
@@ -11,7 +11,7 @@ use bus_mapping::evm::{GasCost, OpcodeId};
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 use std::convert::TryInto;
 
-static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(1), // 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(-1),
@@ -63,10 +63,10 @@ impl<F: FieldExt> PcSuccessCase<F> {
         // - pc[7..0] = state.program_counter
         // - pc[32] + .. + pc[8] = 0
         cb.require_equal(
-            utils::from_bytes::expr(self.pc.cells[0..8].to_vec()),
+            from_bytes::expr(self.pc.cells[0..8].to_vec()),
             state_curr.program_counter.expr(),
         );
-        cb.require_zero(utils::sum::expr(&self.pc.cells[8..32]));
+        cb.require_zero(sum::expr(&self.pc.cells[8..32]));
 
         // Push the result on the stack
         cb.stack_push(self.pc.expr());

--- a/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
@@ -13,7 +13,7 @@ use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
 static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
-    gc_delta: Some(1),
+    gc_delta: Some(1), // 1 stack pop
     pc_delta: Some(1),
     sp_delta: Some(1),
     gas_delta: Some(GasCost::QUICK.as_usize()),

--- a/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
@@ -1,7 +1,7 @@
 use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
-use super::utils;
 use super::utils::common_cases::{OutOfGasCase, StackUnderflowCase};
 use super::utils::constraint_builder::ConstraintBuilder;
+use super::utils::StateTransition;
 use super::{
     CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
 };
@@ -12,7 +12,7 @@ use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
-static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(1), // 1 stack pop
     pc_delta: Some(1),
     sp_delta: Some(1),

--- a/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
@@ -1,178 +1,87 @@
-use super::super::{Case, Cell, Constraint, CoreStateInstance, ExecutionStep};
-use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
-use crate::util::Expr;
+use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
+use super::utils;
+use super::utils::common_cases::{OutOfGasCase, StackUnderflowCase};
+use super::utils::constraint_builder::ConstraintBuilder;
+use super::{
+    CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
+};
+use crate::impl_op_gadget;
+use crate::util::{Expr, ToWord};
 use bus_mapping::evm::{GasCost, OpcodeId};
 use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
+static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+    gc_delta: Some(1),
+    pc_delta: Some(1),
+    sp_delta: Some(1),
+    gas_delta: Some(GasCost::QUICK.as_usize()),
+};
+const NUM_POPPED: usize = 1;
+
+impl_op_gadget!(
+    #set[POP]
+    PopGadget {
+        PopSuccessCase(),
+        StackUnderflowCase(NUM_POPPED),
+        OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
+    }
+);
+
 #[derive(Clone, Debug)]
-pub struct PopGadget<F> {
-    success: Cell<F>,
-    stack_underflow: Cell<F>, // case selector
-    out_of_gas: (
-        Cell<F>, // case selector
-        Cell<F>, // gas available
-    ),
+struct PopSuccessCase<F> {
+    case_selector: Cell<F>,
+    value: Word<F>,
 }
 
-impl<F: FieldExt> OpGadget<F> for PopGadget<F> {
-    const RESPONSIBLE_OPCODES: &'static [OpcodeId] = &[
-        OpcodeId::POP, // 0x50 of op id
-    ];
+impl<F: FieldExt> PopSuccessCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::Success,
+        num_word: 1,
+        num_cell: 0,
+        will_halt: false,
+    };
 
-    const CASE_CONFIGS: &'static [CaseConfig] = &[
-        CaseConfig {
-            case: Case::Success,
-            num_word: 0, // no operand required for pop
-            num_cell: 0,
-            will_halt: false,
-        },
-        CaseConfig {
-            case: Case::StackUnderflow,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-        CaseConfig {
-            case: Case::OutOfGas,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-    ];
-
-    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self {
-        let [success, stack_underflow, out_of_gas]: [CaseAllocation<F>; 3] =
-            case_allocations.try_into().unwrap();
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
         Self {
-            success: success.selector,
-
-            stack_underflow: stack_underflow.selector,
-            out_of_gas: (
-                out_of_gas.selector.clone(),
-                out_of_gas.resumption.unwrap().gas_available,
-            ),
+            case_selector: alloc.selector.clone(),
+            value: alloc.words.pop().unwrap(),
         }
     }
 
-    fn constraints(
+    pub(crate) fn constraint(
         &self,
-        op_execution_state_curr: &OpExecutionState<F>,
-        op_execution_state_next: &OpExecutionState<F>,
-    ) -> Vec<Constraint<F>> {
-        let OpExecutionState { opcode, .. } = &op_execution_state_curr;
-        let common_polys = vec![opcode.expr() - OpcodeId::POP.expr()];
+        state_curr: &OpExecutionState<F>,
+        state_next: &OpExecutionState<F>,
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
 
-        let success = {
-            // interpreter state transition constraints
-            let op_execution_state_transition_constraints = vec![
-                op_execution_state_next.global_counter.expr()
-                    - (op_execution_state_curr.global_counter.expr()
-                        + 1.expr()),
-                op_execution_state_next.stack_pointer.expr()
-                    - (op_execution_state_curr.stack_pointer.expr() + 1.expr()),
-                op_execution_state_next.program_counter.expr()
-                    - (op_execution_state_curr.program_counter.expr()
-                        + 1.expr()),
-                op_execution_state_next.gas_counter.expr()
-                    - (op_execution_state_curr.gas_counter.expr()
-                        + GasCost::QUICK.expr()),
-            ];
+        // Pop the value from the stack
+        cb.stack_pop(self.value.expr());
 
-            let case_selector = &self.success;
+        // State transitions
+        STATE_TRANSITION.constraints(&mut cb, state_curr, state_next);
 
-            Constraint {
-                name: "PopGadget success",
-                selector: case_selector.expr(),
-                polys: [
-                    common_polys.clone(),
-                    op_execution_state_transition_constraints,
-                ]
-                .concat(),
-                lookups: vec![],
-            }
-        };
-
-        let stack_underflow = {
-            let stack_pointer = op_execution_state_curr.stack_pointer.expr();
-            Constraint {
-                name: "PopGadget stack underflow",
-                selector: self.stack_underflow.expr(),
-                polys: vec![
-                    common_polys.clone(),
-                    vec![(stack_pointer - 1024.expr())],
-                ]
-                .concat(),
-                lookups: vec![],
-            }
-        };
-
-        let out_of_gas = {
-            let (case_selector, gas_available) = &self.out_of_gas;
-            let gas_overdemand = op_execution_state_curr.gas_counter.expr()
-                + GasCost::QUICK.expr()
-                - gas_available.expr();
-            Constraint {
-                name: "PopGadget out of gas",
-                selector: case_selector.expr(),
-                polys: [
-                    common_polys,
-                    vec![
-                        (gas_overdemand.clone() - 1.expr())
-                            * (gas_overdemand - 2.expr()),
-                    ],
-                ]
-                .concat(),
-                lookups: vec![],
-            }
-        };
-
-        vec![success, stack_underflow, out_of_gas]
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
     }
 
     fn assign(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        op_execution_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
     ) -> Result<(), Error> {
-        match execution_step.case {
-            Case::Success => self.assign_success(
-                region,
-                offset,
-                op_execution_state,
-                execution_step,
-            ),
-            Case::StackUnderflow => {
-                unimplemented!()
-            }
-            Case::OutOfGas => {
-                unimplemented!()
-            }
-            _ => unreachable!(),
-        }
-    }
-}
+        // Input
+        self.value
+            .assign(region, offset, Some(step.values[0].to_word()))?;
 
-impl<F: FieldExt> PopGadget<F> {
-    fn assign_success(
-        &self,
-        region: &mut Region<'_, F>,
-        offset: usize,
-        op_execution_state: &mut CoreStateInstance,
-        _execution_step: &ExecutionStep,
-    ) -> Result<(), Error> {
-        op_execution_state.global_counter += 1;
-        op_execution_state.program_counter += 1;
-        op_execution_state.stack_pointer += 1;
-        op_execution_state.gas_counter += 2; // pop consume 2 gas point
-                                             // no word assignments
+        // State transitions
+        STATE_TRANSITION.assign(state);
 
-        self.success
-            .assign(region, offset, Some(F::from_u64(1)))
-            .unwrap();
         Ok(())
     }
 }
@@ -211,7 +120,7 @@ mod test {
                 ExecutionStep {
                     opcode: OpcodeId::POP,
                     case: Case::Success,
-                    values: vec![],
+                    values: vec![BigUint::from(0x02_03u64)],
                 },
                 ExecutionStep {
                     opcode: OpcodeId::PUSH3,

--- a/zkevm-circuits/src/evm_circuit/op_execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/push.rs
@@ -1,266 +1,143 @@
-use super::super::{
-    BusMappingLookup, Case, Cell, Constraint, CoreStateInstance, ExecutionStep,
-    FixedLookup, Lookup, Word,
+use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
+use super::utils;
+use super::utils::common_cases::{OutOfGasCase, StackOverflowCase};
+use super::utils::constraint_builder::ConstraintBuilder;
+use super::{
+    CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
 };
-use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
+use crate::impl_op_gadget;
 use crate::util::{Expr, ToWord};
+use array_init::array_init;
 use bus_mapping::evm::{GasCost, OpcodeId};
-use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
-use std::{array, convert::TryInto};
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region};
+use std::convert::TryInto;
+
+static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+    gc_delta: Some(1),
+    pc_delta: None,
+    sp_delta: Some(-1),
+    gas_delta: Some(GasCost::FASTEST.as_usize()),
+};
+const NUM_PUSHED: usize = 1;
+
+impl_op_gadget!(
+    #range
+    [
+         PUSH1,  PUSH2,  PUSH3,  PUSH4,  PUSH5,  PUSH6,  PUSH7,  PUSH8,
+         PUSH9, PUSH10, PUSH11, PUSH12, PUSH13, PUSH14, PUSH15, PUSH16,
+        PUSH17, PUSH18, PUSH19, PUSH20, PUSH21, PUSH22, PUSH23, PUSH24,
+        PUSH25, PUSH26, PUSH27, PUSH28, PUSH29, PUSH30, PUSH31, PUSH32,
+    ]
+    PushGadget {
+        PushSuccessCase(),
+        StackOverflowCase(NUM_PUSHED),
+        OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
+    }
+);
 
 #[derive(Clone, Debug)]
-struct PushSuccessAllocation<F> {
+struct PushSuccessCase<F> {
     case_selector: Cell<F>,
-    word: Word<F>,
+    value: Word<F>,
     selectors: [Cell<F>; 32], /* whether its PUSH1, ..., or PUSH32 ([1, 1,
                                * 0, ..., 0] means PUSH2) */
 }
 
-#[derive(Clone, Debug)]
-pub struct PushGadget<F> {
-    success: PushSuccessAllocation<F>,
-    stack_overflow: Cell<F>, // case selector
-    out_of_gas: (
-        Cell<F>, // case selector
-        Cell<F>, // gas available
-    ),
-}
+impl<F: FieldExt> PushSuccessCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::Success,
+        num_word: 1,
+        num_cell: 32, // for PUSH selectors
+        will_halt: false,
+    };
 
-impl<F: FieldExt> OpGadget<F> for PushGadget<F> {
-    const RESPONSIBLE_OPCODES: &'static [OpcodeId] = &[
-        OpcodeId::PUSH1,
-        OpcodeId::PUSH2,
-        OpcodeId::PUSH3,
-        OpcodeId::PUSH4,
-        OpcodeId::PUSH5,
-        OpcodeId::PUSH6,
-        OpcodeId::PUSH7,
-        OpcodeId::PUSH8,
-        OpcodeId::PUSH9,
-        OpcodeId::PUSH10,
-        OpcodeId::PUSH11,
-        OpcodeId::PUSH12,
-        OpcodeId::PUSH13,
-        OpcodeId::PUSH14,
-        OpcodeId::PUSH15,
-        OpcodeId::PUSH16,
-        OpcodeId::PUSH17,
-        OpcodeId::PUSH18,
-        OpcodeId::PUSH19,
-        OpcodeId::PUSH20,
-        OpcodeId::PUSH21,
-        OpcodeId::PUSH22,
-        OpcodeId::PUSH23,
-        OpcodeId::PUSH24,
-        OpcodeId::PUSH25,
-        OpcodeId::PUSH26,
-        OpcodeId::PUSH27,
-        OpcodeId::PUSH28,
-        OpcodeId::PUSH29,
-        OpcodeId::PUSH30,
-        OpcodeId::PUSH31,
-        OpcodeId::PUSH32,
-    ];
-
-    const CASE_CONFIGS: &'static [CaseConfig] = &[
-        CaseConfig {
-            case: Case::Success,
-            num_word: 1,
-            num_cell: 32, // for PUSH selectors
-            will_halt: false,
-        },
-        CaseConfig {
-            case: Case::StackOverflow,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-        CaseConfig {
-            case: Case::OutOfGas,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-    ];
-
-    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self {
-        let [mut success, stack_overflow, out_of_gas]: [CaseAllocation<F>; 3] =
-            case_allocations.try_into().unwrap();
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
         Self {
-            success: PushSuccessAllocation {
-                case_selector: success.selector.clone(),
-                word: success.words.pop().unwrap(),
-                selectors: success.cells.try_into().unwrap(),
-            },
-            stack_overflow: stack_overflow.selector,
-            out_of_gas: (
-                out_of_gas.selector,
-                out_of_gas.resumption.unwrap().gas_available,
-            ),
+            case_selector: alloc.selector.clone(),
+            value: alloc.words.pop().unwrap(),
+            selectors: array_init(|_| alloc.cells.pop().unwrap()),
         }
     }
 
-    fn constraints(
+    pub(crate) fn constraint(
         &self,
         state_curr: &OpExecutionState<F>,
         state_next: &OpExecutionState<F>,
-    ) -> Vec<Constraint<F>> {
-        let OpExecutionState { opcode, .. } = &state_curr;
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
 
-        let common_lookups = vec![Lookup::FixedLookup(
-            FixedLookup::Range32,
-            [opcode.expr() - OpcodeId::PUSH1.expr(), 0.expr(), 0.expr()],
-        )];
+        let num_pushed =
+            state_curr.opcode.expr() - OpcodeId::PUSH1.expr() + 1.expr();
 
-        let success = {
-            let num_pushed = opcode.expr() - OpcodeId::PUSH1.expr() + 1.expr();
-
-            // interpreter state transition constraints
-            let state_transition_constraints = vec![
-                state_next.global_counter.expr()
-                    - (state_curr.global_counter.expr() + 1.expr()),
-                state_next.program_counter.expr()
-                    - (state_curr.program_counter.expr()
-                        + 1.expr()
-                        + num_pushed.clone()),
-                state_next.stack_pointer.expr()
-                    - (state_curr.stack_pointer.expr() - 1.expr()),
-                state_next.gas_counter.expr()
-                    - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
-            ];
-
-            let PushSuccessAllocation {
-                case_selector,
-                word,
-                selectors,
-            } = &self.success;
-
-            let mut push_constraints = vec![];
-            for idx in 0..31 {
-                // selector can transit from 1 to 0 only once as [1, 1, 1, ...,
-                // 0, 0, 0]
-                if idx > 0 {
-                    let diff =
-                        selectors[idx - 1].expr() - selectors[idx].expr();
-                    push_constraints.push(diff.clone() * (1.expr() - diff));
-                }
-                // selectors needs to be 0 or 1
-                push_constraints.push(
-                    selectors[idx].expr() * (1.expr() - selectors[idx].expr()),
-                );
-                // word byte should be 0 when selector is 0
-                push_constraints.push(
-                    word.cells[idx].expr() * (1.expr() - selectors[idx].expr()),
-                );
+        // First selector (for the LSB) always needs to be enabled
+        cb.require_equal(self.selectors[0].expr(), 1.expr());
+        // Check all other selectors
+        for idx in 1..32 {
+            // selector can transit from 1 to 0 only once as [1, 1, 1, ...,
+            // 0, 0, 0]
+            if idx > 0 {
+                let diff =
+                    self.selectors[idx - 1].expr() - self.selectors[idx].expr();
+                cb.require_boolean(diff);
             }
+            // selectors needs to be 0 or 1
+            cb.require_boolean(self.selectors[idx].expr());
+            // word byte should be 0 when selector is 0
+            cb.add_expression(
+                self.value.cells[idx].expr()
+                    * (1.expr() - self.selectors[idx].expr()),
+            );
+        }
 
-            let selectors_sum =
-                selectors.iter().fold(0.expr(), |sum, s| sum + s.expr());
-            push_constraints.push(selectors_sum - num_pushed);
+        // Sum of selectors needs to be exactly the number of bytes that needs to be pushed.
+        cb.require_equal(
+            utils::sum::expr(&self.selectors[..]),
+            num_pushed.clone(),
+        );
 
-            let bus_mapping_lookups =
-                [vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: (-1).expr(),
-                    value: word.expr(),
-                    is_write: true,
-                })]]
-                .concat();
+        // Push the value on the stack
+        cb.stack_push(self.value.expr());
 
-            Constraint {
-                name: "PushGadget success",
-                selector: case_selector.expr(),
-                polys: [state_transition_constraints, push_constraints]
-                    .concat(),
-                lookups: bus_mapping_lookups,
-            }
-        };
+        // State transitions
+        let mut st =
+            utils::StateTransitionExpressions::new(STATE_TRANSITION.clone());
+        st.pc_delta = Some(1.expr() + num_pushed);
+        st.constraints(&mut cb, state_curr, state_next);
 
-        let stack_overflow = {
-            let stack_pointer = state_curr.stack_pointer.expr();
-            Constraint {
-                name: "PushGadget stack overflow",
-                selector: self.stack_overflow.expr(),
-                polys: vec![stack_pointer],
-                lookups: vec![],
-            }
-        };
-
-        let out_of_gas = {
-            let (case_selector, gas_available) = &self.out_of_gas;
-            let gas_overdemand = state_curr.gas_counter.expr()
-                + GasCost::FASTEST.expr()
-                - gas_available.expr();
-            Constraint {
-                name: "PushGadget out of gas",
-                selector: case_selector.expr(),
-                polys: vec![
-                    (gas_overdemand.clone() - 1.expr())
-                        * (gas_overdemand.clone() - 2.expr())
-                        * (gas_overdemand - 3.expr()),
-                ],
-                lookups: vec![],
-            }
-        };
-
-        array::IntoIter::new([success, stack_overflow, out_of_gas])
-            .map(move |mut constraint| {
-                constraint.lookups =
-                    [common_lookups.clone(), constraint.lookups].concat();
-                constraint
-            })
-            .collect()
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
     }
 
     fn assign(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
     ) -> Result<(), Error> {
-        match execution_step.case {
-            Case::Success => {
-                self.assign_success(region, offset, core_state, execution_step)
-            }
-            Case::StackOverflow => {
-                unimplemented!()
-            }
-            Case::OutOfGas => {
-                unimplemented!()
-            }
-            _ => unreachable!(),
-        }
-    }
-}
+        let num_pushed =
+            (step.opcode.as_u8() - OpcodeId::PUSH1.as_u8() + 1) as usize;
 
-impl<F: FieldExt> PushGadget<F> {
-    fn assign_success(
-        &self,
-        region: &mut Region<'_, F>,
-        offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
-    ) -> Result<(), Error> {
-        core_state.global_counter += 1;
-        core_state.program_counter += 1
-            + (execution_step.opcode.as_u8() - OpcodeId::PUSH1.as_u8() + 1)
-                as usize;
-        core_state.stack_pointer -= 1;
-        core_state.gas_counter += 3;
+        // Input
+        self.value
+            .assign(region, offset, Some(step.values[0].to_word()))?;
 
-        self.success.word.assign(
-            region,
-            offset,
-            Some(execution_step.values[0].to_word()),
-        )?;
-        self.success
-            .selectors
+        // Selectors
+        self.selectors
             .iter()
-            .zip(execution_step.values[1].to_word().iter())
+            .zip(step.values[1].to_word().iter())
             .map(|(alloc, bit)| {
                 alloc.assign(region, offset, Some(F::from_u64(*bit as u64)))
             })
             .collect::<Result<Vec<_>, _>>()?;
+
+        // State transitions
+        let mut st = STATE_TRANSITION.clone();
+        st.pc_delta = Some(1 + num_pushed);
+        st.assign(state);
+
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
@@ -17,7 +17,7 @@ use num::{BigUint, ToPrimitive};
 use std::convert::TryInto;
 
 static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
-    gc_delta: Some(3),
+    gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
     gas_delta: Some(GasCost::FAST.as_usize()),

--- a/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
@@ -1,8 +1,8 @@
 use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
-use super::utils;
 use super::utils::common_cases::{OutOfGasCase, StackUnderflowCase};
 use super::utils::constraint_builder::ConstraintBuilder;
 use super::utils::math_gadgets::{IsEqualGadget, IsZeroGadget};
+use super::utils::{and, select, sum, StateTransition};
 use super::{
     CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
 };
@@ -16,7 +16,7 @@ use halo2::{arithmetic::FieldExt, circuit::Region};
 use num::{BigUint, ToPrimitive};
 use std::convert::TryInto;
 
-static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(3), // 2 stack pops + 1 stack push
     pc_delta: Some(1),
     sp_delta: Some(1),
@@ -83,7 +83,7 @@ impl<F: FieldExt> SignextendSuccessCase<F> {
         // so we can use that as an additional condition to enable the selector.
         let is_msb_sum_zero = self
             .is_msb_sum_zero
-            .constraints(&mut cb, utils::sum::expr(&self.index.cells[1..32]));
+            .constraints(&mut cb, sum::expr(&self.index.cells[1..32]));
         // We need to find the byte we have to get the sign from so we can extend correctly.
         // We go byte by byte and check if `idx == index[0]`.
         // If they are equal (at most once) we add the byte value to the sum, else we add 0.
@@ -94,7 +94,7 @@ impl<F: FieldExt> SignextendSuccessCase<F> {
         for idx in 0..31 {
             // Check if this byte is selected
             // The additional condition for this is that none of the non-LSB bytes are non-zero (see above).
-            let is_selected = utils::and::expr(vec![
+            let is_selected = and::expr(vec![
                 self.is_byte_selected[idx].constraints(
                     &mut cb,
                     self.index.cells[0].expr(),
@@ -143,7 +143,7 @@ impl<F: FieldExt> SignextendSuccessCase<F> {
                 if idx == 0 {
                     self.value.cells[idx].expr()
                 } else {
-                    utils::select::expr(
+                    select::expr(
                         self.selectors[idx - 1].expr(),
                         self.sign_byte.expr(),
                         self.value.cells[idx].expr(),
@@ -183,11 +183,11 @@ impl<F: FieldExt> SignextendSuccessCase<F> {
         let msb_sum_zero = self.is_msb_sum_zero.assign(
             region,
             offset,
-            utils::sum::value(&step.values[0].to_word()[1..32]),
+            sum::value(&step.values[0].to_word()[1..32]),
         )?;
         let mut previous_selector_value: F = 0.into();
         for i in 0..31 {
-            let selected = utils::and::value(vec![
+            let selected = and::value(vec![
                 self.is_byte_selected[i].assign(
                     region,
                     offset,

--- a/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
@@ -16,18 +16,20 @@ use halo2::{arithmetic::FieldExt, circuit::Region};
 use num::{BigUint, ToPrimitive};
 use std::convert::TryInto;
 
-const GC_DELTA: usize = 3;
-const PC_DELTA: usize = 1;
-const SP_DELTA: usize = 1;
-const GAS: GasCost = GasCost::FAST;
+static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+    gc_delta: Some(3),
+    pc_delta: Some(1),
+    sp_delta: Some(1),
+    gas_delta: Some(GasCost::FAST.as_usize()),
+};
 const NUM_POPPED: usize = 2;
 
 impl_op_gadget!(
-    [SIGNEXTEND]
+    #set[SIGNEXTEND]
     SignextendGadget {
         SignextendSuccessCase(),
         StackUnderflowCase(NUM_POPPED),
-        OutOfGasCase(GAS.as_usize()),
+        OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
     }
 );
 
@@ -156,13 +158,7 @@ impl<F: FieldExt> SignextendSuccessCase<F> {
         cb.stack_push(self.result.expr());
 
         // State transitions
-        utils::StateTransitions {
-            gc_delta: Some(GC_DELTA.expr()),
-            sp_delta: Some(SP_DELTA.expr()),
-            pc_delta: Some(PC_DELTA.expr()),
-            gas_delta: Some(GAS.expr()),
-        }
-        .constraints(&mut cb, state_curr, state_next);
+        STATE_TRANSITION.constraints(&mut cb, state_curr, state_next);
 
         // Generate the constraint
         cb.constraint(self.case_selector.expr(), name)
@@ -218,10 +214,7 @@ impl<F: FieldExt> SignextendSuccessCase<F> {
             .unwrap();
 
         // State transitions
-        state.global_counter += GC_DELTA;
-        state.program_counter += PC_DELTA;
-        state.stack_pointer += SP_DELTA;
-        state.gas_counter += GAS.as_usize();
+        STATE_TRANSITION.assign(state);
 
         Ok(())
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/swap.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/swap.rs
@@ -1,7 +1,7 @@
 use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
-use super::utils;
 use super::utils::common_cases::{OutOfGasCase, RangeStackUnderflowCase};
 use super::utils::constraint_builder::ConstraintBuilder;
+use super::utils::StateTransition;
 use super::{
     CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
 };
@@ -13,7 +13,7 @@ use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region};
 use std::convert::TryInto;
 
-static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+static STATE_TRANSITION: StateTransition = StateTransition {
     gc_delta: Some(4), // 2 stack reads + 2 stack writes
     pc_delta: Some(1),
     sp_delta: Some(0),
@@ -28,7 +28,7 @@ impl_op_gadget!(
     ]
     SwapGadget {
         SwapSuccessCase(),
-        RangeStackUnderflowCase(OpcodeId::SWAP1.as_u64(), 16, 1),
+        RangeStackUnderflowCase(OpcodeId::SWAP1, 16, 1),
         OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
     }
 );
@@ -63,6 +63,7 @@ impl<F: FieldExt> SwapSuccessCase<F> {
         let mut cb = ConstraintBuilder::default();
 
         // The stack index we have to peek, deduced from the 'x' value of 'swapx'
+        // The offset starts at 1 for SWAP1
         let swap_offset =
             state_curr.opcode.expr() - (OpcodeId::SWAP1.as_u64() - 1).expr();
 

--- a/zkevm-circuits/src/evm_circuit/op_execution/swap.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/swap.rs
@@ -28,7 +28,7 @@ impl_op_gadget!(
     ]
     SwapGadget {
         SwapSuccessCase(),
-        RangeStackUnderflowCase(OpcodeId::SWAP1.as_u64() - 1, 17),
+        RangeStackUnderflowCase(OpcodeId::SWAP1.as_u64(), 16, 1),
         OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
     }
 );
@@ -42,7 +42,7 @@ struct SwapSuccessCase<F> {
 impl<F: FieldExt> SwapSuccessCase<F> {
     pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
         case: Case::Success,
-        num_word: 2, // value
+        num_word: 2, // values
         num_cell: 0,
         will_halt: false,
     };
@@ -64,13 +64,13 @@ impl<F: FieldExt> SwapSuccessCase<F> {
 
         // The stack index we have to peek, deduced from the 'x' value of 'swapx'
         let swap_offset =
-            state_curr.opcode.expr() - OpcodeId::SWAP1.expr() + 1.expr();
+            state_curr.opcode.expr() - (OpcodeId::SWAP1.as_u64() - 1).expr();
 
         // Peek the value at `swap_offset`
         cb.stack_lookup(swap_offset.clone(), self.values[0].expr(), false);
         // Peek the value at the top of the stack
         cb.stack_lookup(0.expr(), self.values[1].expr(), false);
-        // Write the value previously at the top of the stack at `swap_offset`
+        // Write the value previously at the top of the stack to `swap_offset`
         cb.stack_lookup(swap_offset, self.values[1].expr(), true);
         // Write the value previously at `swap_offset` to the top of the stack
         cb.stack_lookup(0.expr(), self.values[0].expr(), true);

--- a/zkevm-circuits/src/evm_circuit/op_execution/swap.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/swap.rs
@@ -1,239 +1,106 @@
-use super::super::{
-    BusMappingLookup, Case, Cell, Constraint, CoreStateInstance, ExecutionStep,
-    FixedLookup, Lookup, Word,
+use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
+use super::utils;
+use super::utils::common_cases::{OutOfGasCase, RangeStackUnderflowCase};
+use super::utils::constraint_builder::ConstraintBuilder;
+use super::{
+    CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
 };
-use super::{CaseAllocation, CaseConfig, OpExecutionState, OpGadget};
+use crate::impl_op_gadget;
 use crate::util::{Expr, ToWord};
+use array_init::array_init;
 use bus_mapping::evm::{GasCost, OpcodeId};
-use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
-use std::{array, convert::TryInto};
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region};
+use std::convert::TryInto;
+
+static STATE_TRANSITION: utils::StateTransition = utils::StateTransition {
+    gc_delta: Some(4), // 2 stack reads + 2 stack writes
+    pc_delta: Some(1),
+    sp_delta: Some(0),
+    gas_delta: Some(GasCost::FASTEST.as_usize()),
+};
+
+impl_op_gadget!(
+    #range
+    [
+        SWAP1,  SWAP2,  SWAP3,  SWAP4,  SWAP5,  SWAP6,  SWAP7,  SWAP8,
+        SWAP9, SWAP10, SWAP11, SWAP12, SWAP13, SWAP14, SWAP15, SWAP16,
+    ]
+    SwapGadget {
+        SwapSuccessCase(),
+        RangeStackUnderflowCase(OpcodeId::SWAP1.as_u64() - 1, 17),
+        OutOfGasCase(STATE_TRANSITION.gas_delta.unwrap()),
+    }
+);
 
 #[derive(Clone, Debug)]
-struct SwapSuccessAllocation<F> {
+struct SwapSuccessCase<F> {
     case_selector: Cell<F>,
-    words: [Word<F>; 2],
+    values: [Word<F>; 2],
 }
 
-#[derive(Clone, Debug)]
-pub struct SwapGadget<F> {
-    success: SwapSuccessAllocation<F>,
-    stack_underflow: Cell<F>, // case selector
-    out_of_gas: (
-        Cell<F>, // case selector
-        Cell<F>, // gas available
-    ),
-}
+impl<F: FieldExt> SwapSuccessCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::Success,
+        num_word: 2, // value
+        num_cell: 0,
+        will_halt: false,
+    };
 
-impl<F: FieldExt> OpGadget<F> for SwapGadget<F> {
-    const RESPONSIBLE_OPCODES: &'static [OpcodeId] = &[
-        OpcodeId::SWAP1,
-        OpcodeId::SWAP2,
-        OpcodeId::SWAP3,
-        OpcodeId::SWAP4,
-        OpcodeId::SWAP5,
-        OpcodeId::SWAP6,
-        OpcodeId::SWAP7,
-        OpcodeId::SWAP8,
-        OpcodeId::SWAP9,
-        OpcodeId::SWAP10,
-        OpcodeId::SWAP11,
-        OpcodeId::SWAP12,
-        OpcodeId::SWAP13,
-        OpcodeId::SWAP14,
-        OpcodeId::SWAP15,
-        OpcodeId::SWAP16,
-    ];
-
-    const CASE_CONFIGS: &'static [CaseConfig] = &[
-        CaseConfig {
-            case: Case::Success,
-            num_word: 2,
-            num_cell: 0,
-            will_halt: false,
-        },
-        CaseConfig {
-            case: Case::StackUnderflow,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-        CaseConfig {
-            case: Case::OutOfGas,
-            num_word: 0,
-            num_cell: 0,
-            will_halt: true,
-        },
-    ];
-
-    fn construct(case_allocations: Vec<CaseAllocation<F>>) -> Self {
-        let [success, stack_underflow, out_of_gas]: [CaseAllocation<F>; 3] =
-            case_allocations.try_into().unwrap();
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
         Self {
-            success: SwapSuccessAllocation {
-                case_selector: success.selector.clone(),
-                words: success.words.try_into().unwrap(),
-            },
-            stack_underflow: stack_underflow.selector,
-            out_of_gas: (
-                out_of_gas.selector,
-                out_of_gas.resumption.unwrap().gas_available,
-            ),
+            case_selector: alloc.selector.clone(),
+            values: array_init(|_| alloc.words.pop().unwrap()),
         }
     }
 
-    fn constraints(
+    pub(crate) fn constraint(
         &self,
         state_curr: &OpExecutionState<F>,
         state_next: &OpExecutionState<F>,
-    ) -> Vec<Constraint<F>> {
-        let OpExecutionState { opcode, .. } = &state_curr;
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
 
-        let common_lookups = vec![Lookup::FixedLookup(
-            FixedLookup::Range16,
-            [opcode.expr() - OpcodeId::SWAP1.expr(), 0.expr(), 0.expr()],
-        )];
+        // The stack index we have to peek, deduced from the 'x' value of 'swapx'
+        let swap_offset =
+            state_curr.opcode.expr() - OpcodeId::SWAP1.expr() + 1.expr();
 
-        let num_swaped = opcode.expr() - OpcodeId::SWAP1.expr() + 1.expr();
-        let success = {
-            let SwapSuccessAllocation {
-                case_selector,
-                words,
-            } = &self.success;
+        // Peek the value at `swap_offset`
+        cb.stack_lookup(swap_offset.clone(), self.values[0].expr(), false);
+        // Peek the value at the top of the stack
+        cb.stack_lookup(0.expr(), self.values[1].expr(), false);
+        // Write the value previously at the top of the stack at `swap_offset`
+        cb.stack_lookup(swap_offset, self.values[1].expr(), true);
+        // Write the value previously at `swap_offset` to the top of the stack
+        cb.stack_lookup(0.expr(), self.values[0].expr(), true);
 
-            let state_transition_constraints = vec![
-                state_next.global_counter.expr()
-                    - (state_curr.global_counter.expr() + 4.expr()),
-                state_next.program_counter.expr()
-                    - (state_curr.program_counter.expr() + 1.expr()),
-                state_next.stack_pointer.expr()
-                    - state_curr.stack_pointer.expr(),
-                state_next.gas_counter.expr()
-                    - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
-            ];
+        // State transitions
+        STATE_TRANSITION.constraints(&mut cb, state_curr, state_next);
 
-            /*
-                bus_mapping_lookup(gc, Stack, key+X, $val1, Read)
-                bus_mapping_lookup(gc+1, Stack, key, $val2, Read)
-                bus_mapping_lookup(gc+2, Stack, key+X, $val2, Write)
-                bus_mapping_lookup(gc+3, Stack, key, $val1, Write)
-            */
-
-            let bus_mapping_lookups = vec![
-                // constrain (num_swaped)th value of stack
-                Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: num_swaped.clone(),
-                    value: words[0].expr(),
-                    is_write: false,
-                }),
-                // constrain top value of stack
-                Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: 0.expr(),
-                    value: words[1].expr(),
-                    is_write: false,
-                }),
-                // constrains when swap done
-                Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: num_swaped.clone(),
-                    value: words[1].expr(),
-                    is_write: true,
-                }),
-                Lookup::BusMappingLookup(BusMappingLookup::Stack {
-                    index_offset: 0.expr(),
-                    value: words[0].expr(),
-                    is_write: true,
-                }),
-            ];
-
-            Constraint {
-                name: "SwapGadget success",
-                selector: case_selector.expr(),
-                polys: state_transition_constraints,
-                lookups: bus_mapping_lookups,
-            }
-        };
-
-        // stack_underflow condition: 0 <= num_swaped +  stack_pointer - 1024 <= 16
-        let stack_pointer = state_curr.stack_pointer.expr();
-        let diff = num_swaped + stack_pointer - 1024.expr();
-        let stack_underflow = {
-            Constraint {
-                name: "SwapGadget stack underflow",
-                selector: self.stack_underflow.expr(),
-                polys: vec![],
-                lookups: vec![Lookup::FixedLookup(
-                    FixedLookup::Range17,
-                    [diff, 0.expr(), 0.expr()],
-                )],
-            }
-        };
-
-        let out_of_gas = {
-            let (case_selector, gas_available) = &self.out_of_gas;
-            let gas_overdemand = state_curr.gas_counter.expr()
-                + GasCost::FASTEST.expr()
-                - gas_available.expr();
-            Constraint {
-                name: "SwapGadget out of gas",
-                selector: case_selector.expr(),
-                polys: vec![
-                    (gas_overdemand.clone() - 1.expr())
-                        * (gas_overdemand.clone() - 2.expr())
-                        * (gas_overdemand - 3.expr()),
-                ],
-                lookups: vec![],
-            }
-        };
-
-        array::IntoIter::new([success, stack_underflow, out_of_gas])
-            .map(move |mut constraint| {
-                constraint.lookups =
-                    [common_lookups.clone(), constraint.lookups].concat();
-                constraint
-            })
-            .collect()
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
     }
 
     fn assign(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
     ) -> Result<(), Error> {
-        match execution_step.case {
-            Case::Success => {
-                self.assign_success(region, offset, core_state, execution_step)
-            }
-            Case::StackUnderflow => {
-                unimplemented!()
-            }
-            Case::OutOfGas => {
-                unimplemented!()
-            }
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl<F: FieldExt> SwapGadget<F> {
-    fn assign_success(
-        &self,
-        region: &mut Region<'_, F>,
-        offset: usize,
-        core_state: &mut CoreStateInstance,
-        execution_step: &ExecutionStep,
-    ) -> Result<(), Error> {
-        core_state.global_counter += 4;
-        core_state.program_counter += 1;
-        core_state.gas_counter += 3;
-
+        // Inputs
         for idx in 0..2 {
-            self.success.words[idx].assign(
+            self.values[idx].assign(
                 region,
                 offset,
-                Some(execution_step.values[idx].to_word()),
+                Some(step.values[idx].to_word()),
             )?;
         }
+
+        // State transitions
+        STATE_TRANSITION.assign(state);
+
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils.rs
@@ -234,7 +234,7 @@ pub(crate) mod from_bytes {
     pub(crate) fn expr<F: FieldExt>(bytes: Vec<Cell<F>>) -> Expression<F> {
         assert!(bytes.len() <= 32, "number of bytes too large");
         let mut value = 0.expr();
-        let mut multiplier = F::from_u64(1);
+        let mut multiplier = F::one();
         for byte in bytes.iter() {
             value = value + byte.expr() * multiplier;
             multiplier *= F::from_u64(256);
@@ -244,8 +244,8 @@ pub(crate) mod from_bytes {
 
     pub(crate) fn value<F: FieldExt>(bytes: Vec<u8>) -> F {
         assert!(bytes.len() <= 32, "number of bytes too large");
-        let mut value = F::from_u64(0);
-        let mut multiplier = F::from_u64(1);
+        let mut value = F::zero();
+        let mut multiplier = F::one();
         for byte in bytes.iter() {
             value += F::from_u64(*byte as u64) * multiplier;
             multiplier *= F::from_u64(256);
@@ -351,11 +351,11 @@ macro_rules! impl_op_gadget {
                         )*
                     ];
                     // Add common expressions to all cases
-                    let cb = utils::[<require_opcode_in_ $shared>](
+                    let cb = super::utils::[<require_opcode_in_ $shared>](
                         state_curr.opcode.expr(),
                         vec![$(OpcodeId::$op),*],
                     );
-                    utils::batch_add_expressions(
+                    super::utils::batch_add_expressions(
                         cases,
                         cb.expressions,
                         cb.lookups,

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils.rs
@@ -3,7 +3,10 @@
 use super::super::Constraint;
 use super::utils::constraint_builder::ConstraintBuilder;
 use super::OpExecutionState;
-use crate::util::Expr;
+use crate::{
+    evm_circuit::{CoreStateInstance, Lookup},
+    util::Expr,
+};
 use halo2::{arithmetic::FieldExt, plonk::Expression};
 
 pub(crate) mod common_cases;
@@ -16,14 +19,23 @@ pub(crate) mod math_gadgets;
 // that the state variable needs to remain the same (which may not
 // be correct, but this will easily be detected while testing).
 #[derive(Clone, Debug, Default)]
-pub(crate) struct StateTransitions<F> {
+pub(crate) struct StateTransitionExpressions<F> {
     pub gc_delta: Option<Expression<F>>,
     pub sp_delta: Option<Expression<F>>,
     pub pc_delta: Option<Expression<F>>,
     pub gas_delta: Option<Expression<F>>,
 }
 
-impl<F: FieldExt> StateTransitions<F> {
+impl<F: FieldExt> StateTransitionExpressions<F> {
+    pub(crate) fn new(state_transition: StateTransition) -> Self {
+        Self {
+            gc_delta: Some(state_transition.gc_delta.unwrap_or(0).expr()),
+            pc_delta: Some(state_transition.pc_delta.unwrap_or(0).expr()),
+            sp_delta: Some(state_transition.sp_delta.unwrap_or(0).expr()),
+            gas_delta: Some(state_transition.gas_delta.unwrap_or(0).expr()),
+        }
+    }
+
     pub(crate) fn constraints(
         &self,
         cb: &mut ConstraintBuilder<F>,
@@ -57,9 +69,46 @@ impl<F: FieldExt> StateTransitions<F> {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+pub(crate) struct StateTransition {
+    pub gc_delta: Option<usize>,
+    pub sp_delta: Option<i32>,
+    pub pc_delta: Option<usize>,
+    pub gas_delta: Option<usize>,
+}
+
+impl StateTransition {
+    pub(crate) fn assign(&self, state: &mut CoreStateInstance) {
+        // Global Counter
+        state.global_counter += self.gc_delta.unwrap_or(0);
+        // Stack Pointer
+        let sp_delta = self.sp_delta.unwrap_or(0);
+        if sp_delta < 0 {
+            state.stack_pointer -= -sp_delta as usize;
+        } else {
+            state.stack_pointer += sp_delta as usize;
+        }
+        // Program Counter
+        state.program_counter += self.pc_delta.unwrap_or(0);
+        // Gas Counter
+        state.gas_counter += self.gas_delta.unwrap_or(0);
+    }
+
+    pub(crate) fn constraints<F: FieldExt>(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        state_curr: &OpExecutionState<F>,
+        state_next: &OpExecutionState<F>,
+    ) {
+        StateTransitionExpressions::new(self.clone())
+            .constraints(cb, state_curr, state_next);
+    }
+}
+
 pub(crate) fn batch_add_expressions<F: FieldExt>(
     constraints: Vec<Constraint<F>>,
     expressions: Vec<Expression<F>>,
+    lookups: Vec<Lookup<F>>,
 ) -> Vec<Constraint<F>> {
     constraints
         .into_iter()
@@ -67,6 +116,8 @@ pub(crate) fn batch_add_expressions<F: FieldExt>(
             constraint.polys =
                 [constraint.polys.clone(), expressions.clone().to_vec()]
                     .concat();
+            constraint.lookups =
+                [constraint.lookups.clone(), lookups.clone().to_vec()].concat();
             constraint
         })
         .collect()
@@ -184,7 +235,7 @@ macro_rules! count {
 /// Common OpGadget implementer
 #[macro_export]
 macro_rules! impl_op_gadget {
-    ([$($op:ident),*] $name:ident { $($case:ident ($($args:expr),*) ),* $(,)? }) => {
+    (# $shared:ident [$($op:ident),* $(,)?] $name:ident { $($case:ident ($($args:expr),*) ),* $(,)? }) => {
 
         paste::paste! {
             #[derive(Clone, Debug)]
@@ -243,17 +294,17 @@ macro_rules! impl_op_gadget {
                             [<$case:snake>],
                         )*
                     ];
+                    // Add common expressions to all cases
+                    let cb = utils::common_cases::[<require_opcode_in_ $shared>](
+                        state_curr.opcode.expr(),
+                        vec![$(OpcodeId::$op.expr()),*],
+                    );
+                    utils::batch_add_expressions(
+                        cases,
+                        cb.expressions,
+                        cb.lookups,
+                    )
                 }
-                // Add common expressions to all cases
-                let mut cb = ConstraintBuilder::default();
-                cb.require_in_set(
-                    state_curr.opcode.expr(),
-                    vec![$(OpcodeId::$op.expr()),*],
-                );
-                utils::batch_add_expressions(
-                    cases,
-                    cb.expressions,
-                )
             }
 
             paste::paste! {

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/common_cases.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/common_cases.rs
@@ -4,7 +4,7 @@ use super::super::{
 };
 use super::constraint_builder::ConstraintBuilder;
 use crate::util::Expr;
-use halo2::plonk::Error;
+use halo2::plonk::{Error, Expression};
 use halo2::{arithmetic::FieldExt, circuit::Region};
 
 pub const STACK_START_IDX: usize = 1024;
@@ -121,6 +121,67 @@ impl<F: FieldExt> StackUnderflowCase<F> {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct RangeStackUnderflowCase<F> {
+    case_selector: Cell<F>,
+    start_op: u64,
+    range: u64,
+}
+
+impl<F: FieldExt> RangeStackUnderflowCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::StackUnderflow,
+        num_word: 0,
+        num_cell: 0,
+        will_halt: true,
+    };
+
+    pub(crate) fn construct(
+        alloc: &mut CaseAllocation<F>,
+        start_op: u64,
+        range: u64,
+    ) -> Self {
+        Self {
+            case_selector: alloc.selector.clone(),
+            start_op,
+            range,
+        }
+    }
+
+    pub(crate) fn constraint(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        _state_next: &OpExecutionState<F>,
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
+
+        // The stack index we have to peek, deduced from the opcode and `start_op`
+        let stack_offset = state_curr.opcode.expr() - self.start_op.expr();
+
+        // Stack underflow when
+        //  `STACK_START_IDX <= state_curr.stack_pointer.expr() + stack_offset < STACK_START_IDX + range`
+        cb.require_in_range(
+            state_curr.stack_pointer.expr() + stack_offset
+                - STACK_START_IDX.expr(),
+            self.range,
+        );
+
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
+    }
+
+    pub(crate) fn assign(
+        &self,
+        _region: &mut Region<'_, F>,
+        _offset: usize,
+        _state: &mut CoreStateInstance,
+        _step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct StackOverflowCase<F> {
     case_selector: Cell<F>,
     num_pushed: usize,
@@ -165,4 +226,23 @@ impl<F: FieldExt> StackOverflowCase<F> {
     ) -> Result<(), Error> {
         Ok(())
     }
+}
+
+pub(crate) fn require_opcode_in_set<F: FieldExt>(
+    value: Expression<F>,
+    set: Vec<Expression<F>>,
+) -> ConstraintBuilder<F> {
+    let mut cb = ConstraintBuilder::default();
+    cb.require_in_set(value, set);
+    cb
+}
+
+pub(crate) fn require_opcode_in_range<F: FieldExt>(
+    value: Expression<F>,
+    set: Vec<Expression<F>>,
+) -> ConstraintBuilder<F> {
+    assert!(!set.is_empty());
+    let mut cb = ConstraintBuilder::default();
+    cb.require_in_range(value - set[0].clone(), set.len() as u64);
+    cb
 }

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
@@ -1,6 +1,7 @@
 use super::super::utils;
 use super::super::CaseAllocation;
 use super::super::Cell;
+use super::{from_bytes, get_range};
 use crate::evm_circuit::param::MAX_BYTES_FIELD;
 use crate::util::Expr;
 use array_init::array_init;
@@ -113,7 +114,7 @@ impl<F: FieldExt, const NUM_BYTES: usize> LtGadget<F, NUM_BYTES> {
         Self {
             lt: alloc.cells.pop().unwrap(),
             diff: array_init(|_| alloc.cells.pop().unwrap()),
-            range: utils::get_range(NUM_BYTES * 8),
+            range: get_range(NUM_BYTES * 8),
         }
     }
 
@@ -123,7 +124,7 @@ impl<F: FieldExt, const NUM_BYTES: usize> LtGadget<F, NUM_BYTES> {
         lhs: Expression<F>,
         rhs: Expression<F>,
     ) -> Expression<F> {
-        let diff = utils::from_bytes::expr(self.diff.to_vec());
+        let diff = from_bytes::expr(self.diff.to_vec());
         // The equation we require to hold: `lhs - rhs == diff - (lt * range)`.
         cb.require_equal(lhs - rhs, diff - (self.lt.expr() * self.range));
 

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
@@ -229,3 +229,58 @@ impl<F: FieldExt, const NUM_BYTES: usize> ComparisonGadget<F, NUM_BYTES> {
         Ok((lt, eq))
     }
 }
+
+/// Returns (is_a, is_b):
+/// - `is_a` is `1` when `value == a`, else `0`
+/// - `is_b` is `1` when `value == b`, else `0`
+/// `value` is required to be either `a` or `b`.
+/// The benefit of this gadget over `IsEqualGadget` is that the
+/// expression returned is a single value which will make
+/// future expressions depending on this result more efficient.
+#[derive(Clone, Debug)]
+pub struct PairSelectGadget<F> {
+    pub(crate) is_a: Cell<F>,
+}
+
+impl<F: FieldExt> PairSelectGadget<F> {
+    pub const NUM_CELLS: usize = 1;
+    pub const NUM_WORDS: usize = 0;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            is_a: alloc.cells.pop().unwrap(),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        value: Expression<F>,
+        a: Expression<F>,
+        b: Expression<F>,
+    ) -> (Expression<F>, Expression<F>) {
+        let is_b = 1.expr() - self.is_a.expr();
+        // `is_a` needs to be boolean
+        cb.require_boolean(self.is_a.expr());
+        // Force `is_a` to be `0` when `value != a`
+        cb.add_expression(self.is_a.expr() * (value.clone() - a));
+        // Force `1 - is_a` to be `0` when `value != b`
+        cb.add_expression(is_b.clone() * (value - b));
+
+        (self.is_a.expr(), is_b)
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        value: F,
+        a: F,
+        _b: F,
+    ) -> Result<(F, F), Error> {
+        let is_a = if value == a { F::one() } else { F::zero() };
+        self.is_a.assign(region, offset, Some(is_a))?;
+
+        Ok((is_a, F::one() - is_a))
+    }
+}


### PR DESCRIPTION
Updated all opcodes implementations to use all the utilities we currently have available that did not already do so. Unfortunately this makes for a large diff but better earlier than later I think. The comparator gadget was already updated in #120 so did not update it again here.

All implementations should be identical to the previous version. If you find a change it's very likely I made a mistake in the conversion. I did do a small change in `push.rs` lines 75..91 because I think there was an issue there (did not check the MSB selector) but maybe I misunderstood something.