### PR TITLE
bus-mapping: Extend CallContext

### DIFF
--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "bus-mapping"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["CPerezz <c.perezbaro@gmail.com>"]
-
 
 [dependencies]
 ff = "0.11"

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -28,8 +28,10 @@ pub enum Error {
     WordToMemAddr,
     /// Error while generating a trace.
     TracingError,
-    /// JSON-RPC related error
+    /// JSON-RPC related error.
     JSONRpcError(ProviderError),
+    /// OpcodeId is not a call type.
+    OpcodeIdNotCallType,
 }
 
 impl From<ProviderError> for Error {

--- a/bus-mapping/src/evm/opcodes/sload.rs
+++ b/bus-mapping/src/evm/opcodes/sload.rs
@@ -2,7 +2,6 @@ use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
 use crate::{
-    eth_types::Address,
     operation::{StackOp, StorageOp, RW},
     Error,
 };
@@ -31,7 +30,7 @@ impl Opcode for Sload {
         let storage_value_read = step.storage.get_or_err(&stack_value_read)?;
         state.push_op(StorageOp::new(
             RW::READ,
-            Address::from([0u8; 20]), // TODO: Fill with the correct value
+            state.tx_ctx.call_ctx().address,
             stack_value_read,
             storage_value_read,
             storage_value_read,
@@ -56,7 +55,7 @@ mod sload_tests {
         circuit_input_builder::{
             CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
         },
-        eth_types::Word,
+        eth_types::{Address, Word},
         evm::StackAddress,
         mock,
     };
@@ -110,7 +109,7 @@ mod sload_tests {
         // Add StorageOp associated to the storage read.
         state_ref.push_op(StorageOp::new(
             RW::READ,
-            Address::from([0u8; 20]), // TODO: Fill with the correct value
+            Address::from([0u8; 20]),
             Word::from(0x0u32),
             Word::from(0x6fu32),
             Word::from(0x6fu32),


### PR DESCRIPTION
Add the required fields in the CallContext, and use it to detect
CREATE/CREATE2 RETURN errors, and to fill the address in SLOAD
StorageOp.

Resolve https://github.com/appliedzkp/zkevm-circuits/issues/137
Resolve https://github.com/appliedzkp/zkevm-circuits/issues/185