### PR TITLE
Add GethClient and support for minimum required JSON-RPC endpoints by bus-mapping.

### DIFF
--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -16,6 +16,9 @@ hex = "0.4"
 geth-utils = { path = "../geth-utils" }
 web3 = {version = "0.17", default-features = false}
 uint = "0.9.1"
+ethers-providers = "0.5.5"
 
 [dev-dependencies]
+url = "2.2.2"
+tokio = { version = "1.13", features = ["macros"] }
 pretty_assertions = "1.0.0"

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["CPerezz <c.perezbaro@gmail.com>"]
 ff = "0.11"
 pasta_curves = "0.1"
 itertools = "0.10"
-serde = {version = "1.0.127", features = ["derive"] }
+serde = {version = "1.0.130", features = ["derive"] }
 lazy_static = "1.4"
 serde_json = "1.0.66"
 hex = "0.4"

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -1,6 +1,7 @@
 //! Error module for the bus-mapping crate
 
 use core::fmt::{Display, Formatter, Result as FmtResult};
+use ethers_providers::ProviderError;
 use std::error::Error as StdError;
 
 /// Error type for any BusMapping related failure.
@@ -26,6 +27,14 @@ pub enum Error {
     WordToMemAddr,
     /// Error while generating a trace.
     TracingError,
+    /// JSON-RPC related error
+    JSONRpcError(ProviderError),
+}
+
+impl From<ProviderError> for Error {
+    fn from(err: ProviderError) -> Self {
+        Error::JSONRpcError(err)
+    }
 }
 
 impl Display for Error {

--- a/bus-mapping/src/eth_types.rs
+++ b/bus-mapping/src/eth_types.rs
@@ -183,28 +183,19 @@ impl From<GethExecStep> for GethExecStepInternal {
                 .stack
                 .0
                 .iter()
-                .map(|stack_elem| {
-                    DebugU256::from_big_endian(&stack_elem.to_be_bytes())
-                })
+                .map(|stack_elem| DebugU256(stack_elem.0))
                 .collect(),
             memory: step
                 .memory
                 .0
-                .iter()
-                .map(|mem_elem| {
-                    DebugU256::from_big_endian(&mem_elem.to_be_bytes())
-                })
+                .chunks(32)
+                .map(|word| DebugU256::from_big_endian(word))
                 .collect(),
             storage: step
                 .storage
                 .0
                 .iter()
-                .map(|(k, v)| {
-                    (
-                        DebugU256::from_big_endian(&k.to_be_bytes()),
-                        DebugU256::from_big_endian(&v.to_be_bytes()),
-                    )
-                })
+                .map(|(k, v)| (DebugU256(k.0), DebugU256(v.0)))
                 .collect(),
         }
     }
@@ -257,13 +248,13 @@ impl<'de> Deserialize<'de> for GethExecStep {
 /// `debug_traceBlockByHash` and `debug_traceBlockByNumber` Geth JSON-RPC calls.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[doc(hidden)]
-pub(crate) struct ResultGethExecTrace(pub(crate) Vec<ResultGethExecStep>);
+pub(crate) struct ResultGethExecTraces(pub(crate) Vec<ResultGethExecTrace>);
 
 /// Helper type built to deal with the weird `result` field added between `GethExecutionTrace`s in
 /// `debug_traceBlockByHash` and `debug_traceBlockByNumber` Geth JSON-RPC calls.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[doc(hidden)]
-pub(crate) struct ResultGethExecStep {
+pub(crate) struct ResultGethExecTrace {
     pub(crate) result: GethExecTrace,
 }
 

--- a/bus-mapping/src/eth_types.rs
+++ b/bus-mapping/src/eth_types.rs
@@ -253,6 +253,20 @@ impl<'de> Deserialize<'de> for GethExecStep {
     }
 }
 
+/// Helper type built to deal with the weird `result` field added between `GethExecutionTrace`s in
+/// `debug_traceBlockByHash` and `debug_traceBlockByNumber` Geth JSON-RPC calls.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[doc(hidden)]
+pub(crate) struct ResultGethExecTrace(pub(crate) Vec<ResultGethExecStep>);
+
+/// Helper type built to deal with the weird `result` field added between `GethExecutionTrace`s in
+/// `debug_traceBlockByHash` and `debug_traceBlockByNumber` Geth JSON-RPC calls.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[doc(hidden)]
+pub(crate) struct ResultGethExecStep {
+    pub(crate) result: GethExecTrace,
+}
+
 /// The execution trace type returned by geth RPC debug_trace* methods.  Corresponds to
 /// `ExecutionResult` in `go-ethereum/internal/ethapi/api.go`.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -222,5 +222,6 @@ pub mod circuit_input_builder;
 #[macro_use]
 pub mod eth_types;
 pub mod mock;
+pub mod rpc;
 pub use error::Error;
 pub use exec_trace::BlockConstants;

--- a/bus-mapping/src/rpc.rs
+++ b/bus-mapping/src/rpc.rs
@@ -1,6 +1,6 @@
 //! Module which contains all the RPC calls that are needed at any point to query a Geth node in order to get a Block, Tx or Trace info.
 
-use crate::eth_types::{Block, Hash, Transaction};
+use crate::eth_types::{Block, Hash, Transaction, U64};
 use crate::Error;
 use ethers_providers::JsonRpcClient;
 
@@ -13,6 +13,37 @@ pub fn serialize<T: serde::Serialize>(t: &T) -> serde_json::Value {
     serde_json::to_value(t).expect("Types never fail to serialize.")
 }
 
+/// Struct used to define the input that you want to provide to the `eth_getBlockByNumber` call as it mixes numbers with string literals.
+#[derive(Debug)]
+pub enum BlockNumber {
+    /// Specific block number
+    Num(U64),
+    /// Earliest block
+    Earliest,
+    /// Latest block
+    Latest,
+    /// Pending block
+    Pending,
+}
+
+impl From<u64> for BlockNumber {
+    fn from(num: u64) -> Self {
+        BlockNumber::Num(U64::from(num))
+    }
+}
+
+impl BlockNumber {
+    /// Serializes a BlockNumber as a [`Value`](serde_json::Value) to be able to throw it into a JSON-RPC request.
+    pub fn serialize(self) -> serde_json::Value {
+        match self {
+            BlockNumber::Num(num) => serialize(&num),
+            BlockNumber::Earliest => serialize(&"earliest"),
+            BlockNumber::Latest => serialize(&"latest"),
+            BlockNumber::Pending => serialize(&"pending"),
+        }
+    }
+}
+
 /// Placeholder structure designed to contain the methods that the BusMapping needs in order to enable Geth queries.
 pub struct GethClient<P: JsonRpcClient>(P);
 
@@ -22,7 +53,7 @@ impl<P: JsonRpcClient> GethClient<P> {
         Self(provider)
     }
 
-    /// Calls `eth_getBlockByHash` via JSON-RPC returning a [`Block`] returning only the list of tx_hashes involved on it.
+    /// Calls `eth_getBlockByHash` via JSON-RPC returning a [`Block`] returning all the block information including it's transaction's details.
     pub async fn get_block_by_hash(
         &self,
         hash: Hash,
@@ -31,6 +62,19 @@ impl<P: JsonRpcClient> GethClient<P> {
         let flag = serialize(&true);
         self.0
             .request("eth_getBlockByHash", [hash, flag])
+            .await
+            .map_err(|e| Error::JSONRpcError(e.into()))
+    }
+
+    /// Calls `eth_getBlockByNumber` via JSON-RPC returning a [`Block`] returning all the block information including it's transaction's details.
+    pub async fn get_block_by_number(
+        &self,
+        block_num: BlockNumber,
+    ) -> Result<Block<Transaction>, Error> {
+        let num = block_num.serialize();
+        let flag = serialize(&true);
+        self.0
+            .request("eth_getBlockByNumber", [num, flag])
             .await
             .map_err(|e| Error::JSONRpcError(e.into()))
     }
@@ -45,14 +89,33 @@ mod rpc_tests {
 
     // The test is ignored as the values used depend on the Geth instance used each time you run the tests.
     // And we can't assume that everyone will have a Geth client synced with mainnet to have unified "test-vectors".
-    #[ignore]
+    //#[ignore]
     #[tokio::test]
     async fn test_get_block_by_hash() {
         let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
 
-        let hash = Hash::from_str("0x60d58d0e417b2b7fab8c74a5efc8292cb5651cd056caad126fb308523b40abc2").unwrap();
+        let hash = Hash::from_str("0x0492a44be5a74a6724bd666d308498c7a830a498f2c574768cbb25d09b4ec948").unwrap();
         let prov = GethClient::new(transport);
-        let block = prov.get_block_by_hash(hash).await.unwrap();
-        assert!(hash == block.transactions[0].hash)
+        let block_by_hash = prov.get_block_by_hash(hash).await.unwrap();
+        assert!(hash == block_by_hash.hash.unwrap());
+    }
+
+    // The test is ignored as the values used depend on the Geth instance used each time you run the tests.
+    // And we can't assume that everyone will have a Geth client synced with mainnet to have unified "test-vectors".
+    //#[ignore]
+    #[tokio::test]
+    async fn test_get_block_by_number() {
+        let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
+
+        let hash = Hash::from_str("0x0492a44be5a74a6724bd666d308498c7a830a498f2c574768cbb25d09b4ec948").unwrap();
+        let prov = GethClient::new(transport);
+        let block_by_num_latest =
+            prov.get_block_by_number(BlockNumber::Latest).await.unwrap();
+        assert!(hash == block_by_num_latest.hash.unwrap());
+        let block_by_num = prov.get_block_by_number(1u64.into()).await.unwrap();
+        assert!(
+            block_by_num.transactions[0].hash
+                == block_by_num_latest.transactions[0].hash
+        );
     }
 }

--- a/bus-mapping/src/rpc.rs
+++ b/bus-mapping/src/rpc.rs
@@ -1,7 +1,7 @@
 //! Module which contains all the RPC calls that are needed at any point to query a Geth node in order to get a Block, Tx or Trace info.
 
 use crate::eth_types::{
-    Block, GethExecTrace, Hash, ResultGethExecTrace, Transaction, U64,
+    Block, GethExecTrace, Hash, ResultGethExecTraces, Transaction, U64,
 };
 use crate::Error;
 use ethers_providers::JsonRpcClient;
@@ -87,7 +87,7 @@ impl<P: JsonRpcClient> GethClient<P> {
         hash: Hash,
     ) -> Result<Vec<GethExecTrace>, Error> {
         let hash = serialize(&hash);
-        let resp: ResultGethExecTrace = self
+        let resp: ResultGethExecTraces = self
             .0
             .request("debug_traceBlockByHash", [hash])
             .await
@@ -101,7 +101,7 @@ impl<P: JsonRpcClient> GethClient<P> {
         block_num: BlockNumber,
     ) -> Result<Vec<GethExecTrace>, Error> {
         let num = block_num.serialize();
-        let resp: ResultGethExecTrace = self
+        let resp: ResultGethExecTraces = self
             .0
             .request("debug_traceBlockByNumber", [num])
             .await

--- a/bus-mapping/src/rpc.rs
+++ b/bus-mapping/src/rpc.rs
@@ -1,0 +1,58 @@
+//! Module which contains all the RPC calls that are needed at any point to query a Geth node in order to get a Block, Tx or Trace info.
+
+use crate::eth_types::{Block, Hash, Transaction};
+use crate::Error;
+use ethers_providers::JsonRpcClient;
+
+/// Serialize a type.
+///
+/// # Panics
+///
+/// If the type returns an error during serialization.
+pub fn serialize<T: serde::Serialize>(t: &T) -> serde_json::Value {
+    serde_json::to_value(t).expect("Types never fail to serialize.")
+}
+
+/// Placeholder structure designed to contain the methods that the BusMapping needs in order to enable Geth queries.
+pub struct GethQueries<P: JsonRpcClient>(P);
+
+impl<P: JsonRpcClient> GethQueries<P> {
+    /// Generates a new GethQueriesProvider instance.
+    pub fn new(provider: P) -> Self {
+        Self(provider)
+    }
+
+    /// Calls `eth_getBlockByHash` via JSON-RPC returning a [`Block`] returning only the list of tx_hashes involved on it.
+    pub async fn get_block_by_hash(
+        &self,
+        hash: Hash,
+    ) -> Result<Block<Transaction>, Error> {
+        let hash = serialize(&hash);
+        let flag = serialize(&true);
+        self.0
+            .request("eth_getBlockByHash", [hash, flag])
+            .await
+            .map_err(|e| Error::JSONRpcError(e.into()))
+    }
+}
+
+#[cfg(test)]
+mod rpc_tests {
+    use super::*;
+    use ethers_providers::Http;
+    use std::str::FromStr;
+    use url::Url;
+
+    // The test is ignored as the values used depend on the Geth instance used each time you run the tests.
+    // And we can't assume that everyone will have a Geth client synced with mainnet to have unified "test-vectors".
+    #[ignore]
+    #[tokio::test]
+    async fn test_get_block_by_hash() {
+        let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
+
+        let hash = Hash::from_str("0x60d58d0e417b2b7fab8c74a5efc8292cb5651cd056caad126fb308523b40abc2").unwrap();
+        let prov = GethQueries::new(transport);
+        let block = prov.get_block_by_hash(hash).await.unwrap();
+        assert!(hash == block.transactions[0].hash)
+    }
+}

--- a/bus-mapping/src/rpc.rs
+++ b/bus-mapping/src/rpc.rs
@@ -1,6 +1,8 @@
 //! Module which contains all the RPC calls that are needed at any point to query a Geth node in order to get a Block, Tx or Trace info.
 
-use crate::eth_types::{Block, Hash, Transaction, U64};
+use crate::eth_types::{
+    Block, GethExecTrace, Hash, ResultGethExecTrace, Transaction, U64,
+};
 use crate::Error;
 use ethers_providers::JsonRpcClient;
 
@@ -78,6 +80,34 @@ impl<P: JsonRpcClient> GethClient<P> {
             .await
             .map_err(|e| Error::JSONRpcError(e.into()))
     }
+
+    /// Calls `debug_traceBlockByHash` via JSON-RPC returning a [`Vec<GethExecTrace>`] with each GethTrace corresponding to 1 transaction of the block.
+    pub async fn trace_block_by_hash(
+        &self,
+        hash: Hash,
+    ) -> Result<Vec<GethExecTrace>, Error> {
+        let hash = serialize(&hash);
+        let resp: ResultGethExecTrace = self
+            .0
+            .request("debug_traceBlockByHash", [hash])
+            .await
+            .map_err(|e| Error::JSONRpcError(e.into()))?;
+        Ok(resp.0.into_iter().map(|step| step.result).collect())
+    }
+
+    /// Calls `debug_traceBlockByNumber` via JSON-RPC returning a [`Vec<GethExecTrace>`] with each GethTrace corresponding to 1 transaction of the block.
+    pub async fn trace_block_by_number(
+        &self,
+        block_num: BlockNumber,
+    ) -> Result<Vec<GethExecTrace>, Error> {
+        let num = block_num.serialize();
+        let resp: ResultGethExecTrace = self
+            .0
+            .request("debug_traceBlockByNumber", [num])
+            .await
+            .map_err(|e| Error::JSONRpcError(e.into()))?;
+        Ok(resp.0.into_iter().map(|step| step.result).collect())
+    }
 }
 
 #[cfg(test)]
@@ -89,12 +119,12 @@ mod rpc_tests {
 
     // The test is ignored as the values used depend on the Geth instance used each time you run the tests.
     // And we can't assume that everyone will have a Geth client synced with mainnet to have unified "test-vectors".
-    //#[ignore]
+    #[ignore]
     #[tokio::test]
     async fn test_get_block_by_hash() {
         let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
 
-        let hash = Hash::from_str("0x0492a44be5a74a6724bd666d308498c7a830a498f2c574768cbb25d09b4ec948").unwrap();
+        let hash = Hash::from_str("0xe4f7aa19a76fcf31a6adff3b400300849e39dd84076765fb3af09d05ee9d787a").unwrap();
         let prov = GethClient::new(transport);
         let block_by_hash = prov.get_block_by_hash(hash).await.unwrap();
         assert!(hash == block_by_hash.hash.unwrap());
@@ -102,12 +132,12 @@ mod rpc_tests {
 
     // The test is ignored as the values used depend on the Geth instance used each time you run the tests.
     // And we can't assume that everyone will have a Geth client synced with mainnet to have unified "test-vectors".
-    //#[ignore]
+    #[ignore]
     #[tokio::test]
     async fn test_get_block_by_number() {
         let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
 
-        let hash = Hash::from_str("0x0492a44be5a74a6724bd666d308498c7a830a498f2c574768cbb25d09b4ec948").unwrap();
+        let hash = Hash::from_str("0xe4f7aa19a76fcf31a6adff3b400300849e39dd84076765fb3af09d05ee9d787a").unwrap();
         let prov = GethClient::new(transport);
         let block_by_num_latest =
             prov.get_block_by_number(BlockNumber::Latest).await.unwrap();
@@ -117,5 +147,39 @@ mod rpc_tests {
             block_by_num.transactions[0].hash
                 == block_by_num_latest.transactions[0].hash
         );
+    }
+
+    // The test is ignored as the values used depend on the Geth instance used each time you run the tests.
+    // And we can't assume that everyone will have a Geth client synced with mainnet to have unified "test-vectors".
+    #[ignore]
+    #[tokio::test]
+    async fn test_trace_block_by_hash() {
+        let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
+
+        let hash = Hash::from_str("0xe2d191e9f663a3a950519eadeadbd614965b694a65a318a0b8f053f2d14261ff").unwrap();
+        let prov = GethClient::new(transport);
+        let trace_by_hash = prov.trace_block_by_hash(hash).await.unwrap();
+        // Since we called in the test block the same transaction twice the len should be the same and != 0.
+        assert!(
+            trace_by_hash[0].struct_logs.len()
+                == trace_by_hash[1].struct_logs.len()
+        );
+        assert!(trace_by_hash[0].struct_logs.len() != 0);
+    }
+
+    // The test is ignored as the values used depend on the Geth instance used each time you run the tests.
+    // And we can't assume that everyone will have a Geth client synced with mainnet to have unified "test-vectors".
+    //#[ignore]
+    #[tokio::test]
+    async fn test_trace_block_by_number() {
+        let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
+        let prov = GethClient::new(transport);
+        let trace_by_hash = prov.trace_block_by_number(5.into()).await.unwrap();
+        // Since we called in the test block the same transaction twice the len should be the same and != 0.
+        assert!(
+            trace_by_hash[0].struct_logs.len()
+                == trace_by_hash[1].struct_logs.len()
+        );
+        assert!(trace_by_hash[0].struct_logs.len() != 0);
     }
 }

--- a/bus-mapping/src/rpc.rs
+++ b/bus-mapping/src/rpc.rs
@@ -164,12 +164,12 @@ mod rpc_tests {
             trace_by_hash[0].struct_logs.len()
                 == trace_by_hash[1].struct_logs.len()
         );
-        assert!(trace_by_hash[0].struct_logs.len() != 0);
+        assert!(!trace_by_hash[0].struct_logs.is_empty());
     }
 
     // The test is ignored as the values used depend on the Geth instance used each time you run the tests.
     // And we can't assume that everyone will have a Geth client synced with mainnet to have unified "test-vectors".
-    //#[ignore]
+    #[ignore]
     #[tokio::test]
     async fn test_trace_block_by_number() {
         let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
@@ -180,6 +180,6 @@ mod rpc_tests {
             trace_by_hash[0].struct_logs.len()
                 == trace_by_hash[1].struct_logs.len()
         );
-        assert!(trace_by_hash[0].struct_logs.len() != 0);
+        assert!(!trace_by_hash[0].struct_logs.is_empty());
     }
 }

--- a/bus-mapping/src/rpc.rs
+++ b/bus-mapping/src/rpc.rs
@@ -14,10 +14,10 @@ pub fn serialize<T: serde::Serialize>(t: &T) -> serde_json::Value {
 }
 
 /// Placeholder structure designed to contain the methods that the BusMapping needs in order to enable Geth queries.
-pub struct GethQueries<P: JsonRpcClient>(P);
+pub struct GethClient<P: JsonRpcClient>(P);
 
-impl<P: JsonRpcClient> GethQueries<P> {
-    /// Generates a new GethQueriesProvider instance.
+impl<P: JsonRpcClient> GethClient<P> {
+    /// Generates a new `GethClient` instance.
     pub fn new(provider: P) -> Self {
         Self(provider)
     }
@@ -51,7 +51,7 @@ mod rpc_tests {
         let transport = Http::new(Url::parse("http://localhost:8545").unwrap());
 
         let hash = Hash::from_str("0x60d58d0e417b2b7fab8c74a5efc8292cb5651cd056caad126fb308523b40abc2").unwrap();
-        let prov = GethQueries::new(transport);
+        let prov = GethClient::new(transport);
         let block = prov.get_block_by_hash(hash).await.unwrap();
         assert!(hash == block.transactions[0].hash)
     }


### PR DESCRIPTION
Introduce a generic struct which holds a `Provider` (can be Http, Ws,
Ipc) which will be used to make any calls/requests to Geth.

Since the `json_rpc` lib that we use requires the response types to be:
`Serialize + Deserialize`, it has been needed to impl `Serialize` for
the types that were lacking it.

- GethExecStepInternal now derives `Serialize`.
- Implemented `From<GethExecStep> for GethExecStepInternal` which is
  used in the next point.
- Implement `Serialize` for `GethExecStep` serializing it as a
  `GethExecStepInternal` using the previous `From` impl mentioned.

Geth return value for `debug_traceBlockByHash` and
`debug_traceBlockByNumber` isn't the expected.

While the expected format was to get from these calls
`Vec<GethExecTrace>`, you are given a similar vector but that contains a
`result` Json field that makes no sense previous to each trace.

Therefore it has been needed to simulate this as a new type and derive
`Serialize` and `Deserialize` for it so that the response from this call
can be parsed from the JSON and turned into usable data structures.

Following @ed255 suggestions the following extra JSON-RPC methods have
been provided support:
- debug_traceBlockByHash
- debug_traceBlockByNumber

Resolves: #23

This structure will be used by another trait (some kind of "Coordinator" crate) which will be in charge of providing this provider/transport info to the bus-mapping running instance.

Co-authored-by: Eduard S. <eduardsanou@posteo.net>