### PR TITLE
gitignore circuit_benchmarks bench_params

### DIFF
--- a/circuit-benchmarks/.gitignore
+++ b/circuit-benchmarks/.gitignore
@@ -1,0 +1,1 @@
+src/bench_params.rs


### PR DESCRIPTION
currently circuit-benchmarks/src/bench_params.rs (if ever generated) will be easily added to git by mistake. But this should depend on the ENV config of different people