### PR TITLE
Use more instance columns for power of randomness

### DIFF
--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -31,8 +31,10 @@ impl<F: FieldExt> ExecutionGadget<F> for JumpGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::JUMP;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
-        let destination =
-            RandomLinearCombination::new(cb.query_bytes(), cb.randomness());
+        let destination = RandomLinearCombination::new(
+            cb.query_bytes(),
+            cb.power_of_randomness(),
+        );
 
         // Pop the value from the stack
         cb.stack_pop(destination.expr());

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -35,8 +35,10 @@ impl<F: FieldExt> ExecutionGadget<F> for JumpiGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::JUMPI;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
-        let destination =
-            RandomLinearCombination::new(cb.query_bytes(), cb.randomness());
+        let destination = RandomLinearCombination::new(
+            cb.query_bytes(),
+            cb.power_of_randomness(),
+        );
         let condition = cb.query_cell();
 
         // Pop the value from the stack

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -41,7 +41,8 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
         let opcode = cb.query_cell();
 
         // In successful case the address must be in 5 bytes
-        let address = MemoryAddress::new(cb.query_bytes(), cb.randomness());
+        let address =
+            MemoryAddress::new(cb.query_bytes(), cb.power_of_randomness());
         let value = cb.query_word();
 
         // Check if this is an MLOAD

--- a/zkevm-circuits/src/evm_circuit/execution/msize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/msize.rs
@@ -37,7 +37,8 @@ impl<F: FieldExt> ExecutionGadget<F> for MsizeGadget<F> {
         );
 
         // Push the value on the stack
-        let value = RandomLinearCombination::new(bytes, cb.randomness());
+        let value =
+            RandomLinearCombination::new(bytes, cb.power_of_randomness());
         cb.stack_push(value.expr());
 
         // State transition

--- a/zkevm-circuits/src/evm_circuit/execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pc.rs
@@ -38,7 +38,8 @@ impl<F: FieldExt> ExecutionGadget<F> for PcGadget<F> {
         );
 
         // Push the value on the stack
-        let value = RandomLinearCombination::new(bytes, cb.randomness());
+        let value =
+            RandomLinearCombination::new(bytes, cb.power_of_randomness());
         cb.stack_push(value.expr());
 
         // State transition

--- a/zkevm-circuits/src/evm_circuit/execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/push.rs
@@ -95,7 +95,7 @@ impl<F: FieldExt> ExecutionGadget<F> for PushGadget<F> {
         );
 
         // Push the value on the stack
-        let value = Word::new(bytes, cb.randomness());
+        let value = Word::new(bytes, cb.power_of_randomness());
         cb.stack_push(value.expr());
 
         // State transition

--- a/zkevm-circuits/src/evm_circuit/execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signextend.rs
@@ -124,7 +124,7 @@ impl<F: FieldExt> ExecutionGadget<F> for SignextendGadget<F> {
                     )
                 }
             }),
-            cb.randomness(),
+            cb.power_of_randomness(),
         );
 
         // Pop the byte index and the value from the stack, push the result on

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -88,18 +88,27 @@ impl<F: FieldExt, const N: usize> RandomLinearCombination<F, N> {
 
     pub(crate) fn random_linear_combine_expr(
         bytes: [Expression<F>; N],
-        randomness: Expression<F>,
+        power_of_randomness: &[Expression<F>],
     ) -> Expression<F> {
-        bytes.iter().rev().fold(0.expr(), |acc, byte| {
-            acc * randomness.clone() + byte.clone()
-        })
+        assert!(bytes.len() <= power_of_randomness.len() + 1);
+
+        let mut rlc = bytes[0].clone();
+        for (byte, randomness) in
+            bytes[1..].iter().zip(power_of_randomness.iter())
+        {
+            rlc = rlc + byte.clone() * randomness.clone();
+        }
+        rlc
     }
 
-    pub(crate) fn new(cells: [Cell<F>; N], randomness: Expression<F>) -> Self {
+    pub(crate) fn new(
+        cells: [Cell<F>; N],
+        power_of_randomness: &[Expression<F>],
+    ) -> Self {
         Self {
             expression: Self::random_linear_combine_expr(
                 cells.clone().map(|cell| cell.expr()),
-                randomness,
+                power_of_randomness,
             ),
             cells,
         }


### PR DESCRIPTION
This PR aims to take down the random linear combination degree to 2, by introducing 31 constant instance columns with values <code>[r, r<sup>2</sup>, r<sup>3</sup>, ..., r<sup>31</sup>]</code>.