### PR TITLE
bus-mapping: Add StateDB key-value database

### DIFF
--- a/bus-mapping/src/eth_types.rs
+++ b/bus-mapping/src/eth_types.rs
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use web3::types;
 pub use web3::types::{
-    AccessList, Address, Block, Bytes, Index, Transaction, H2048, H64, U256,
-    U64,
+    AccessList, Address, Block, Bytes, Index, Transaction, H2048, H256, H64,
+    U256, U64,
 };
 
 /// Trait used to define types that can be converted to a 256 bit scalar value.

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -226,5 +226,6 @@ pub mod eth_types;
 pub(crate) mod geth_errors;
 pub mod mock;
 pub mod rpc;
+pub(crate) mod statedb;
 pub use error::Error;
 pub use exec_trace::BlockConstants;

--- a/bus-mapping/src/statedb.rs
+++ b/bus-mapping/src/statedb.rs
@@ -1,0 +1,162 @@
+use crate::eth_types::{Address, Word, H256};
+use std::collections::HashMap;
+
+/// Account of the Ethereum State Trie, which contains an in-memory key-value
+/// database that represents the Account Storage Trie.
+#[derive(Debug, PartialEq)]
+pub(crate) struct Account {
+    pub nonce: Word,
+    pub balance: Word,
+    pub storage: HashMap<Word, Word>,
+    pub codeHash: H256,
+}
+
+impl Account {
+    fn zero() -> Self {
+        Self {
+            nonce: Word::zero(),
+            balance: Word::zero(),
+            storage: HashMap::new(),
+            codeHash: H256::zero(),
+        }
+    }
+}
+
+/// In-memory key-value database that represents the Ethereum State Trie.
+#[derive(Debug)]
+pub(crate) struct StateDB {
+    state: HashMap<Address, Account>,
+    acc_zero: Account,
+    value_zero: Word,
+}
+
+impl StateDB {
+    /// Create an empty Self
+    pub fn new() -> Self {
+        Self {
+            state: HashMap::new(),
+            acc_zero: Account::zero(),
+            value_zero: Word::zero(),
+        }
+    }
+
+    /// Set an [`Account`] at `addr` in the StateDB.
+    pub fn set_account(&mut self, addr: &Address, acc: Account) {
+        self.state.insert(*addr, acc);
+    }
+
+    /// Get a reference to the [`Account`] at `addr`.  Returns false and a zero
+    /// [`Account`] when the [`Account`] wasn't found in the state.
+    pub fn get_account(&self, addr: &Address) -> (bool, &Account) {
+        match self.state.get(addr) {
+            Some(acc) => (true, acc),
+            None => (false, &self.acc_zero),
+        }
+    }
+
+    /// Get a mutable reference to the [`Account`] at `addr`.  If the
+    /// [`Account`] is not found in the state, a zero one will be inserted
+    /// and returned along with false.
+    pub fn get_account_mut(&mut self, addr: &Address) -> (bool, &mut Account) {
+        let found = if self.state.contains_key(addr) {
+            true
+        } else {
+            self.state.insert(*addr, Account::zero());
+            false
+        };
+        (found, self.state.get_mut(addr).expect("addr not inserted"))
+    }
+
+    /// Get a reference to the storage value from [`Account`] at `addr`, at
+    /// `key`.  Returns false and a zero [`Word`] when the [`Account`] or `key`
+    /// wasn't found in the state.
+    pub fn get_storage(&self, addr: &Address, key: &Word) -> (bool, &Word) {
+        let (_, acc) = self.get_account(addr);
+        match acc.storage.get(key) {
+            Some(value) => (true, value),
+            None => (false, &self.value_zero),
+        }
+    }
+
+    /// Get a mutable reference to the storage value from [`Account`] at `addr`,
+    /// at `key`.  Returns false when the [`Account`] or `key` wasn't found in
+    /// the state and it is created.  If the [`Account`] or `key` is not found
+    /// in the state, a zero [`Account`] will be inserted, a zero value will
+    /// be inserted at `key` in its storage, and the value will be returned
+    /// along with false.
+    pub fn get_storage_mut(
+        &mut self,
+        addr: &Address,
+        key: &Word,
+    ) -> (bool, &mut Word) {
+        let (_, acc) = self.get_account_mut(addr);
+        let found = if acc.storage.contains_key(key) {
+            true
+        } else {
+            acc.storage.insert(*key, Word::zero());
+            false
+        };
+        (found, acc.storage.get_mut(key).expect("key not inserted"))
+    }
+}
+
+#[cfg(test)]
+mod statedb_tests {
+    use super::*;
+    use crate::address;
+
+    #[test]
+    fn statedb() {
+        let addr_a = address!("0x0000000000000000000000000000000000000001");
+        let addr_b = address!("0x0000000000000000000000000000000000000002");
+        let mut statedb = StateDB::new();
+
+        // Get non-existing account
+        let (found, acc) = statedb.get_account(&addr_a);
+        assert!(!found);
+        assert_eq!(acc, &Account::zero());
+
+        // Get non-existing storage key for non-existing account
+        let (found, value) = statedb.get_storage(&addr_a, &Word::from(2));
+        assert!(!found);
+        assert_eq!(value, &Word::zero());
+
+        // Get mut non-existing account and set nonce
+        let (found, acc) = statedb.get_account_mut(&addr_a);
+        assert!(!found);
+        assert_eq!(acc, &Account::zero());
+        acc.nonce = Word::from(100);
+
+        // Get existing account and check nonce
+        let (found, acc) = statedb.get_account(&addr_a);
+        assert!(found);
+        assert_eq!(acc.nonce, Word::from(100));
+
+        // Get non-existing storage key for existing account and set value
+        let (found, value) = statedb.get_storage_mut(&addr_a, &Word::from(2));
+        assert!(!found);
+        assert_eq!(value, &Word::zero());
+        *value = Word::from(101);
+
+        // Get existing storage key and check value
+        let (found, value) = statedb.get_storage(&addr_a, &Word::from(2));
+        assert!(found);
+        assert_eq!(value, &Word::from(101));
+
+        // Get non-existing storage key for non-existing account and set value
+        let (found, value) = statedb.get_storage_mut(&addr_b, &Word::from(3));
+        assert!(!found);
+        assert_eq!(value, &Word::zero());
+        *value = Word::from(102);
+
+        // Get existing account and check nonce
+        let (found, acc) = statedb.get_account(&addr_b);
+        assert!(found);
+        assert_eq!(acc.nonce, Word::zero());
+
+        // Get existing storage key and check value
+        let (found, value) = statedb.get_storage(&addr_b, &Word::from(3));
+        assert!(found);
+        assert_eq!(value, &Word::from(102));
+    }
+}


### PR DESCRIPTION
This is a small PR to introduce the StateDB key-value database that will be used in the `CircuitInputBuilder`.   It's not yet integrated because in order to use it in the `CircuitInputBuilder` we first need to fill this database with results from geth, but we don't have the methods yet, and we also need to keep track of all state operations to know what to query from geth.

Resolve https://github.com/appliedzkp/zkevm-circuits/issues/184