### PR TITLE
Radical Pi Gate

### DIFF
--- a/keccak256/src/gates/pi.rs
+++ b/keccak256/src/gates/pi.rs
@@ -1,77 +1,21 @@
-use crate::gates::gate_helpers::Lane;
-
-use halo2::{
-    circuit::Region,
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
-    poly::Rotation,
-};
+use halo2::circuit::Cell;
 use itertools::Itertools;
 use pairing::arithmetic::FieldExt;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
-#[derive(Clone, Debug)]
-pub struct PiConfig<F> {
-    q_enable: Selector,
-    state: [Column<Advice>; 25],
-    _marker: PhantomData<F>,
-}
-
-impl<F: FieldExt> PiConfig<F> {
-    pub const OFFSET: usize = 2;
-    pub fn configure(
-        q_enable: Selector,
-        meta: &mut ConstraintSystem<F>,
-        state: [Column<Advice>; 25],
-    ) -> PiConfig<F> {
-        meta.create_gate("pi", |meta| {
-            let q_enable = meta.query_selector(q_enable);
-            (0..5)
-                .cartesian_product(0..5)
-                .map(|(x, y)| {
-                    let lane = meta.query_advice(
-                        state[5 * ((x + 3 * y) % 5) + x],
-                        Rotation::cur(),
-                    );
-                    let new_lane =
-                        meta.query_advice(state[5 * x + y], Rotation::next());
-
-                    q_enable.clone() * (new_lane - lane)
-                })
-                .collect::<Vec<Expression<F>>>()
-        });
-
-        PiConfig {
-            q_enable,
-            state,
-            _marker: PhantomData,
-        }
-    }
-
-    pub fn assign_region(
-        &self,
-        region: &mut Region<'_, F>,
-        offset: usize,
-        previous_state: [Lane<F>; 25],
-    ) -> Result<[Lane<F>; 25], Error> {
-        self.q_enable.enable(region, offset)?;
-        let mut next_state: Vec<Lane<F>> = vec![];
-
-        for (x, y) in (0..5).cartesian_product(0..5) {
-            let idx_prev = 5 * ((x + 3 * y) % 5) + x;
-            let idx_next = 5 * x + y;
-            let lane = &previous_state[idx_prev];
-            let cell = region.assign_advice(
-                || "lane next row",
-                self.state[idx_next],
-                offset,
-                || Ok(lane.value),
-            )?;
-            next_state.push(Lane {
-                cell,
-                value: lane.value,
-            });
-        }
-        Ok(next_state.try_into().unwrap())
-    }
+/// The Keccak Pi step
+///
+/// It has no gates. We just have to permute the previous state into the correct
+/// order. The copy constrain in the next gate can then enforce the Pi step
+/// permutation.
+pub fn pi_gate_permutation<F: FieldExt>(
+    state: [(Cell, F); 25],
+) -> [(Cell, F); 25] {
+    let state: [(Cell, F); 25] = (0..5)
+        .cartesian_product(0..5)
+        .map(|(x, y)| state[5 * ((x + 3 * y) % 5) + x])
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    state
 }


### PR DESCRIPTION
we don't need 25 columns for the pi gate.
We can use a function that takes input [(Cell, F); 25] and output [(Cell, F); 25]. Permute them at the right order. The copy constraint in the next gate will enforce what Pi intended to do.