### PR TITLE
build gethutils for apple silicon

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.x86_64-apple-darwin]
+[target.'cfg(target_os="macos")']
 rustflags = ["-C", "link-args=-framework CoreFoundation -framework Security"]


### PR DESCRIPTION
### Problem

The command `cargo test -p bus-mapping` failed on Apple M1 with the following error messages

```
  = note: Undefined symbols for architecture arm64:
            "_CFStringCreateWithBytes", referenced from:
                _crypto/x509/internal/macos.x509_CFStringCreateWithBytes_trampoline in libgeth_utils-614fa87fc478fa6f.rlib(go.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This is the same issue as #131's. But the solution in #131 only includes the `x86_64` version of macOS.

### Solution

Apply the config to all macOS