### PR TITLE
bus-mapping: Extend CircuitInputBuilder

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,4 +33,5 @@ jobs:
       - run: ./run.sh --steps "setup"
       - run: ./run.sh --steps "gendata"
       - run: ./run.sh --steps "tests" --tests "rpc"
+      - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
       - run: ./run.sh --steps "cleanup"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
+ "log",
  "pairing_bn256",
  "pretty_assertions",
  "regex",
@@ -1085,6 +1086,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "eth-keystore"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,8 +1974,10 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "bus-mapping",
+ "env_logger",
  "ethers",
  "lazy_static",
+ "log",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -3348,6 +3370,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -17,6 +17,7 @@ uint = "0.9.1"
 ethers-providers = "0.6"
 ethers-core = "0.6"
 regex = "1.5.4"
+log = "0.4.14"
 
 [dev-dependencies]
 url = "2.2.2"

--- a/bus-mapping/src/eth_types.rs
+++ b/bus-mapping/src/eth_types.rs
@@ -123,7 +123,7 @@ impl ToAddress for U256 {
     }
 }
 
-/// Ethereum Hash (160 bits).
+/// Ethereum Hash (256 bits).
 pub type Hash = types::H256;
 
 impl ToWord for Address {
@@ -140,6 +140,15 @@ impl<F: FieldExt> ToScalar<F> for Address {
         bytes[32 - Self::len_bytes()..].copy_from_slice(self.as_bytes());
         F::from_bytes(&bytes).into()
     }
+}
+
+/// Chain specific constants
+#[derive(Debug, Clone)]
+pub struct ChainConstants {
+    /// Coinbase
+    pub coinbase: Address,
+    /// Chain ID
+    pub chain_id: u64,
 }
 
 /// Struct used to define the storage proof

--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -6,6 +6,7 @@ pub mod stack;
 pub mod storage;
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 pub use {
     memory::{Memory, MemoryAddress},
     opcodes::{ids::OpcodeId, Opcode},
@@ -15,9 +16,15 @@ pub use {
 
 /// Wrapper type over `usize` which represents the program counter of the Evm.
 #[derive(
-    Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord,
+    Clone, Copy, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord,
 )]
 pub struct ProgramCounter(pub(crate) usize);
+
+impl fmt::Debug for ProgramCounter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("0x{:06x}", self.0))
+    }
+}
 
 impl From<ProgramCounter> for usize {
     fn from(addr: ProgramCounter) -> usize {
@@ -50,8 +57,14 @@ impl ProgramCounter {
 /// [`Operation`](crate::operation::Operation). The purpose of the
 /// `GlobalCounter` is to enforce that each Opcode/Instruction and Operation is
 /// unique and just executed once.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub struct GlobalCounter(pub(crate) usize);
+
+impl fmt::Debug for GlobalCounter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}", self.0))
+    }
+}
 
 impl From<GlobalCounter> for usize {
     fn from(addr: GlobalCounter) -> usize {
@@ -93,16 +106,28 @@ impl GlobalCounter {
 /// Defines the gas left to perate in a
 /// [`ExecStep`](crate::circuit_input_builder::ExecStep).
 #[derive(
-    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize,
+    Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize,
 )]
 pub struct Gas(pub u64);
+
+impl fmt::Debug for Gas {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}", self.0))
+    }
+}
 
 /// Defines the gas consumed by an
 /// [`ExecStep`](crate::circuit_input_builder::ExecStep).
 #[derive(
-    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize,
+    Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize,
 )]
 pub struct GasCost(pub(crate) u64);
+
+impl fmt::Debug for GasCost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}", self.0))
+    }
+}
 
 impl GasCost {
     /// Constant cost for free step

--- a/bus-mapping/src/evm/memory.rs
+++ b/bus-mapping/src/evm/memory.rs
@@ -9,8 +9,14 @@ use core::str::FromStr;
 use std::fmt;
 
 /// Represents a `MemoryAddress` of the EVM.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub struct MemoryAddress(pub(crate) usize);
+
+impl fmt::Debug for MemoryAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("0x{:06x}", self.0))
+    }
+}
 
 impl MemoryAddress {
     /// Returns the zero address for Memory targets.

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -15,6 +15,7 @@ use crate::eth_types::GethExecStep;
 use crate::Error;
 use core::fmt::Debug;
 use ids::OpcodeId;
+use log::warn;
 
 use self::push::Push;
 use dup::Dup;
@@ -40,6 +41,13 @@ pub trait Opcode: Debug {
         state: &mut CircuitInputStateRef,
         next_steps: &[GethExecStep],
     ) -> Result<(), Error>;
+}
+
+fn dummy_gen_associated_ops(
+    _state: &mut CircuitInputStateRef,
+    _next_steps: &[GethExecStep],
+) -> Result<(), Error> {
+    Ok(())
 }
 
 type FnGenAssociatedOps = fn(
@@ -192,7 +200,12 @@ impl OpcodeId {
             // OpcodeId::STATICCALL => {},
             // OpcodeId::REVERT => {},
             // OpcodeId::SELFDESTRUCT => {},
-            _ => unimplemented!(),
+            // _ => panic!("Opcode {:?} gen_associated_ops not implemented",
+            // self),
+            _ => {
+                warn!("Using dummy gen_associated_ops for opcode {:?}", self);
+                dummy_gen_associated_ops
+            }
         }
     }
 

--- a/bus-mapping/src/evm/opcodes/dup.rs
+++ b/bus-mapping/src/evm/opcodes/dup.rs
@@ -62,16 +62,12 @@ mod dup_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 

--- a/bus-mapping/src/evm/opcodes/mstore.rs
+++ b/bus-mapping/src/evm/opcodes/mstore.rs
@@ -74,16 +74,12 @@ mod mstore_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 

--- a/bus-mapping/src/evm/opcodes/pc.rs
+++ b/bus-mapping/src/evm/opcodes/pc.rs
@@ -57,16 +57,12 @@ mod pc_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 

--- a/bus-mapping/src/evm/opcodes/push.rs
+++ b/bus-mapping/src/evm/opcodes/push.rs
@@ -59,16 +59,12 @@ mod push_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 

--- a/bus-mapping/src/evm/opcodes/sload.rs
+++ b/bus-mapping/src/evm/opcodes/sload.rs
@@ -80,16 +80,12 @@ mod sload_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 

--- a/bus-mapping/src/evm/opcodes/stackonlyop.rs
+++ b/bus-mapping/src/evm/opcodes/stackonlyop.rs
@@ -69,16 +69,12 @@ mod stackonlyop_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
@@ -135,16 +131,12 @@ mod stackonlyop_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
@@ -215,16 +207,12 @@ mod stackonlyop_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 

--- a/bus-mapping/src/evm/opcodes/swap.rs
+++ b/bus-mapping/src/evm/opcodes/swap.rs
@@ -84,16 +84,12 @@ mod swap_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder = CircuitInputBuilder::new(
-            block.eth_block,
-            block.block_ctants.clone(),
-        );
+        let mut test_builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         let mut tx = Transaction::new(&block.eth_tx);
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 

--- a/bus-mapping/src/evm/stack.rs
+++ b/bus-mapping/src/evm/stack.rs
@@ -7,8 +7,14 @@ use std::fmt;
 
 /// Represents a `StackAddress` of the EVM.
 /// The address range goes `TOP -> DOWN (1024, 0]`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub struct StackAddress(pub(crate) usize);
+
+impl fmt::Debug for StackAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}", self.0))
+    }
+}
 
 impl StackAddress {
     /// Generates a new StackAddress given a `usize`.

--- a/bus-mapping/src/exec_trace.rs
+++ b/bus-mapping/src/exec_trace.rs
@@ -1,140 +1,26 @@
 //! This module contains the logic for parsing and interacting with EVM
 //! execution traces.
-use crate::eth_types::Address;
-use crate::eth_types::U64;
-use crate::eth_types::{Block, Hash, Word};
 use crate::operation::Target;
-use serde::Serialize;
-use std::str::FromStr;
+use std::fmt;
 
-/// Definition of all of the constants related to an Ethereum block and
-/// chain.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct BlockConstants {
-    hash: Hash, // Until we know how to deal with it
-    coinbase: Address,
-    timestamp: Word,
-    number: U64, // u64
-    difficulty: Word,
-    gas_limit: Word,
-    chain_id: Word,
-    base_fee: Word,
-}
-
-impl BlockConstants {
-    /// Generate a BlockConstants from an ethereum block, useful for testing.
-    pub fn from_eth_block<TX>(
-        block: &Block<TX>,
-        chain_id: &Word,
-        &coinbase: &Address,
-    ) -> Self {
-        Self {
-            hash: block.hash.unwrap(),
-            coinbase,
-            timestamp: block.timestamp,
-            number: block.number.unwrap(),
-            difficulty: block.difficulty,
-            gas_limit: block.gas_limit,
-            chain_id: *chain_id,
-            base_fee: block.base_fee_per_gas.unwrap(),
-        }
-    }
-
-    /// Generate a new mock BlockConstants, useful for testing.
-    pub fn mock() -> Self {
-        BlockConstants {
-            hash: Hash::from([0u8; 32]),
-            coinbase: Address::from_str(
-                "0x00000000000000000000000000000000c014ba5e",
-            )
-            .unwrap(),
-            timestamp: Word::from(1633398551u64),
-            number: U64([123456u64]),
-            difficulty: Word::from(0x200000u64),
-            gas_limit: Word::from(15_000_000u64),
-            chain_id: Word::one(),
-            base_fee: Word::from(97u64),
-        }
-    }
-}
-
-impl BlockConstants {
-    #[allow(clippy::too_many_arguments)]
-    /// Generates a new `BlockConstants` instance from it's fields.
-    pub fn new(
-        hash: Hash,
-        coinbase: Address,
-        timestamp: Word,
-        number: U64,
-        difficulty: Word,
-        gas_limit: Word,
-        chain_id: Word,
-        base_fee: Word,
-    ) -> BlockConstants {
-        BlockConstants {
-            hash,
-            coinbase,
-            timestamp,
-            number,
-            difficulty,
-            gas_limit,
-            chain_id,
-            base_fee,
-        }
-    }
-    #[inline]
-    /// Return the hash of a block.
-    pub fn hash(&self) -> &Hash {
-        &self.hash
-    }
-
-    #[inline]
-    /// Return the coinbase of a block.
-    pub fn coinbase(&self) -> &Address {
-        &self.coinbase
-    }
-
-    #[inline]
-    /// Return the timestamp of a block.
-    pub fn timestamp(&self) -> &Word {
-        &self.timestamp
-    }
-
-    #[inline]
-    /// Return the block number.
-    pub fn number(&self) -> &U64 {
-        &self.number
-    }
-
-    #[inline]
-    /// Return the difficulty of a block.
-    pub fn difficulty(&self) -> &Word {
-        &self.difficulty
-    }
-
-    #[inline]
-    /// Return the gas_limit of a block.
-    pub fn gas_limit(&self) -> &Word {
-        &self.gas_limit
-    }
-
-    #[inline]
-    /// Return the chain ID associated to a block.
-    pub fn chain_id(&self) -> &Word {
-        &self.chain_id
-    }
-
-    #[inline]
-    /// Return the base fee of a block.
-    pub fn base_fee(&self) -> &Word {
-        &self.base_fee
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 /// The target and index of an `Operation` in the context of an
 /// `ExecutionTrace`.
 pub struct OperationRef(Target, usize);
+
+impl fmt::Debug for OperationRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "OperationRef{{ {}, {} }}",
+            match self.0 {
+                Target::Memory => "Memory",
+                Target::Stack => "Stack",
+                Target::Storage => "Storage",
+            },
+            self.1
+        ))
+    }
+}
 
 impl From<(Target, usize)> for OperationRef {
     fn from(op_ref_data: (Target, usize)) -> Self {

--- a/bus-mapping/src/external_tracer.rs
+++ b/bus-mapping/src/external_tracer.rs
@@ -1,9 +1,68 @@
 //! This module generates traces by connecting to an external tracer
-use crate::eth_types::{self, Address, GethExecStep, Word};
-use crate::BlockConstants;
+use crate::eth_types::{self, Address, Block, GethExecStep, Hash, Word, U64};
 use crate::Error;
 use geth_utils;
 use serde::Serialize;
+
+/// Definition of all of the constants related to an Ethereum block and
+/// chain to be used as setup for the external tracer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BlockConstants {
+    hash: Hash,
+    coinbase: Address,
+    timestamp: Word,
+    number: U64,
+    difficulty: Word,
+    gas_limit: Word,
+    chain_id: Word,
+    base_fee: Word,
+}
+
+impl BlockConstants {
+    /// Generate a BlockConstants from an ethereum block, useful for testing.
+    pub fn from_eth_block<TX>(
+        block: &Block<TX>,
+        chain_id: &Word,
+        &coinbase: &Address,
+    ) -> Self {
+        Self {
+            hash: block.hash.unwrap(),
+            coinbase,
+            timestamp: block.timestamp,
+            number: block.number.unwrap(),
+            difficulty: block.difficulty,
+            gas_limit: block.gas_limit,
+            chain_id: *chain_id,
+            base_fee: block.base_fee_per_gas.unwrap(),
+        }
+    }
+}
+
+impl BlockConstants {
+    #[allow(clippy::too_many_arguments)]
+    /// Generates a new `BlockConstants` instance from it's fields.
+    pub fn new(
+        hash: Hash,
+        coinbase: Address,
+        timestamp: Word,
+        number: U64,
+        difficulty: Word,
+        gas_limit: Word,
+        chain_id: Word,
+        base_fee: Word,
+    ) -> BlockConstants {
+        BlockConstants {
+            hash,
+            coinbase,
+            timestamp,
+            number,
+            difficulty,
+            gas_limit,
+            chain_id,
+            base_fee,
+        }
+    }
+}
 
 /// Definition of all of the constants related to an Ethereum transaction.
 #[derive(Debug, Clone, Serialize)]

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -48,10 +48,12 @@
 //! by the provided trace.
 //!
 //! ```rust
-//! use bus_mapping::{BlockConstants, Error};
+//! use bus_mapping::Error;
 //! use bus_mapping::evm::Gas;
 //! use bus_mapping::mock;
-//! use bus_mapping::eth_types::{self, Address, Word, Hash, U64, GethExecTrace, GethExecStep};
+//! use bus_mapping::eth_types::{
+//!     self, Address, Word, Hash, U64, GethExecTrace, GethExecStep, ChainConstants
+//! };
 //! use bus_mapping::circuit_input_builder::CircuitInputBuilder;
 //! use pairing::arithmetic::FieldExt;
 //!
@@ -103,23 +105,17 @@
 //! ]
 //! "#;
 //!
-//! let block_ctants = BlockConstants::new(
-//!     Hash::zero(),
-//!     Address::zero(),
-//!     Word::zero(),
-//!     U64::zero(),
-//!     Word::zero(),
-//!     Word::zero(),
-//!     Word::zero(),
-//!     Word::zero(),
-//! );
+//! let ctants = ChainConstants{
+//!     coinbase: Address::zero(),
+//!     chain_id: 0,
+//! };
 //!
 //! // We use some mock data as context for the trace
 //! let eth_block = mock::new_block();
 //! let eth_tx = mock::new_tx(&eth_block);
 //!
 //! let mut builder =
-//!     CircuitInputBuilder::new(eth_block, block_ctants);
+//!     CircuitInputBuilder::new(&eth_block, ctants);
 //!
 //! let geth_steps: Vec<GethExecStep> = serde_json::from_str(input_trace).unwrap();
 //! let geth_trace = GethExecTrace {
@@ -226,6 +222,5 @@ pub mod eth_types;
 pub(crate) mod geth_errors;
 pub mod mock;
 pub mod rpc;
-pub(crate) mod state_db;
+pub mod state_db;
 pub use error::Error;
-pub use exec_trace::BlockConstants;

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -10,6 +10,7 @@ pub use super::evm::{GlobalCounter, MemoryAddress, StackAddress};
 use crate::eth_types::{Address, Word};
 pub use container::OperationContainer;
 use core::cmp::Ordering;
+use core::fmt;
 use core::fmt::Debug;
 
 /// Marker that defines whether an Operation performs a `READ` or a `WRITE`.
@@ -57,11 +58,22 @@ pub trait Op: Eq + Ord {
 /// Represents a [`READ`](RW::READ)/[`WRITE`](RW::WRITE) into the memory implied
 /// by an specific [`OpcodeId`](crate::evm::opcodes::ids::OpcodeId) of the
 /// [`ExecStep`](crate::circuit_input_builder::ExecStep).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct MemoryOp {
     rw: RW,
     addr: MemoryAddress,
     value: u8,
+}
+
+impl fmt::Debug for MemoryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("MemoryOp { ")?;
+        f.write_fmt(format_args!(
+            "{:?}, addr: {:?}, value: 0x{:02x}",
+            self.rw, self.addr, self.value
+        ))?;
+        f.write_str(" }")
+    }
 }
 
 impl MemoryOp {
@@ -113,11 +125,22 @@ impl Ord for MemoryOp {
 /// Represents a [`READ`](RW::READ)/[`WRITE`](RW::WRITE) into the stack implied
 /// by an specific [`OpcodeId`](crate::evm::opcodes::ids::OpcodeId) of the
 /// [`ExecStep`](crate::circuit_input_builder::ExecStep).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct StackOp {
     rw: RW,
     addr: StackAddress,
     value: Word,
+}
+
+impl fmt::Debug for StackOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("StackOp { ")?;
+        f.write_fmt(format_args!(
+            "{:?}, addr: {:?}, value: {:?}",
+            self.rw, self.addr, self.value
+        ))?;
+        f.write_str(" }")
+    }
 }
 
 impl StackOp {
@@ -169,13 +192,24 @@ impl Ord for StackOp {
 /// Represents a [`READ`](RW::READ)/[`WRITE`](RW::WRITE) into the storage
 /// implied by an specific [`OpcodeId`](crate::evm::opcodes::ids::OpcodeId) of
 /// the [`ExecStep`](crate::circuit_input_builder::ExecStep).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct StorageOp {
     rw: RW,
     address: Address,
     key: Word,
     value: Word,
     value_prev: Word,
+}
+
+impl fmt::Debug for StorageOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("StorageOp { ")?;
+        f.write_fmt(format_args!(
+            "{:?}, addr: {:?}, key: {:?}, val_prev: {:?}, val: {:?}",
+            self.rw, self.address, self.key, self.value_prev, self.value,
+        ))?;
+        f.write_str(" }")
+    }
 }
 
 impl StorageOp {

--- a/bus-mapping/src/state_db.rs
+++ b/bus-mapping/src/state_db.rs
@@ -1,14 +1,21 @@
-use crate::eth_types::{Address, Word, H256};
+//! Implementation of an in-memory key-value database to represent the
+//! Ethereum State Trie.
+
+use crate::eth_types::{Address, Hash, Word};
 use std::collections::HashMap;
 
 /// Account of the Ethereum State Trie, which contains an in-memory key-value
 /// database that represents the Account Storage Trie.
 #[derive(Debug, PartialEq)]
 pub struct Account {
+    /// Nonce
     pub nonce: Word,
+    /// Balance
     pub balance: Word,
+    /// Storage key-value map
     pub storage: HashMap<Word, Word>,
-    pub codeHash: H256,
+    /// Code hash
+    pub code_hash: Hash,
 }
 
 impl Account {
@@ -17,7 +24,7 @@ impl Account {
             nonce: Word::zero(),
             balance: Word::zero(),
             storage: HashMap::new(),
-            codeHash: H256::zero(),
+            code_hash: Hash::zero(),
         }
     }
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,6 +14,8 @@ bus-mapping = { path = "../bus-mapping"}
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 url = "2.2.2"
 pretty_assertions = "1.0.0"
+log = "0.4.14"
+env_logger = "0.9"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
@@ -21,3 +23,4 @@ pretty_assertions = "1.0.0"
 [features]
 default = []
 rpc = []
+circuit_input_builder = []

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -3,7 +3,7 @@ set -e
 
 ARG_DEFAULT_SUDO=
 ARG_DEFAULT_STEPS="setup gendata tests cleanup"
-ARG_DEFAULT_TESTS="rpc"
+ARG_DEFAULT_TESTS="rpc circuit_input_builder"
 
 usage() {
     cat >&2 << EOF
@@ -97,7 +97,7 @@ fi
 if [ -n "$STEP_TESTS" ]; then
     for testname in $ARG_TESTS; do
         echo "+ Running test group $testname"
-        cargo test --test $testname --features $testname
+        cargo test --test $testname --features $testname -- --nocapture
     done
 fi
 

--- a/integration-tests/src/bin/gen_blockchain_data.rs
+++ b/integration-tests/src/bin/gen_blockchain_data.rs
@@ -9,9 +9,10 @@ use ethers::{
     solc::Solc,
 };
 use integration_tests::{
-    get_provider, get_wallet, CompiledContract, GenDataOutput, CONTRACTS,
-    CONTRACTS_PATH,
+    get_provider, get_wallet, log_init, CompiledContract, GenDataOutput,
+    CONTRACTS, CONTRACTS_PATH,
 };
+use log::{debug, info};
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
@@ -28,7 +29,7 @@ where
     T: Tokenize,
     M: Middleware,
 {
-    println!("Deploying {}...", compiled.name);
+    info!("Deploying {}...", compiled.name);
     let factory =
         ContractFactory::new(compiled.abi.clone(), compiled.bin.clone(), prov);
     factory
@@ -42,7 +43,9 @@ where
 
 #[tokio::main]
 async fn main() {
+    log_init();
     // Compile contracts
+    info!("Compiling contracts...");
     let mut contracts = HashMap::new();
     for (name, contract_path) in CONTRACTS {
         let path_sol = Path::new(CONTRACTS_PATH).join(contract_path);
@@ -90,11 +93,11 @@ async fn main() {
     loop {
         match prov.client_version().await {
             Ok(version) => {
-                println!("Geth online: {}", version);
+                info!("Geth online: {}", version);
                 break;
             }
             Err(err) => {
-                println!("Geth not available: {:?}", err);
+                debug!("Geth not available: {:?}", err);
                 sleep(Duration::from_millis(500));
             }
         }
@@ -114,9 +117,10 @@ async fn main() {
 
     let accounts = prov.get_accounts().await.expect("cannot get accounts");
     let wallet0 = get_wallet(0);
-    println!("wallet0: {:x}", wallet0.address());
+    info!("wallet0: {:x}", wallet0.address());
 
     // Transfer funds to our account.
+    info!("Transferring funds from coinbase...");
     let tx = TransactionRequest::new()
         .to(wallet0.address())
         .value(WEI_IN_ETHER) // send 1 ETH

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -3,8 +3,9 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_docs)]
 
-use bus_mapping::eth_types::Address;
+use bus_mapping::eth_types::{Address, ChainConstants};
 use bus_mapping::rpc::GethClient;
+use env_logger::Env;
 use ethers::{
     abi,
     core::k256::ecdsa::SigningKey,
@@ -41,6 +42,12 @@ lazy_static! {
     };
 }
 
+/// Initialize log
+pub fn log_init() {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+        .init();
+}
+
 /// Get the integration test [`GethClient`]
 pub fn get_client() -> GethClient<Http> {
     let transport = Http::new(Url::parse(&GETH0_URL).expect("invalid url"));
@@ -51,6 +58,15 @@ pub fn get_client() -> GethClient<Http> {
 pub fn get_provider() -> Provider<Http> {
     let transport = Http::new(Url::parse(&GETH0_URL).expect("invalid url"));
     Provider::new(transport).interval(Duration::from_millis(100))
+}
+
+/// Get the chain constants by querying the geth client.
+pub async fn get_chain_constants() -> ChainConstants {
+    let client = get_client();
+    ChainConstants {
+        coinbase: client.get_coinbase().await.unwrap(),
+        chain_id: client.get_chain_id().await.unwrap(),
+    }
 }
 
 const PHRASE: &str = "work man father plunge mystery proud hollow address reunion sauce theory bonus";

--- a/integration-tests/tests/circuit_input_builder.rs
+++ b/integration-tests/tests/circuit_input_builder.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "circuit_input_builder")]
+
+use bus_mapping::circuit_input_builder::{
+    gen_state_access_trace, AccessSet, CircuitInputBuilder,
+};
+use bus_mapping::eth_types::{Word, H256};
+use bus_mapping::state_db;
+use ethers::core::utils::keccak256;
+use integration_tests::{
+    get_chain_constants, get_client, log_init, GenDataOutput,
+};
+use lazy_static::lazy_static;
+use log::trace;
+use std::collections::HashMap;
+
+lazy_static! {
+    pub static ref GEN_DATA: GenDataOutput = GenDataOutput::load();
+}
+
+/// This test builds the complete circuit inputs for the block where the Greeter
+/// contract is deployed.
+#[tokio::test]
+async fn test_circuit_input_builder_block_a() {
+    log_init();
+    let (block_num, _address) = GEN_DATA.deployments.get("Greeter").unwrap();
+    let cli = get_client();
+
+    // 1. Query geth for Block, Txs and TxExecTraces
+    let eth_block = cli.get_block_by_number((*block_num).into()).await.unwrap();
+    let geth_trace = cli
+        .trace_block_by_number((*block_num).into())
+        .await
+        .unwrap();
+    let tx_index = 0;
+
+    // 2. Get State Accesses from TxExecTraces
+    let access_trace = gen_state_access_trace(
+        &eth_block,
+        &eth_block.transactions[tx_index],
+        &geth_trace[tx_index],
+    )
+    .unwrap();
+    trace!("AccessTrace:");
+    for access in &access_trace {
+        trace!("{:#?}", access);
+    }
+
+    let access_set = AccessSet::from(access_trace);
+    trace!("AccessSet: {:#?}", access_set);
+
+    // 3. Query geth for all accounts, storage keys, and codes from Accesses
+    let mut proofs = Vec::new();
+    for (address, key_set) in access_set.state {
+        let mut keys: Vec<Word> = key_set.iter().cloned().collect();
+        keys.sort();
+        let proof = cli
+            .get_proof(address, keys, (*block_num - 1).into())
+            .await
+            .unwrap();
+        proofs.push(proof);
+    }
+    let mut codes = HashMap::new();
+    for address in access_set.code {
+        let code = cli
+            .get_code(address, (*block_num - 1).into())
+            .await
+            .unwrap();
+        codes.insert(address, code);
+    }
+
+    let constants = get_chain_constants().await;
+    let mut builder = CircuitInputBuilder::new(&eth_block, constants);
+
+    // 4. Build a partial StateDB from step 3
+    for proof in proofs {
+        let mut storage = HashMap::new();
+        for storage_proof in proof.storage_proof {
+            storage.insert(storage_proof.key, storage_proof.value);
+        }
+        builder.sdb.set_account(
+            &proof.address,
+            state_db::Account {
+                nonce: proof.nonce,
+                balance: proof.balance,
+                storage,
+                code_hash: proof.code_hash,
+            },
+        )
+    }
+    trace!("StateDB: {:#?}", builder.sdb);
+
+    for (_address, code) in codes {
+        let hash = H256(keccak256(&code));
+        builder.codes.insert(hash, code.clone());
+    }
+
+    // 5. For each step in TxExecTraces, gen the associated ops and state
+    // circuit inputs
+    let block_geth_trace = cli
+        .trace_block_by_number((*block_num).into())
+        .await
+        .unwrap();
+    for (tx_index, tx) in eth_block.transactions.iter().enumerate() {
+        let geth_trace = &block_geth_trace[tx_index];
+        builder.handle_tx(tx, geth_trace).unwrap();
+    }
+
+    trace!("CircuitInputBuilder: {:#?}", builder);
+}

--- a/integration-tests/tests/rpc.rs
+++ b/integration-tests/tests/rpc.rs
@@ -2,7 +2,7 @@
 
 use bus_mapping::eth_types::{StorageProof, Word};
 use integration_tests::{
-    get_client, CompiledContract, GenDataOutput, CONTRACTS_PATH,
+    get_client, CompiledContract, GenDataOutput, CHAIN_ID, CONTRACTS_PATH,
 };
 use lazy_static::lazy_static;
 use pretty_assertions::assert_eq;
@@ -11,6 +11,20 @@ use std::path::Path;
 
 lazy_static! {
     pub static ref GEN_DATA: GenDataOutput = GenDataOutput::load();
+}
+
+#[tokio::test]
+async fn test_get_chain_id() {
+    let cli = get_client();
+    let chain_id = cli.get_chain_id().await.unwrap();
+    assert_eq!(CHAIN_ID, chain_id);
+}
+
+#[tokio::test]
+async fn test_get_coinbase() {
+    let cli = get_client();
+    let coinbase = cli.get_coinbase().await.unwrap();
+    assert_eq!(GEN_DATA.coinbase, coinbase);
 }
 
 #[tokio::test]
@@ -55,10 +69,7 @@ async fn test_get_contract_code() {
     .expect("cannot deserialize json from file");
 
     let cli = get_client();
-    let code = cli
-        .get_code_by_address(*address, (*block_num).into())
-        .await
-        .unwrap();
+    let code = cli.get_code(*address, (*block_num).into()).await.unwrap();
     assert_eq!(compiled.bin_runtime.to_vec(), code);
 }
 

--- a/zkevm-circuits/src/state_circuit/state.rs
+++ b/zkevm-circuits/src/state_circuit/state.rs
@@ -1971,10 +1971,8 @@ mod tests {
         let geth_steps: Vec<GethExecStep> =
             serde_json::from_str(input_trace).expect("Error on trace parsing");
         let block = mock::BlockData::new_single_tx_geth_steps(geth_steps);
-        let mut builder = CircuitInputBuilder::new(
-            block.eth_block.clone(),
-            block.block_ctants.clone(),
-        );
+        let mut builder =
+            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
         let stack_ops = builder.block.container.sorted_stack();


### PR DESCRIPTION
- CircuitInputBuilder:
    - Fix `gen_state_access_trace` by splitting the code and address in the
      context of a call.
    - Add `codes` field in the CircuitInputBuilder to keep a mapping of
      code hash -> code.
    - When doing the `gen_associated_ops` step for opcodes not yet
      implemented, instead of panic show a log warning, so that we can
      generate circuit inputs for blocks eventhough the implementation
      is not complete.  This will allow performing integration tests.
    - Resolve https://github.com/appliedzkp/zkevm-circuits/issues/207
- rpc:
    - Add `eth_coinbase` and `eth_chainId` methods.
    - Remove `BlockNumber` in favour of the implementation in `ethers`.
- General:
    - Replace usage of `BlockConstants` by the new struct
      `ChainConstants`.  This way we split constant parameters of the
      chain into `ChainConstants` and block parameters into `Block`.
      `BlockConstants` is now only used by the external_tracer.
    - Move `BlockConstants` from `bus-mapping/src/exec_trace.rs` to
      `bus-mapping/src/external_tracer.rs`.
    - Implement the Debug trait for some types manually to make debug
      output nicer.
    - Introduce a `circuit_input_builder` integration test with geth.
      The test builds the circuit inputs for the block where the
      Greeter.sol contract is deployed, up to step 5 from
      https://github.com/appliedzkp/zkevm-circuits/issues/222 (whith
      some missing parts)
    - Fix `mload` by allowing memory reads at addresses higher than the
      memory size found in the trace (in such case, a 0 value is read)