### PR TITLE
ADD opcode implementation

### DIFF
--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -38,8 +38,6 @@ pub enum Error {
     WordToMemAddr,
     /// Error while generating a trace.
     TracingError,
-    /// Error while adding EvmWord
-    EvmWordAddingOverflow,
 }
 
 impl Display for Error {

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
     WordToMemAddr,
     /// Error while generating a trace.
     TracingError,
+    /// Error while adding EvmWord
+    EvmWordAddingOverflow,
 }
 
 impl Display for Error {

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -372,34 +372,36 @@ mod evm_tests {
     }
 
     #[test]
-    fn evmword_from_str() -> Result<(), Error> {
+    fn evmword_from_str() {
         let word_str =
             "000000000000000000000000000000000000000000000000000c849c24f39248";
 
         let word_from_u128 = EvmWord::from(3523505890234952u128);
-        let word_from_str = EvmWord::from_str(word_str)?;
+        let word_from_str = EvmWord::from_str(word_str).unwrap();
 
         assert_eq!(word_from_u128, word_from_str);
-        Ok(())
     }
 
     #[test]
-    fn evmword_add() -> Result<(), Error> {
-        let a = EvmWord::from_str("deadbeef")?;
-        let b = EvmWord::from_str("faceb00c")?;
-        let c = a.add(b);
+    fn evmword_add() {
+        // Test add
+        let a = EvmWord::from_str("deadbeef").unwrap();
+        let b = EvmWord::from_str("faceb00c").unwrap();
         assert_eq!(
-            c.unwrap().to_hex(),
+            a.add(b).unwrap().to_hex(),
             "00000000000000000000000000000000000000000000000000000001d97c6efb"
         );
-        let a = EvmWord::from_str(
+
+        // Test add Error
+        let c = EvmWord::from_str(
             "8000000000000000000000000000000000000000000000000000000000000000",
-        )?;
-        let b = EvmWord::from_str(
+        )
+        .unwrap();
+        let d = EvmWord::from_str(
             "8000000000000000000000000000000000000000000000000000000000000000",
-        )?;
-        assert!(a.add(b).is_err());
-        Ok(())
+        )
+        .unwrap();
+        assert_eq!(&format!("{:?}", c.add(d)), "Err(EvmWordAddingOverflow)");
     }
 
     #[test]

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -372,36 +372,36 @@ mod evm_tests {
     }
 
     #[test]
-    fn evmword_from_str() {
+    fn evmword_from_str() -> Result<(), Error> {
         let word_str =
             "000000000000000000000000000000000000000000000000000c849c24f39248";
 
         let word_from_u128 = EvmWord::from(3523505890234952u128);
-        let word_from_str = EvmWord::from_str(word_str).unwrap();
+        let word_from_str = EvmWord::from_str(word_str)?;
 
         assert_eq!(word_from_u128, word_from_str);
+        Ok(())
     }
 
     #[test]
-    fn evmword_add() {
+    fn evmword_add() -> Result<(), Error> {
         // Test add
-        let a = EvmWord::from_str("deadbeef").unwrap();
-        let b = EvmWord::from_str("faceb00c").unwrap();
+        let a = EvmWord::from_str("deadbeef")?;
+        let b = EvmWord::from_str("faceb00c")?;
         assert_eq!(
-            a.adc(b).unwrap().to_hex(),
+            a.adc(b)?.to_hex(),
             "00000000000000000000000000000000000000000000000000000001d97c6efb"
         );
 
         // Test add Error
         let c = EvmWord::from_str(
             "8000000000000000000000000000000000000000000000000000000000000000",
-        )
-        .unwrap();
+        )?;
         let d = EvmWord::from_str(
             "8000000000000000000000000000000000000000000000000000000000000000",
-        )
-        .unwrap();
+        )?;
         assert_eq!(&format!("{:?}", c.adc(d)), "Err(EvmWordAddingOverflow)");
+        Ok(())
     }
 
     #[test]
@@ -450,6 +450,6 @@ mod evm_tests {
                 .unwrap()
                 .to_word(),
             EvmWord::from(1u32),
-        )
+        );
     }
 }

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -200,7 +200,7 @@ impl EvmWord {
     }
 
     /// Returns an added `EvmWord`
-    pub fn add(self, number: EvmWord) -> Result<EvmWord, Error> {
+    pub fn adc(self, number: EvmWord) -> Result<EvmWord, Error> {
         let u8_max = u8::MAX as u16;
         let mut result = EvmWord::default();
         let mut carry = 0;
@@ -388,7 +388,7 @@ mod evm_tests {
         let a = EvmWord::from_str("deadbeef").unwrap();
         let b = EvmWord::from_str("faceb00c").unwrap();
         assert_eq!(
-            a.add(b).unwrap().to_hex(),
+            a.adc(b).unwrap().to_hex(),
             "00000000000000000000000000000000000000000000000000000001d97c6efb"
         );
 
@@ -401,7 +401,7 @@ mod evm_tests {
             "8000000000000000000000000000000000000000000000000000000000000000",
         )
         .unwrap();
-        assert_eq!(&format!("{:?}", c.add(d)), "Err(EvmWordAddingOverflow)");
+        assert_eq!(&format!("{:?}", c.adc(d)), "Err(EvmWordAddingOverflow)");
     }
 
     #[test]

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -1,4 +1,5 @@
 //! Definition of each opcode of the EVM.
+mod add;
 pub mod ids;
 mod mload;
 mod push;
@@ -9,6 +10,7 @@ use crate::{
     exec_trace::{ExecutionStep, TraceContext},
     Error,
 };
+use add::Add;
 use core::fmt::Debug;
 use ids::OpcodeId;
 use mload::Mload;
@@ -56,6 +58,9 @@ impl Opcode for OpcodeId {
             }
             OpcodeId::STOP => {
                 Stop {}.gen_associated_ops(ctx, exec_step, next_steps)
+            }
+            OpcodeId::ADD => {
+                Add {}.gen_associated_ops(ctx, exec_step, next_steps)
             }
             _ => unimplemented!(),
         }

--- a/bus-mapping/src/evm/opcodes/add.rs
+++ b/bus-mapping/src/evm/opcodes/add.rs
@@ -1,0 +1,203 @@
+use super::Opcode;
+use crate::{
+    exec_trace::{ExecutionStep, TraceContext},
+    operation::{StackOp, RW},
+    Error,
+};
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Add;
+
+impl Opcode for Add {
+    fn gen_associated_ops(
+        &self,
+        ctx: &mut TraceContext,
+        exec_step: &mut ExecutionStep,
+        next_steps: &[ExecutionStep],
+    ) -> Result<(), Error> {
+        //
+        // First stack read
+        //
+        let stack_last_value_read = exec_step
+            .stack()
+            .last()
+            .cloned()
+            .ok_or(Error::InvalidStackPointer)?;
+        let stack_last_position = exec_step.stack().last_filled();
+
+        // Manage first stack read at latest stack position
+        ctx.push_op(
+            exec_step,
+            StackOp::new(RW::READ, stack_last_position, stack_last_value_read),
+        );
+
+        //
+        // Second stack read
+        //
+        let stack_second_last_value_read = exec_step
+            .stack()
+            .second_last()
+            .cloned()
+            .ok_or(Error::InvalidStackPointer)?;
+        let stack_second_last_position = exec_step.stack().second_last_filled();
+
+        // Manage second stack read at second latest stack position
+        ctx.push_op(
+            exec_step,
+            StackOp::new(
+                RW::READ,
+                stack_second_last_position,
+                stack_second_last_value_read,
+            ),
+        );
+
+        //
+        // First plus second stack value write
+        //
+
+        let added_value = stack_last_value_read
+            .add(stack_second_last_value_read)
+            .unwrap();
+
+        // Manage second stack read at second latest stack position
+        ctx.push_op(
+            exec_step,
+            StackOp::new(RW::WRITE, stack_second_last_position, added_value),
+        );
+
+        exec_step.mut_stack().pop();
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod add_tests {
+    use super::*;
+    use crate::{
+        bytecode,
+        evm::{EvmWord, GasCost, OpcodeId, Stack, StackAddress, Storage},
+        external_tracer, BlockConstants, ExecutionTrace,
+    };
+    use pasta_curves::pallas::Scalar;
+
+    #[test]
+    fn add_opcode_impl() -> Result<(), Error> {
+        let code = bytecode! {
+            #[start]
+            PUSH1(0x80u64)
+            PUSH1(0x80u64)
+            ADD
+            STOP
+        };
+
+        let block_ctants = BlockConstants::default();
+
+        // Get the execution steps from the external tracer
+        let obtained_steps = &external_tracer::trace(&block_ctants, &code)?
+            [code.get_pos("start")..];
+
+        // Obtained trace computation
+        let obtained_exec_trace = ExecutionTrace::<Scalar>::new(
+            obtained_steps.to_vec(),
+            block_ctants,
+        )?;
+
+        let mut ctx = TraceContext::new();
+
+        // The memory is the same in both steps as none of them edits the
+        // memory of the EVM.
+        let mem_map = obtained_steps[0].memory.clone();
+
+        // Generate Step1 corresponding to PUSH1 80
+        let mut step_1 = ExecutionStep {
+            memory: mem_map.clone(),
+            stack: Stack::empty(),
+            storage: Storage::empty(),
+            instruction: OpcodeId::PUSH1,
+            gas: obtained_steps[0].gas(),
+            gas_cost: GasCost::FASTEST,
+            depth: 1u8,
+            pc: obtained_steps[0].pc(),
+            gc: ctx.gc,
+            bus_mapping_instance: vec![],
+        };
+
+        // Add StackOp associated to the 0x80 push at the latest Stack pos.
+        ctx.push_op(
+            &mut step_1,
+            StackOp::new(
+                RW::WRITE,
+                StackAddress::from(1023),
+                EvmWord::from(0x80u8),
+            ),
+        );
+
+        // Generate Step2 corresponding to PUSH1 80
+        let mut step_2 = ExecutionStep {
+            memory: mem_map.clone(),
+            stack: Stack(vec![EvmWord::from(0x80u8)]),
+            storage: Storage::empty(),
+            instruction: OpcodeId::PUSH1,
+            gas: obtained_steps[1].gas(),
+            gas_cost: GasCost::FASTEST,
+            depth: 1u8,
+            pc: obtained_steps[1].pc(),
+            gc: ctx.gc,
+            bus_mapping_instance: vec![],
+        };
+
+        // Add StackOp associated to the 0x80 push at the latest Stack pos.
+        ctx.push_op(
+            &mut step_2,
+            StackOp::new(
+                RW::WRITE,
+                StackAddress::from(1022),
+                EvmWord::from(0x80u8),
+            ),
+        );
+
+        // Generate Step3 corresponding to ADD
+        let mut step_3 = ExecutionStep {
+            memory: mem_map.clone(),
+            stack: Stack::empty(),
+            storage: Storage::empty(),
+            instruction: OpcodeId::ADD,
+            gas: obtained_steps[0].gas(),
+            gas_cost: GasCost::FASTEST,
+            depth: 1u8,
+            pc: obtained_steps[0].pc(),
+            gc: ctx.gc,
+            bus_mapping_instance: vec![],
+        };
+
+        // Add StackOp associated to the 0x80 push at the latest Stack pos.
+        ctx.push_op(
+            &mut step_3,
+            StackOp::new(
+                RW::WRITE,
+                StackAddress::from(1023),
+                EvmWord([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                ]),
+            ),
+        );
+
+        // Compare first step bus mapping instance
+        assert_eq!(
+            obtained_exec_trace[0].bus_mapping_instance(),
+            step_1.bus_mapping_instance()
+        );
+        // println!("{:?}", obtained_exec_trace);
+        // Compare first step entirely
+        assert_eq!(obtained_exec_trace[0], step_1);
+        assert_eq!(obtained_exec_trace[1], step_2);
+        // assert_eq!(obtained_exec_trace[2], step_3);
+
+        // Compare containers
+        // assert_eq!(obtained_exec_trace.ctx.container, ctx.container);
+
+        Ok(())
+    }
+}

--- a/bus-mapping/src/evm/opcodes/add.rs
+++ b/bus-mapping/src/evm/opcodes/add.rs
@@ -59,13 +59,13 @@ impl Opcode for Add {
             .add(stack_second_last_value_read)
             .unwrap();
 
-        exec_step.mut_stack().add();
-
         // Manage second stack read at second latest stack position
         ctx.push_op(
             exec_step,
             StackOp::new(RW::WRITE, stack_second_last_position, sum),
         );
+
+        exec_step.mut_stack().add();
 
         Ok(())
     }
@@ -174,6 +174,32 @@ mod add_tests {
             bus_mapping_instance: vec![],
         };
 
+        // Manage first stack read at latest stack position
+        ctx.push_op(
+            &mut step_3,
+            StackOp::new(
+                RW::READ,
+                StackAddress::from(1022),
+                EvmWord([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128,
+                ]),
+            ),
+        );
+
+        // Manage second stack read at second latest stack position
+        ctx.push_op(
+            &mut step_3,
+            StackOp::new(
+                RW::READ,
+                StackAddress::from(1023),
+                EvmWord([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128,
+                ]),
+            ),
+        );
+
         // Add StackOp associated to the 0x80 push at the latest Stack pos.
         ctx.push_op(
             &mut step_3,
@@ -199,7 +225,7 @@ mod add_tests {
         assert_eq!(obtained_exec_trace[2], step_3);
 
         // Compare containers
-        // assert_eq!(obtained_exec_trace.ctx.container, ctx.container);
+        assert_eq!(obtained_exec_trace.ctx.container, ctx.container);
 
         Ok(())
     }

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -2,7 +2,6 @@
 use crate::evm::EvmWord;
 use crate::Error;
 use core::str::FromStr;
-
 /// Represents a `StackAddress` of the EVM.
 /// The address range goes `TOP -> DOWN (1024, 0]`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -85,8 +84,23 @@ impl Stack {
         StackAddress::from(1024 - self.0.len())
     }
 
+    /// Returns the second last filled `StackAddress`.
+    pub fn second_last_filled(&self) -> StackAddress {
+        StackAddress::from(1024 - self.0.len() - 1)
+    }
+
     /// Returns the last [`EvmWord`] allocated in the `Stack`.
     pub fn last(&self) -> Option<&EvmWord> {
         self.0.last()
+    }
+
+    /// Returns the second last [`EvmWord`] allocated in the `Stack`.
+    pub fn second_last(&self) -> Option<&EvmWord> {
+        self.0.get(self.0.len() - 1)
+    }
+
+    /// Pop the last [`EvmWord`] allocated in the `Stack`.
+    pub fn pop(&mut self) -> Option<EvmWord> {
+        self.0.pop()
     }
 }

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -101,8 +101,12 @@ impl Stack {
 mod stack_tests {
     use super::*;
 
-    macro_rules! test_vec {
-        ($($x:expr),*) => (Stack::new(vec![ $(EvmWord::from_str($x).unwrap()), *]))
+    fn setup_stack(stack_value: [&str; 3]) -> Stack {
+        Stack::new(vec![
+            EvmWord::from_str(stack_value[0]).unwrap(),
+            EvmWord::from_str(stack_value[1]).unwrap(),
+            EvmWord::from_str(stack_value[2]).unwrap(),
+        ])
     }
 
     #[test]
@@ -118,7 +122,7 @@ mod stack_tests {
 
     #[test]
     fn stack_pointer() -> Result<(), Error> {
-        let stack = test_vec!("0x15", "0x16", "0x17");
+        let stack = setup_stack(["0x15", "0x16", "0x17"]);
 
         assert_eq!(stack.stack_pointer(), StackAddress::from(1020));
         assert_eq!(stack.last_filled(), StackAddress::from(1021));
@@ -128,7 +132,7 @@ mod stack_tests {
 
     #[test]
     fn stack_get_value() -> Result<(), Error> {
-        let stack = test_vec!("0x15", "0x16", "0x17");
+        let stack = setup_stack(["0x15", "0x16", "0x17"]);
 
         assert_eq!(stack.last().unwrap(), &EvmWord::from_str("0x17")?);
         assert_eq!(stack.nth_last(1).unwrap(), &EvmWord::from_str("0x16")?);

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -100,7 +100,7 @@ impl Stack {
         let length = self.0.len();
         let last_value = self.0.last().unwrap();
         let second_last_value = self.0.get(self.0.len() - 2).unwrap();
-        let sum = last_value.add(*second_last_value).unwrap();
+        let sum = last_value.adc(*second_last_value).unwrap();
         self.0[length - 2] = sum;
         self.pop()
     }

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -101,8 +101,8 @@ impl Stack {
         let last_value = self.0.last().unwrap();
         let second_last_value = self.0.get(self.0.len() - 2).unwrap();
         let sum = last_value.add(*second_last_value).unwrap();
-        self.0[length - 1] = sum;
-        self.0.pop()
+        self.0[length - 2] = sum;
+        self.pop()
     }
 
     /// Pop the last [`EvmWord`] allocated in the `Stack`.

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -2,6 +2,7 @@
 use crate::evm::EvmWord;
 use crate::Error;
 use core::str::FromStr;
+
 /// Represents a `StackAddress` of the EVM.
 /// The address range goes `TOP -> DOWN (1024, 0]`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -94,21 +95,6 @@ impl Stack {
     pub fn nth_last(&self, nth: usize) -> Option<&EvmWord> {
         self.0.get(self.0.len() - (nth + 1))
     }
-
-    /// Add last and second last value, and store on second last address and delete last element in the `Stack`.
-    pub fn add(&mut self) -> Option<EvmWord> {
-        let length = self.0.len();
-        let last_value = self.0.last().unwrap();
-        let second_last_value = self.0.get(self.0.len() - 2).unwrap();
-        let sum = last_value.adc(*second_last_value).unwrap();
-        self.0[length - 2] = sum;
-        self.pop()
-    }
-
-    /// Pop the last [`EvmWord`] allocated in the `Stack`.
-    pub fn pop(&mut self) -> Option<EvmWord> {
-        self.0.pop()
-    }
 }
 
 #[cfg(test)]
@@ -146,16 +132,6 @@ mod stack_tests {
 
         assert_eq!(stack.last().unwrap(), &EvmWord::from_str("0x17")?);
         assert_eq!(stack.nth_last(1).unwrap(), &EvmWord::from_str("0x16")?);
-        Ok(())
-    }
-
-    #[test]
-    fn stack_pop() -> Result<(), Error> {
-        let mut stack = test_vec!("0x15", "0x16", "0x17");
-        stack.pop();
-
-        assert_eq!(stack.last().unwrap(), &EvmWord::from_str("0x16")?);
-        assert_eq!(stack.stack_pointer(), StackAddress::from(1021));
         Ok(())
     }
 }

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -95,6 +95,16 @@ impl Stack {
         self.0.get(self.0.len() - 2)
     }
 
+    /// Add last and second last value, and store on second last address and delete last element in the `Stack`.
+    pub fn add(&mut self) -> Option<EvmWord> {
+        let length = self.0.len();
+        let last_value = self.0.last().unwrap();
+        let second_last_value = self.0.get(self.0.len() - 2).unwrap();
+        let sum = last_value.add(*second_last_value).unwrap();
+        self.0[length - 1] = sum;
+        self.0.pop()
+    }
+
     /// Pop the last [`EvmWord`] allocated in the `Stack`.
     pub fn pop(&mut self) -> Option<EvmWord> {
         self.0.pop()

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -123,7 +123,7 @@ mod stack_tests {
     fn stack_addr_conversion() -> Result<(), Error> {
         let first_usize = 1023usize;
         let addr1 = StackAddress::from(first_usize);
-        let addr2 = StackAddress::from_str("0x3ff").unwrap();
+        let addr2 = StackAddress::from_str("0x3ff")?;
 
         assert_eq!(addr1.0, first_usize);
         assert_eq!(addr2.0, first_usize);
@@ -144,11 +144,8 @@ mod stack_tests {
     fn stack_get_value() -> Result<(), Error> {
         let stack = test_vec!("0x15", "0x16", "0x17");
 
-        assert_eq!(stack.last().unwrap(), &EvmWord::from_str("0x17").unwrap());
-        assert_eq!(
-            stack.nth_last(1).unwrap(),
-            &EvmWord::from_str("0x16").unwrap()
-        );
+        assert_eq!(stack.last().unwrap(), &EvmWord::from_str("0x17")?);
+        assert_eq!(stack.nth_last(1).unwrap(), &EvmWord::from_str("0x16")?);
         Ok(())
     }
 
@@ -157,7 +154,7 @@ mod stack_tests {
         let mut stack = test_vec!("0x15", "0x16", "0x17");
         stack.pop();
 
-        assert_eq!(stack.last().unwrap(), &EvmWord::from_str("0x16").unwrap());
+        assert_eq!(stack.last().unwrap(), &EvmWord::from_str("0x16")?);
         assert_eq!(stack.stack_pointer(), StackAddress::from(1021));
         Ok(())
     }

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -81,8 +81,8 @@ impl Stack {
     }
 
     /// Returns the second last filled `StackAddress`.
-    pub fn second_last_filled(&self) -> StackAddress {
-        StackAddress::from(1025 - self.0.len())
+    pub fn nth_last_filled(&self, nth: usize) -> StackAddress {
+        StackAddress::from(1024 - self.0.len() + nth)
     }
 
     /// Returns the last [`EvmWord`] allocated in the `Stack`.
@@ -91,8 +91,8 @@ impl Stack {
     }
 
     /// Returns the second last [`EvmWord`] allocated in the `Stack`.
-    pub fn second_last(&self) -> Option<&EvmWord> {
-        self.0.get(self.0.len() - 2)
+    pub fn nth_last(&self, nth: usize) -> Option<&EvmWord> {
+        self.0.get(self.0.len() - (nth + 1))
     }
 
     /// Add last and second last value, and store on second last address and delete last element in the `Stack`.
@@ -136,7 +136,7 @@ mod stack_tests {
 
         assert_eq!(stack.stack_pointer(), StackAddress::from(1020));
         assert_eq!(stack.last_filled(), StackAddress::from(1021));
-        assert_eq!(stack.second_last_filled(), StackAddress::from(1022));
+        assert_eq!(stack.nth_last_filled(1), StackAddress::from(1022));
         Ok(())
     }
 
@@ -146,7 +146,7 @@ mod stack_tests {
 
         assert_eq!(stack.last().unwrap(), &EvmWord::from_str("0x17").unwrap());
         assert_eq!(
-            stack.second_last().unwrap(),
+            stack.nth_last(1).unwrap(),
             &EvmWord::from_str("0x16").unwrap()
         );
         Ok(())

--- a/bus-mapping/src/exec_trace/exec_step.rs
+++ b/bus-mapping/src/exec_trace/exec_step.rs
@@ -53,7 +53,7 @@ impl ExecutionStep {
     ) -> Self {
         ExecutionStep {
             memory: Memory::from(memory),
-            stack: Stack::from_vec(stack),
+            stack: Stack::new(stack),
             storage: Storage::from(storage),
             instruction,
             gas,

--- a/bus-mapping/src/exec_trace/exec_step.rs
+++ b/bus-mapping/src/exec_trace/exec_step.rs
@@ -75,11 +75,6 @@ impl ExecutionStep {
         &self.stack
     }
 
-    /// Returns the mut Stack of this `ExecutionStep`.
-    pub fn mut_stack(&mut self) -> &mut Stack {
-        &mut self.stack
-    }
-
     /// Returns the Storage view of this `ExecutionStep`.
     pub const fn storage(&self) -> &Storage {
         &self.storage

--- a/bus-mapping/src/exec_trace/exec_step.rs
+++ b/bus-mapping/src/exec_trace/exec_step.rs
@@ -75,6 +75,11 @@ impl ExecutionStep {
         &self.stack
     }
 
+    /// Returns the mut Stack of this `ExecutionStep`.
+    pub fn mut_stack(&mut self) -> &mut Stack {
+        &mut self.stack
+    }
+
     /// Returns the Storage view of this `ExecutionStep`.
     pub const fn storage(&self) -> &Storage {
         &self.storage

--- a/bus-mapping/src/operation/container.rs
+++ b/bus-mapping/src/operation/container.rs
@@ -81,7 +81,7 @@ impl OperationContainer {
 }
 
 #[cfg(test)]
-mod stack_tests {
+mod container_test {
     use super::*;
 
     use crate::{

--- a/bus-mapping/src/operation/container.rs
+++ b/bus-mapping/src/operation/container.rs
@@ -31,7 +31,7 @@ impl Default for OperationContainer {
 
 // TODO: impl Index for OperationContainer
 impl OperationContainer {
-    /// Generates a enw instance of an `OperationContainer`.
+    /// Generates a new instance of an `OperationContainer`.
     pub fn new() -> Self {
         Self {
             memory: Vec::new(),
@@ -48,11 +48,11 @@ impl OperationContainer {
         match op.op.into_enum() {
             OpEnum::Memory(op) => {
                 self.memory.push(Operation::new(gc, op));
-                OperationRef::from((Target::Memory, self.storage.len()))
+                OperationRef::from((Target::Memory, self.memory.len()))
             }
             OpEnum::Stack(op) => {
                 self.stack.push(Operation::new(gc, op));
-                OperationRef::from((Target::Stack, self.memory.len()))
+                OperationRef::from((Target::Stack, self.stack.len()))
             }
             OpEnum::Storage(op) => {
                 self.storage.push(Operation::new(gc, op));
@@ -77,5 +77,61 @@ impl OperationContainer {
     /// the container.
     pub fn sorted_storage(&self) -> Vec<Operation<StorageOp>> {
         self.storage.iter().sorted().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod stack_tests {
+    use super::*;
+
+    use crate::{
+        evm::{
+            EthAddress, EvmWord, GlobalCounter, MemoryAddress, StackAddress,
+        },
+        operation::RW,
+    };
+
+    #[test]
+    fn operation_container_test() {
+        let mut global_counter = GlobalCounter::default();
+        let mut operation_container = OperationContainer::default();
+        let stack_operation = Operation::new(
+            global_counter.inc_pre(),
+            StackOp::new(
+                RW::WRITE,
+                StackAddress::from(1023),
+                EvmWord([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                ]),
+            ),
+        );
+        let memory_operation = Operation::new(
+            global_counter.inc_pre(),
+            MemoryOp::new(RW::WRITE, MemoryAddress::from(1), 1),
+        );
+        let storage_operation = Operation::new(
+            global_counter.inc_pre(),
+            StorageOp::new(
+                RW::WRITE,
+                EthAddress::zero(),
+                EvmWord::default(),
+                EvmWord([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                ]),
+                EvmWord::default(),
+            ),
+        );
+        let stack_ref = operation_container.insert(stack_operation.clone());
+        let memory_ref = operation_container.insert(memory_operation.clone());
+        let storage_ref = operation_container.insert(storage_operation.clone());
+
+        assert_eq!(operation_container.sorted_stack()[0], stack_operation);
+        assert_eq!(operation_container.sorted_memory()[0], memory_operation);
+        assert_eq!(operation_container.sorted_storage()[0], storage_operation);
+        assert_eq!(stack_ref, OperationRef::from((Target::Stack, 1)));
+        assert_eq!(memory_ref, OperationRef::from((Target::Memory, 1)));
+        assert_eq!(storage_ref, OperationRef::from((Target::Storage, 1)));
     }
 }


### PR DESCRIPTION
Hi @CPerezz 
I implemented ADD opcode.
On the way to implement it, I needed to implement additional feature described following.
I would appreciate you could confirm.

#### EvmWord `add` methods
I implemented the method which adds two `EvmWord`[u8; 32].
To avoid the reserved word, I named as `adc`.
https://github.com/appliedzkp/zkevm-circuits/pull/150/files#diff-7b072fa82d7fe486f5bd38e48d4922a4a77f322846aaa47163cc90f86b3eee64R203

#### `Add` opcode implementation
I implemented opcode ADD.
https://github.com/appliedzkp/zkevm-circuits/pull/150/files#diff-7491c8fa414fd3b75b63f2e66a58d2540e9c8e68b6d0392ff4b95721bcca930aR11

#### Stack `new` method modification
I modified the Stack `new` method according to the doc explanation.
The method was same with `from_vec` method so I deleted.
https://github.com/appliedzkp/zkevm-circuits/pull/150/files#diff-bacdb9dcd2047875810d93a4f556759cd3b84f472a86b304b5c9dea36d984ca1R61

#### Stack `second_last` method
In evm opcode, it often gets second last value and that pointer so I implemented the function which gets second last value and pointer.
https://github.com/appliedzkp/zkevm-circuits/pull/150/files#diff-bacdb9dcd2047875810d93a4f556759cd3b84f472a86b304b5c9dea36d984ca1R84

#### Stack `add` and `pop` operation
I implemented `add` and `pop` operation.
https://github.com/appliedzkp/zkevm-circuits/pull/150/files#diff-bacdb9dcd2047875810d93a4f556759cd3b84f472a86b304b5c9dea36d984ca1R99

#### OperationContainer insert method modification
I modified `OperationContainer` method because of mis implementation.
https://github.com/appliedzkp/zkevm-circuits/pull/150/files#diff-ee61dc5a453c9a1c66bdf948c3bf0ea56d71a0a37134e2b1ef86eb87ac2e1a35R46

Thank you!