### PR TITLE
bus-mapping: Bump ethers dependency

### DIFF
--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -14,8 +14,8 @@ serde_json = "1.0.66"
 hex = "0.4"
 geth-utils = { path = "../geth-utils" }
 uint = "0.9.1"
-ethers-providers = "0.6.0"
-ethers-core = "0.6.0"
+ethers-providers = "0.6.1"
+ethers-core = "0.6.1"
 regex = "1.5.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Remove unecessary Serialize implementations for types used in rpc
results

Resolve https://github.com/appliedzkp/zkevm-circuits/issues/179