### PR TITLE
Implement `ExecutionState::BeginTx`

### DIFF
--- a/bus-mapping/src/eth_types.rs
+++ b/bus-mapping/src/eth_types.rs
@@ -138,6 +138,7 @@ impl<F: FieldExt> ToScalar<F> for Address {
     fn to_scalar(&self) -> Option<F> {
         let mut bytes = [0u8; 32];
         bytes[32 - Self::len_bytes()..].copy_from_slice(self.as_bytes());
+        bytes.reverse();
         F::from_bytes(&bytes).into()
     }
 }

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -160,6 +160,10 @@ impl GasCost {
     pub const COLD_ACCOUNT_ACCESS_COST: Self = Self(2600);
     /// Constant cost for a warm storage read
     pub const WARM_STORAGE_READ_COST: Self = Self(100);
+    /// Constant cost for a non-creation transaction
+    pub const TX: Self = Self(21000);
+    /// Constant cost for creation transaction
+    pub const CREATION_TX: Self = Self(53000);
 }
 
 impl GasCost {

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -106,11 +106,12 @@ mod test {
     };
     use bus_mapping::eth_types::Word;
     use halo2::{
-        arithmetic::FieldExt,
+        arithmetic::{BaseExt, FieldExt},
         circuit::{Layouter, SimpleFloorPlanner},
         dev::{MockProver, VerifyFailure},
         plonk::{Advice, Circuit, Column, ConstraintSystem, Error},
     };
+    use pairing::bn256::Fr as Fp;
     use rand::{
         distributions::uniform::{SampleRange, SampleUniform},
         random, thread_rng, Rng,
@@ -134,6 +135,10 @@ mod test {
 
     pub(crate) fn rand_word() -> Word {
         Word::from_big_endian(&rand_bytes_array::<32>())
+    }
+
+    pub(crate) fn rand_fp() -> Fp {
+        Fp::rand()
     }
 
     #[derive(Clone)]

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -94,6 +94,15 @@ impl<F: FieldExt> EvmCircuit<F> {
     ) -> Result<(), Error> {
         self.execution.assign_block(layouter, block)
     }
+
+    /// Assign steps in incomplete block for unit test purpose
+    pub fn assign_incomplete_block(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        block: &Block<F>,
+    ) -> Result<(), Error> {
+        self.execution.assign_incomplete_block(layouter, block)
+    }
 }
 
 #[cfg(test)]
@@ -340,7 +349,9 @@ mod test {
                 &self.block.bytecodes,
                 self.block.randomness,
             )?;
-            config.evm_circuit.assign_block(&mut layouter, &self.block)
+            config
+                .evm_circuit
+                .assign_incomplete_block(&mut layouter, &self.block)
         }
     }
 

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -95,13 +95,13 @@ impl<F: FieldExt> EvmCircuit<F> {
         self.execution.assign_block(layouter, block)
     }
 
-    /// Assign steps in incomplete block for unit test purpose
-    pub fn assign_incomplete_block(
+    /// Assign exact steps in block without padding for unit test purpose
+    pub fn assign_block_exact(
         &self,
         layouter: &mut impl Layouter<F>,
         block: &Block<F>,
     ) -> Result<(), Error> {
-        self.execution.assign_incomplete_block(layouter, block)
+        self.execution.assign_block_exact(layouter, block)
     }
 }
 
@@ -351,7 +351,7 @@ mod test {
             )?;
             config
                 .evm_circuit
-                .assign_incomplete_block(&mut layouter, &self.block)
+                .assign_block_exact(&mut layouter, &self.block)
         }
     }
 

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -379,8 +379,6 @@ impl<F: FieldExt> ExecutionConfig<F> {
         layouter: &mut impl Layouter<F>,
         block: &Block<F>,
     ) -> Result<(), Error> {
-        // TODO: Assign region upto the desired capacity
-
         layouter.assign_region(
             || "Execution step",
             |mut region| {
@@ -408,11 +406,15 @@ impl<F: FieldExt> ExecutionConfig<F> {
                 }
                 Ok(())
             },
-        )
+        )?;
+
+        // TODO: Pad leftover region to the desired capacity
+
+        Ok(())
     }
 
-    /// Assign steps in incomplete block for unit test purpose
-    pub fn assign_incomplete_block(
+    /// Assign exact steps in block without padding for unit test purpose
+    pub fn assign_block_exact(
         &self,
         layouter: &mut impl Layouter<F>,
         block: &Block<F>,

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -78,6 +78,7 @@ pub(crate) trait ExecutionGadget<F: FieldExt> {
 #[derive(Clone, Debug)]
 pub(crate) struct ExecutionConfig<F> {
     q_step: Selector,
+    q_step_first: Selector,
     step: Step<F>,
     presets_map: HashMap<ExecutionState, Vec<Preset<F>>>,
     add_gadget: AddGadget<F>,
@@ -116,6 +117,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
         BytecodeTable: LookupTable<F, 4>,
     {
         let q_step = meta.complex_selector();
+        let q_step_first = meta.complex_selector();
         let qs_byte_lookup = meta.advice_column();
         let advices = [(); STEP_WIDTH].map(|_| meta.advice_column());
 
@@ -135,28 +137,44 @@ impl<F: FieldExt> ExecutionConfig<F> {
 
         meta.create_gate("Constrain execution state", |meta| {
             let q_step = meta.query_selector(q_step);
+            let q_step_first = meta.query_selector(q_step_first);
 
             // Only one of execution_state should be enabled
-            let sum_to_one = step_curr
-                .state
-                .execution_state
-                .iter()
-                .fold(1.expr(), |acc, cell| acc - cell.expr());
+            let sum_to_one = (
+                "Only one of execution_state should be enabled",
+                step_curr
+                    .state
+                    .execution_state
+                    .iter()
+                    .fold(1.expr(), |acc, cell| acc - cell.expr()),
+            );
 
             // Cells representation for execution_state should be bool.
-            let bool_checks = step_curr
-                .state
-                .execution_state
-                .iter()
-                .map(|cell| cell.expr() * (1.expr() - cell.expr()));
+            let bool_checks =
+                step_curr.state.execution_state.iter().map(|cell| {
+                    (
+                        "Representation for execution_state should be bool",
+                        cell.expr() * (1.expr() - cell.expr()),
+                    )
+                });
+
+            // TODO: ExecutionState transition needs to be constraint to avoid
+            // transition from non-terminator to BeginTx.
+
+            let first_step_check = {
+                let begin_tx_selector =
+                    step_curr.execution_state_selector(ExecutionState::BeginTx);
+                std::iter::once((
+                    "First step should be BeginTx",
+                    q_step_first * (begin_tx_selector - 1.expr()),
+                ))
+            };
 
             std::iter::once(sum_to_one)
                 .chain(bool_checks)
-                .map(move |poly| q_step.clone() * poly)
+                .map(move |(name, poly)| (name, q_step.clone() * poly))
+                .chain(first_step_check)
         });
-
-        // TODO: ExecutionState transition needs to be constraint to avoid
-        // transition from non-terminator to BeginTx.
 
         // Use qs_byte_lookup as selector to do byte range lookup on each advice
         // column. In this way, ExecutionGadget could enable the byte range
@@ -184,6 +202,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
                 Self::configure_gadget(
                     meta,
                     q_step,
+                    q_step_first,
                     &randomness,
                     &step_curr,
                     &step_next,
@@ -195,6 +214,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
 
         let config = Self {
             q_step,
+            q_step_first,
             add_gadget: configure_gadget!(),
             mul_gadget: configure_gadget!(),
             bitwise_gadget: configure_gadget!(),
@@ -231,9 +251,11 @@ impl<F: FieldExt> ExecutionConfig<F> {
         config
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn configure_gadget<G: ExecutionGadget<F>>(
         meta: &mut ConstraintSystem<F>,
         q_step: Selector,
+        q_step_first: Selector,
         randomness: &Expression<F>,
         step_curr: &Step<F>,
         step_next: &Step<F>,
@@ -249,20 +271,26 @@ impl<F: FieldExt> ExecutionConfig<F> {
 
         let gadget = G::configure(&mut cb);
 
-        let (constraints, lookups, presets) = cb.build();
+        let (constraints, constraints_first_step, lookups, presets) =
+            cb.build();
         assert!(
             presets_map.insert(G::EXECUTION_STATE, presets).is_none(),
             "execution state already configured"
         );
 
-        if !constraints.is_empty() {
-            meta.create_gate(G::NAME, |meta| {
-                let q_step = meta.query_selector(q_step);
+        for (selector, constraints) in [
+            (q_step, constraints),
+            (q_step_first, constraints_first_step),
+        ] {
+            if !constraints.is_empty() {
+                meta.create_gate(G::NAME, |meta| {
+                    let selector = meta.query_selector(selector);
 
-                constraints.into_iter().map(move |(name, constraint)| {
-                    (name, q_step.clone() * constraint)
-                })
-            });
+                    constraints.into_iter().map(move |(name, constraint)| {
+                        (name, selector.clone() * constraint)
+                    })
+                });
+            }
         }
 
         // Push lookups of this ExecutionState to independent_lookups for
@@ -347,6 +375,44 @@ impl<F: FieldExt> ExecutionConfig<F> {
     }
 
     pub fn assign_block(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        block: &Block<F>,
+    ) -> Result<(), Error> {
+        // TODO: Assign region upto the desired capacity
+
+        layouter.assign_region(
+            || "Execution step",
+            |mut region| {
+                let mut offset = 0;
+                for transaction in &block.txs {
+                    for step in &transaction.steps {
+                        let call = &transaction.calls[step.call_idx];
+
+                        self.q_step.enable(&mut region, offset)?;
+                        if offset == 0 {
+                            self.q_step_first.enable(&mut region, offset)?;
+                        }
+
+                        self.assign_exec_step(
+                            &mut region,
+                            offset,
+                            block,
+                            transaction,
+                            call,
+                            step,
+                        )?;
+
+                        offset += STEP_HEIGHT;
+                    }
+                }
+                Ok(())
+            },
+        )
+    }
+
+    /// Assign steps in incomplete block for unit test purpose
+    pub fn assign_incomplete_block(
         &self,
         layouter: &mut impl Layouter<F>,
         block: &Block<F>,

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -19,6 +19,7 @@ use halo2::{
 use std::collections::HashMap;
 
 mod add;
+mod begin_tx;
 mod bitwise;
 mod byte;
 mod comparator;
@@ -37,6 +38,7 @@ mod signextend;
 mod stop;
 mod swap;
 use add::AddGadget;
+use begin_tx::BeginTxGadget;
 use bitwise::BitwiseGadget;
 use byte::ByteGadget;
 use comparator::ComparatorGadget;
@@ -81,6 +83,7 @@ pub(crate) struct ExecutionConfig<F> {
     add_gadget: AddGadget<F>,
     mul_gadget: MulGadget<F>,
     bitwise_gadget: BitwiseGadget<F>,
+    begin_tx_gadget: BeginTxGadget<F>,
     byte_gadget: ByteGadget<F>,
     comparator_gadget: ComparatorGadget<F>,
     dup_gadget: DupGadget<F>,
@@ -195,6 +198,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
             add_gadget: configure_gadget!(),
             mul_gadget: configure_gadget!(),
             bitwise_gadget: configure_gadget!(),
+            begin_tx_gadget: configure_gadget!(),
             byte_gadget: configure_gadget!(),
             comparator_gadget: configure_gadget!(),
             dup_gadget: configure_gadget!(),
@@ -406,6 +410,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
         }
 
         match step.execution_state {
+            ExecutionState::BeginTx => assign_exec_step!(self.begin_tx_gadget),
             ExecutionState::STOP => assign_exec_step!(self.stop_gadget),
             ExecutionState::ADD => assign_exec_step!(self.add_gadget),
             ExecutionState::MUL => assign_exec_step!(self.mul_gadget),

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -1,0 +1,519 @@
+use crate::{
+    evm_circuit::{
+        execution::ExecutionGadget,
+        param::MAX_GAS_SIZE_IN_BYTES,
+        step::ExecutionState,
+        table::{AccountFieldTag, CallContextFieldTag, TxContextFieldTag},
+        util::{
+            common_gadget::TransferWithGasFeeGadget,
+            constraint_builder::{
+                ConstraintBuilder, StepStateTransition,
+                Transition::{Delta, Same, To},
+            },
+            math_gadget::{MulWordByU64Gadget, RangeCheckGadget},
+            select, Cell, RandomLinearCombination, Word,
+        },
+        witness::{Block, Call, ExecStep, Transaction},
+    },
+    util::Expr,
+};
+use bus_mapping::eth_types::{ToLittleEndian, ToScalar};
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
+
+#[derive(Clone, Debug)]
+pub(crate) struct BeginTxGadget<F> {
+    tx_id: Cell<F>,
+    tx_nonce: Cell<F>,
+    tx_gas: Cell<F>,
+    tx_gas_tip_cap: Word<F>,
+    tx_gas_fee_cap: Word<F>,
+    mul_gas_fee_by_gas: MulWordByU64Gadget<F>,
+    tx_caller_address: Cell<F>,
+    tx_callee_address: Cell<F>,
+    tx_is_create: Cell<F>,
+    tx_value: Word<F>,
+    tx_call_data_length: Cell<F>,
+    rw_counter_end_of_reversion: Cell<F>,
+    is_persistent: Cell<F>,
+    sufficient_gas_left: RangeCheckGadget<F, MAX_GAS_SIZE_IN_BYTES>,
+    transfer_with_gas_fee: TransferWithGasFeeGadget<F>,
+    code_hash: Cell<F>,
+}
+
+impl<F: FieldExt> ExecutionGadget<F> for BeginTxGadget<F> {
+    const NAME: &'static str = "BeginTx";
+
+    const EXECUTION_STATE: ExecutionState = ExecutionState::BeginTx;
+
+    fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        cb.require_equal(
+            "call_id is correctly set to rw_counter at the step which creates the call",
+            cb.curr.state.call_id.expr(),
+            cb.curr.state.rw_counter.expr(),
+        );
+
+        let [tx_id, rw_counter_end_of_reversion, is_persistent] = [
+            CallContextFieldTag::TxId,
+            CallContextFieldTag::RwCounterEndOfReversion,
+            CallContextFieldTag::IsPersistent,
+        ]
+        .map(|field_tag| cb.call_context(field_tag));
+
+        let [tx_nonce, tx_gas, tx_caller_address, tx_callee_address, tx_is_create, tx_call_data_length] =
+            [
+                TxContextFieldTag::Nonce,
+                TxContextFieldTag::Gas,
+                TxContextFieldTag::CallerAddress,
+                TxContextFieldTag::CalleeAddress,
+                TxContextFieldTag::IsCreate,
+                TxContextFieldTag::CallDataLength,
+            ]
+            .map(|field_tag| cb.tx_context(tx_id.expr(), field_tag));
+        let [tx_gas_tip_cap, tx_gas_fee_cap, tx_value] = [
+            TxContextFieldTag::GasTipCap,
+            TxContextFieldTag::GasFeeCap,
+            TxContextFieldTag::Value,
+        ]
+        .map(|field_tag| cb.tx_context_as_word(tx_id.expr(), field_tag));
+
+        // Calculate transaction gas fee
+        let mul_gas_fee_by_gas = MulWordByU64Gadget::construct(
+            cb,
+            tx_gas_fee_cap.clone(),
+            tx_gas.clone(),
+            true,
+        );
+
+        // Increase caller's nonce (tx caller's nonce always increases even tx
+        // ends with error)
+        cb.account_write(
+            tx_caller_address.expr(),
+            AccountFieldTag::Nonce,
+            tx_nonce.expr() + 1.expr(),
+            tx_nonce.expr(),
+        );
+
+        // Use intrinsic gas and check gas_left is sufficient
+        let intrinsic_gas_cost =
+            select::expr(tx_is_create.expr(), 53000.expr(), 21000.expr());
+        let gas_left = tx_gas.expr() - intrinsic_gas_cost;
+        let sufficient_gas_left =
+            RangeCheckGadget::construct(cb, gas_left.clone());
+
+        // Prepare access list of caller and callee
+        cb.account_access_list_write(
+            tx_id.expr(),
+            tx_caller_address.expr(),
+            1.expr(),
+            0.expr(),
+        );
+        cb.account_access_list_write(
+            tx_id.expr(),
+            tx_callee_address.expr(),
+            1.expr(),
+            0.expr(),
+        );
+
+        // Transfer value from caller to callee
+        let transfer_with_gas_fee = TransferWithGasFeeGadget::construct(
+            cb,
+            tx_caller_address.expr(),
+            tx_callee_address.expr(),
+            tx_value.clone(),
+            mul_gas_fee_by_gas.product().clone(),
+            is_persistent.expr(),
+            rw_counter_end_of_reversion.expr(),
+        );
+
+        // Assume it's not a creation transaction nor calling a precompiled
+        cb.add_constraint(
+            "Handling of creation transaction has yet to be determined",
+            tx_is_create.expr(),
+        );
+
+        // Read code_hash of callee
+        let code_hash = cb.query_cell();
+        cb.account_read(
+            tx_callee_address.expr(),
+            AccountFieldTag::CodeHash,
+            code_hash.expr(),
+        );
+
+        // Setup call context fields
+        for (field_tag, value) in [
+            (CallContextFieldTag::Depth, 1.expr()),
+            (CallContextFieldTag::CallerAddress, tx_caller_address.expr()),
+            (CallContextFieldTag::CalleeAddress, tx_callee_address.expr()),
+            (CallContextFieldTag::CallDataOffset, 0.expr()),
+            (
+                CallContextFieldTag::CallDataLength,
+                tx_call_data_length.expr(),
+            ),
+            (CallContextFieldTag::Value, tx_value.expr()),
+            (CallContextFieldTag::IsStatic, 0.expr()),
+        ] {
+            cb.call_context_lookup(field_tag, value);
+        }
+
+        cb.require_step_state_transition(StepStateTransition {
+            rw_counter: Delta(16.expr()),
+            call_id: Same,
+            is_root: To(1.expr()),
+            is_create: To(0.expr()),
+            opcode_source: To(code_hash.expr()),
+            program_counter: To(0.expr()),
+            stack_pointer: To(1024.expr()),
+            gas_left: To(gas_left),
+            memory_size: To(0.expr()),
+            state_write_counter: To(0.expr()),
+        });
+
+        Self {
+            tx_id,
+            tx_nonce,
+            tx_gas,
+            tx_gas_tip_cap,
+            tx_gas_fee_cap,
+            mul_gas_fee_by_gas,
+            tx_caller_address,
+            tx_callee_address,
+            tx_is_create,
+            tx_value,
+            tx_call_data_length,
+            rw_counter_end_of_reversion,
+            is_persistent,
+            sufficient_gas_left,
+            transfer_with_gas_fee,
+            code_hash,
+        }
+    }
+
+    fn assign_exec_step(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        block: &Block<F>,
+        tx: &Transaction<F>,
+        call: &Call<F>,
+        step: &ExecStep,
+    ) -> Result<(), Error> {
+        let gas_fee = tx.gas_fee_cap * tx.gas;
+        let [caller_balance_pair, callee_balance_pair, (callee_code_hash, _)] =
+            [step.rw_indices[6], step.rw_indices[7], step.rw_indices[8]]
+                .map(|idx| block.rws[idx].account_value_pair());
+
+        self.tx_id
+            .assign(region, offset, Some(F::from(tx.id as u64)))?;
+        self.tx_nonce
+            .assign(region, offset, Some(F::from(tx.nonce)))?;
+        self.tx_gas.assign(region, offset, Some(F::from(tx.gas)))?;
+        self.tx_gas_tip_cap.assign(
+            region,
+            offset,
+            Some(tx.gas_tip_cap.to_le_bytes()),
+        )?;
+        self.tx_gas_fee_cap.assign(
+            region,
+            offset,
+            Some(tx.gas_fee_cap.to_le_bytes()),
+        )?;
+        self.mul_gas_fee_by_gas.assign(
+            region,
+            offset,
+            tx.gas_fee_cap,
+            tx.gas,
+            gas_fee,
+        )?;
+        self.tx_caller_address.assign(
+            region,
+            offset,
+            tx.caller_address.to_scalar(),
+        )?;
+        self.tx_callee_address.assign(
+            region,
+            offset,
+            tx.callee_address.to_scalar(),
+        )?;
+        self.tx_is_create.assign(
+            region,
+            offset,
+            Some(F::from(tx.is_create as u64)),
+        )?;
+        self.tx_call_data_length.assign(
+            region,
+            offset,
+            Some(F::from(tx.call_data_length as u64)),
+        )?;
+        self.rw_counter_end_of_reversion.assign(
+            region,
+            offset,
+            Some(F::from(call.rw_counter_end_of_reversion as u64)),
+        )?;
+        self.is_persistent.assign(
+            region,
+            offset,
+            Some(F::from(call.is_persistent as u64)),
+        )?;
+        self.sufficient_gas_left.assign(
+            region,
+            offset,
+            F::from(tx.gas - step.gas_cost),
+        )?;
+        self.transfer_with_gas_fee.assign(
+            region,
+            offset,
+            caller_balance_pair,
+            callee_balance_pair,
+            tx.value,
+            gas_fee,
+        )?;
+        self.code_hash.assign(
+            region,
+            offset,
+            Some(RandomLinearCombination::random_linear_combine(
+                callee_code_hash.to_le_bytes(),
+                block.randomness,
+            )),
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::evm_circuit::{
+        step::ExecutionState,
+        table::{AccountFieldTag, CallContextFieldTag},
+        test::{rand_range, run_test_circuit_incomplete_fixed_table},
+        util::RandomLinearCombination,
+        witness::{Block, Bytecode, Call, ExecStep, Rw, Transaction},
+    };
+    use bus_mapping::{
+        address,
+        eth_types::{self, Address, ToLittleEndian, ToWord, Word},
+        evm::OpcodeId,
+    };
+    use halo2::arithmetic::BaseExt;
+    use pairing::bn256::Fr as Fp;
+
+    fn test_ok(tx: eth_types::Transaction) {
+        let gas_fee = tx.gas * tx.max_fee_per_gas.unwrap_or_else(Word::zero);
+        let intrinsic_gas_cost = if tx.to.is_none() { 53000 } else { 21000 };
+
+        let from_balance_prev = Word::from(10).pow(18.into());
+        let to_balance_prev = Word::zero();
+        let from_balance = from_balance_prev - tx.value - gas_fee;
+        let to_balance = to_balance_prev + tx.value;
+
+        let randomness = Fp::rand();
+        let bytecode = Bytecode::new(vec![OpcodeId::STOP.as_u8()]);
+        let block = Block {
+            randomness,
+            txs: vec![Transaction {
+                id: 1,
+                nonce: tx.nonce.low_u64(),
+                gas: tx.gas.low_u64(),
+                gas_tip_cap: tx
+                    .max_priority_fee_per_gas
+                    .unwrap_or_else(Word::zero),
+                gas_fee_cap: tx.max_fee_per_gas.unwrap_or_else(Word::zero),
+                caller_address: tx.from,
+                callee_address: tx.to.unwrap_or_else(Address::zero),
+                is_create: tx.to.is_none(),
+                value: tx.value,
+                call_data_length: tx.input.0.len(),
+                call_data: tx.input.to_vec(),
+                calls: vec![Call {
+                    id: 1,
+                    is_root: true,
+                    is_create: false,
+                    opcode_source:
+                        RandomLinearCombination::random_linear_combine(
+                            bytecode.hash.to_le_bytes(),
+                            randomness,
+                        ),
+                    is_persistent: true,
+                    ..Default::default()
+                }],
+                steps: vec![
+                    ExecStep {
+                        rw_indices: (0..16).collect(),
+                        execution_state: ExecutionState::BeginTx,
+                        rw_counter: 1,
+                        gas_cost: intrinsic_gas_cost,
+                        ..Default::default()
+                    },
+                    ExecStep {
+                        execution_state: ExecutionState::STOP,
+                        rw_counter: 17,
+                        program_counter: 0,
+                        stack_pointer: 1024,
+                        gas_left: tx.gas.low_u64() - intrinsic_gas_cost,
+                        opcode: Some(OpcodeId::STOP),
+                        ..Default::default()
+                    },
+                ],
+            }],
+            rws: vec![
+                Rw::CallContext {
+                    rw_counter: 1,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::TxId,
+                    value: Word::one(),
+                },
+                Rw::CallContext {
+                    rw_counter: 2,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::RwCounterEndOfReversion,
+                    value: Word::zero(),
+                },
+                Rw::CallContext {
+                    rw_counter: 3,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::IsPersistent,
+                    value: Word::one(),
+                },
+                Rw::Account {
+                    rw_counter: 4,
+                    is_write: true,
+                    account_address: tx.from,
+                    field_tag: AccountFieldTag::Nonce,
+                    value: tx.nonce + Word::one(),
+                    value_prev: tx.nonce,
+                },
+                Rw::TxAccessListAccount {
+                    rw_counter: 5,
+                    is_write: true,
+                    tx_id: 1,
+                    account_address: tx.from,
+                    value: true,
+                    value_prev: false,
+                },
+                Rw::TxAccessListAccount {
+                    rw_counter: 6,
+                    is_write: true,
+                    tx_id: 1,
+                    account_address: tx.to.unwrap(),
+                    value: true,
+                    value_prev: false,
+                },
+                Rw::Account {
+                    rw_counter: 7,
+                    is_write: true,
+                    account_address: tx.from,
+                    field_tag: AccountFieldTag::Balance,
+                    value: from_balance,
+                    value_prev: from_balance_prev,
+                },
+                Rw::Account {
+                    rw_counter: 8,
+                    is_write: true,
+                    account_address: tx.to.unwrap_or_else(Address::zero),
+                    field_tag: AccountFieldTag::Balance,
+                    value: to_balance,
+                    value_prev: to_balance_prev,
+                },
+                Rw::Account {
+                    rw_counter: 9,
+                    is_write: false,
+                    account_address: tx.to.unwrap_or_else(Address::zero),
+                    field_tag: AccountFieldTag::CodeHash,
+                    value: bytecode.hash,
+                    value_prev: bytecode.hash,
+                },
+                Rw::CallContext {
+                    rw_counter: 10,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::Depth,
+                    value: Word::one(),
+                },
+                Rw::CallContext {
+                    rw_counter: 11,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::CallerAddress,
+                    value: tx.from.to_word(),
+                },
+                Rw::CallContext {
+                    rw_counter: 12,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::CalleeAddress,
+                    value: tx.to.unwrap_or_else(Address::zero).to_word(),
+                },
+                Rw::CallContext {
+                    rw_counter: 13,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::CallDataOffset,
+                    value: Word::zero(),
+                },
+                Rw::CallContext {
+                    rw_counter: 14,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::CallDataLength,
+                    value: tx.input.0.len().into(),
+                },
+                Rw::CallContext {
+                    rw_counter: 15,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::Value,
+                    value: tx.value,
+                },
+                Rw::CallContext {
+                    rw_counter: 16,
+                    is_write: false,
+                    call_id: 1,
+                    field_tag: CallContextFieldTag::IsStatic,
+                    value: Word::zero(),
+                },
+            ],
+            bytecodes: vec![bytecode],
+        };
+        assert_eq!(run_test_circuit_incomplete_fixed_table(block), Ok(()));
+    }
+
+    #[test]
+    fn begin_tx_gadget_simple() {
+        test_ok(eth_types::Transaction {
+            nonce: Word::zero(),
+            from: address!("0x00000000000000000000000000000000000000fe"),
+            to: Some(address!("0x00000000000000000000000000000000000000ff")),
+            value: Word::from(10).pow(17.into()),
+            gas: 21000.into(),
+            max_fee_per_gas: Some(Word::from(2_000_000_000)),
+            input: Vec::new().into(),
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn begin_tx_gadget_rand() {
+        test_ok(eth_types::Transaction {
+            nonce: Word::from(rand_range(0..u64::MAX)),
+            from: address!("0x00000000000000000000000000000000000000fe"),
+            to: Some(address!("0x00000000000000000000000000000000000000ff")),
+            value: Word::from(rand_range(0..=10u64.pow(18))),
+            gas: 21000.into(),
+            max_fee_per_gas: Some(Word::from(2_000_000_000)),
+            input: Vec::new().into(),
+            ..Default::default()
+        });
+        test_ok(eth_types::Transaction {
+            nonce: Word::from(rand_range(0..u64::MAX)),
+            from: address!("0x00000000000000000000000000000000000000fe"),
+            to: Some(address!("0x00000000000000000000000000000000000000ff")),
+            value: Word::from(10).pow(17.into()),
+            gas: 21000.into(),
+            max_fee_per_gas: Some(Word::from(rand_range(0..42857142857143u64))),
+            input: Vec::new().into(),
+            ..Default::default()
+        });
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -72,6 +72,16 @@ impl<F: FieldExt> ExecutionGadget<F> for BeginTxGadget<F> {
                 |field_tag| cb.tx_context_as_word(tx_id.expr(), field_tag),
             );
 
+        // Add first step constraint to have both rw_counter and tx_id to be 1
+        cb.add_constraint_first_step(
+            "rw_counter is initialized to be 1",
+            1.expr() - cb.curr.state.rw_counter.expr(),
+        );
+        cb.add_constraint_first_step(
+            "tx_id is initialized to be 1",
+            1.expr() - tx_id.expr(),
+        );
+
         // Increase caller's nonce.
         // (tx caller's nonce always increases even tx ends with error)
         cb.account_write(

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -284,7 +284,7 @@ mod test {
     use crate::evm_circuit::{
         step::ExecutionState,
         table::{AccountFieldTag, CallContextFieldTag},
-        test::{rand_range, run_test_circuit_incomplete_fixed_table},
+        test::{rand_fp, rand_range, run_test_circuit_incomplete_fixed_table},
         util::RandomLinearCombination,
         witness::{Block, Bytecode, Call, ExecStep, Rw, Transaction},
     };
@@ -293,8 +293,6 @@ mod test {
         eth_types::{self, Address, ToLittleEndian, ToWord, Word},
         evm::OpcodeId,
     };
-    use halo2::arithmetic::BaseExt;
-    use pairing::bn256::Fr as Fp;
 
     fn test_ok(tx: eth_types::Transaction) {
         let gas_fee = tx.gas * tx.max_fee_per_gas.unwrap_or_else(Word::zero);
@@ -305,7 +303,7 @@ mod test {
         let from_balance = from_balance_prev - tx.value - gas_fee;
         let to_balance = to_balance_prev + tx.value;
 
-        let randomness = Fp::rand();
+        let randomness = rand_fp();
         let bytecode = Bytecode::new(vec![OpcodeId::STOP.as_u8()]);
         let block = Block {
             randomness,

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -173,6 +173,23 @@ impl<F: FieldExt> ExecutionGadget<F> for BeginTxGadget<F> {
         }
 
         cb.require_step_state_transition(StepStateTransition {
+            // 16 read/write including:
+            //   - Read CallContext TxId
+            //   - Read CallContext RwCounterEndOfReversion
+            //   - Read CallContext IsPersistent
+            //   - Write Account Nonce
+            //   - Write TxAccessListAccount
+            //   - Write TxAccessListAccount
+            //   - Write Account Balance
+            //   - Write Account Balance
+            //   - Read Account CodeHash
+            //   - Read CallContext Depth
+            //   - Read CallContext CallerAddress
+            //   - Read CallContext CalleeAddress
+            //   - Read CallContext CallDataOffset
+            //   - Read CallContext CallDataLength
+            //   - Read CallContext Value
+            //   - Read CallContext IsStatic
             rw_counter: Delta(16.expr()),
             call_id: To(call_id.expr()),
             is_root: To(1.expr()),

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -12,7 +12,7 @@ pub(crate) const NUM_BYTES_U64: usize = 8;
 /// represents to overflow a single field element.
 pub(crate) const MAX_BYTES_FIELD: usize = 31;
 
-pub(crate) const STACK_START_IDX: usize = 1024;
+pub(crate) const STACK_CAPACITY: usize = 1024;
 pub(crate) const MAX_GAS_SIZE_IN_BYTES: usize = 8;
 // Number of bytes that will be used of the address word.
 // If any of the other more signficant bytes are used it will

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,7 +1,7 @@
 // Step dimension
 pub(crate) const STEP_WIDTH: usize = 32;
 /// Step height
-pub const STEP_HEIGHT: usize = 10;
+pub const STEP_HEIGHT: usize = 14;
 pub(crate) const NUM_CELLS_STEP_STATE: usize = 10;
 
 // The number of bytes an u64 has.

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -119,13 +119,13 @@ impl FixedTableTag {
 pub enum TxContextFieldTag {
     Nonce = 1,
     Gas,
-    GasTipCap,
-    GasFeeCap,
+    GasPrice,
     CallerAddress,
     CalleeAddress,
     IsCreate,
     Value,
     CallDataLength,
+    CallDataGasCost,
     CallData,
 }
 

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -400,7 +400,7 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
         field_tag: TxContextFieldTag,
     ) -> Cell<F> {
         let cell = self.query_cell();
-        self.tx_context_lookup(id, field_tag.expr(), 0.expr(), cell.expr());
+        self.tx_context_lookup(id, field_tag.expr(), cell.expr());
         cell
     }
 
@@ -410,7 +410,7 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
         field_tag: TxContextFieldTag,
     ) -> Word<F> {
         let word = self.query_word();
-        self.tx_context_lookup(id, field_tag.expr(), 0.expr(), word.expr());
+        self.tx_context_lookup(id, field_tag.expr(), word.expr());
         word
     }
 
@@ -418,13 +418,12 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
         &mut self,
         id: Expression<F>,
         field_tag: Expression<F>,
-        index: Expression<F>,
         value: Expression<F>,
     ) {
         self.add_lookup(Lookup::Tx {
             id,
             field_tag,
-            index,
+            index: 0.expr(),
             value,
         });
     }

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -583,15 +583,17 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
 
     pub(crate) fn call_context(
         &mut self,
+        call_id: Option<Expression<F>>,
         field_tag: CallContextFieldTag,
     ) -> Cell<F> {
         let cell = self.query_cell();
-        self.call_context_lookup(field_tag, cell.expr());
+        self.call_context_lookup(call_id, field_tag, cell.expr());
         cell
     }
 
     pub(crate) fn call_context_lookup(
         &mut self,
+        call_id: Option<Expression<F>>,
         field_tag: CallContextFieldTag,
         value: Expression<F>,
     ) {
@@ -599,7 +601,7 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
             false.expr(),
             RwTableTag::CallContext,
             [
-                self.curr.state.call_id.expr(),
+                call_id.unwrap_or_else(|| self.curr.state.call_id.expr()),
                 field_tag.expr(),
                 value,
                 0.expr(),

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -29,14 +29,14 @@ pub struct Transaction<F> {
     pub id: usize,
     pub nonce: u64,
     pub gas: u64,
-    pub gas_tip_cap: Word,
-    pub gas_fee_cap: Word,
+    pub gas_price: Word,
     pub caller_address: Address,
     pub callee_address: Address,
     pub is_create: bool,
     pub value: Word,
-    pub call_data_length: usize,
     pub call_data: Vec<u8>,
+    pub call_data_length: usize,
+    pub call_data_gas_cost: u64,
     pub calls: Vec<Call<F>>,
     pub steps: Vec<ExecStep>,
 }
@@ -59,19 +59,10 @@ impl<F: FieldExt> Transaction<F> {
                 ],
                 [
                     F::from(self.id as u64),
-                    F::from(TxContextFieldTag::GasTipCap as u64),
+                    F::from(TxContextFieldTag::GasPrice as u64),
                     F::zero(),
                     RandomLinearCombination::random_linear_combine(
-                        self.gas_tip_cap.to_le_bytes(),
-                        randomness,
-                    ),
-                ],
-                [
-                    F::from(self.id as u64),
-                    F::from(TxContextFieldTag::GasFeeCap as u64),
-                    F::zero(),
-                    RandomLinearCombination::random_linear_combine(
-                        self.gas_fee_cap.to_le_bytes(),
+                        self.gas_price.to_le_bytes(),
                         randomness,
                     ),
                 ],
@@ -107,6 +98,12 @@ impl<F: FieldExt> Transaction<F> {
                     F::from(TxContextFieldTag::CallDataLength as u64),
                     F::zero(),
                     F::from(self.call_data_length as u64),
+                ],
+                [
+                    F::from(self.id as u64),
+                    F::from(TxContextFieldTag::CallDataGasCost as u64),
+                    F::zero(),
+                    F::from(self.call_data_gas_cost),
                 ],
             ],
             self.call_data

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 use crate::evm_circuit::{
+    param::STACK_CAPACITY,
     step::ExecutionState,
     table::{
         AccountFieldTag, CallContextFieldTag, RwTableTag, TxContextFieldTag,
@@ -490,7 +491,7 @@ fn step_convert(
         execution_state: ExecutionState::from(step),
         rw_counter: usize::from(step.rwc),
         program_counter: usize::from(step.pc) as u64,
-        stack_pointer: 1024 - step.stack_size,
+        stack_pointer: STACK_CAPACITY - step.stack_size,
         gas_left: step.gas_left.0,
         gas_cost: step.gas_cost.as_u64(),
         opcode: Some(step.op),


### PR DESCRIPTION
This PR aims to implement `ExecutionGadget` of `ExecutionState::BeginTx`.

The spec it follows could be found [here](https://github.com/han0110/zkevm-specs/blob/feature%2Fuse-legacy-tx-format/src/zkevm_specs/evm/execution/begin_tx.py).

Integration with `witness.rs` is left for further PRs, or left for `CALL` implementation PR
