### PR TITLE
Fix `JUMP` and `JUMPI` to support 8 bytes for destination

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::MAX_CODE_SIZE_IN_BYTES,
+        param::NUM_BYTES_PROGRAM_COUNTER,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -22,7 +22,7 @@ use std::convert::TryInto;
 #[derive(Clone, Debug)]
 pub(crate) struct JumpGadget<F> {
     same_context: SameContextGadget<F>,
-    destination: RandomLinearCombination<F, MAX_CODE_SIZE_IN_BYTES>,
+    destination: RandomLinearCombination<F, NUM_BYTES_PROGRAM_COUNTER>,
 }
 
 impl<F: FieldExt> ExecutionGadget<F> for JumpGadget<F> {
@@ -80,7 +80,11 @@ impl<F: FieldExt> ExecutionGadget<F> for JumpGadget<F> {
         self.destination.assign(
             region,
             offset,
-            Some(destination.to_le_bytes()[..3].try_into().unwrap()),
+            Some(
+                destination.to_le_bytes()[..NUM_BYTES_PROGRAM_COUNTER]
+                    .try_into()
+                    .unwrap(),
+            ),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::MAX_GAS_SIZE_IN_BYTES,
+        param::{MAX_GAS_SIZE_IN_BYTES, NUM_ADDRESS_BYTES_USED},
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -164,7 +164,11 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
         self.address.assign(
             region,
             offset,
-            Some(address.to_le_bytes()[..5].try_into().unwrap()),
+            Some(
+                address.to_le_bytes()[..NUM_ADDRESS_BYTES_USED]
+                    .try_into()
+                    .unwrap(),
+            ),
         )?;
         self.value
             .assign(region, offset, Some(value.to_le_bytes()))?;

--- a/zkevm-circuits/src/evm_circuit/execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pc.rs
@@ -1,6 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
+        param::NUM_BYTES_PROGRAM_COUNTER,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -19,7 +20,7 @@ use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 #[derive(Clone, Debug)]
 pub(crate) struct PcGadget<F> {
     same_context: SameContextGadget<F>,
-    value: RandomLinearCombination<F, 8>,
+    value: RandomLinearCombination<F, NUM_BYTES_PROGRAM_COUNTER>,
 }
 
 impl<F: FieldExt> ExecutionGadget<F> for PcGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,7 +1,10 @@
 // Step dimension
-pub const STEP_WIDTH: usize = 32;
-pub const STEP_HEIGHT: usize = 10;
-pub const NUM_CELLS_STEP_STATE: usize = 10;
+pub(crate) const STEP_WIDTH: usize = 32;
+pub(crate) const STEP_HEIGHT: usize = 10;
+pub(crate) const NUM_CELLS_STEP_STATE: usize = 10;
+
+// The number of bytes an u64 has.
+pub(crate) const NUM_BYTES_U64: usize = 8;
 
 /// The maximum number of bytes that a field element
 /// can be broken down into without causing the value it
@@ -13,9 +16,11 @@ pub(crate) const MAX_GAS_SIZE_IN_BYTES: usize = 8;
 // Number of bytes that will be used of the address word.
 // If any of the other more signficant bytes are used it will
 // always result in an out-of-gas error.
-pub const NUM_ADDRESS_BYTES_USED: usize = 5;
-pub const MAX_MEMORY_SIZE_IN_BYTES: usize = 5;
-// Number of bytes that will be used of the JUMP* destination or code copy range
-// check. Although the deployed code has maximum size of 0x6000, the size of
-// a creation transaction could be 128KB, which needs 3 bytes to cover.
-pub const MAX_CODE_SIZE_IN_BYTES: usize = 3;
+pub(crate) const NUM_ADDRESS_BYTES_USED: usize = 5;
+pub(crate) const MAX_MEMORY_SIZE_IN_BYTES: usize = 5;
+// Number of bytes that will be used of prorgam counter. Although the maximum
+// size of execution bytecode could be at most 128kB due to the size limit of a
+// transaction, which could be covered by 3 bytes, we still support program
+// counter to u64 as go-ethereum in case transaction size is allowed larger in
+// the future.
+pub(crate) const NUM_BYTES_PROGRAM_COUNTER: usize = NUM_BYTES_U64;


### PR DESCRIPTION
This PR aims to fix the implementation of `JUMP` and `JUMPI` to support 8 bytes destination just like current `geth` implementation.

It previously assumes execution bytecode has maximum size <code>2<sup>24</sup>-1</code> and fit 3 bytes, because transaction size could only be up to 128kB. But the assumption would be broken if any change made to ethereum p2p protocol to allow a larger transaction size.

Also it simplify the check `is_zero` of condition to check the random linear combination directly instead of sum of bytes. (We already assume the random linear combination is collision resistent, so if random linear combination is zero, the decompose bytes should also sum to zero.)