### PR TITLE
bus-mapping: Handle code_hash in CircuitInputBuilder, Define more Operations

### DIFF
--- a/bus-mapping/src/bytecode.rs
+++ b/bus-mapping/src/bytecode.rs
@@ -19,7 +19,7 @@ impl Bytecode {
     }
 
     /// Get the generated code
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_vec(&self) -> Vec<u8> {
         self.code.clone()
     }
 

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -10,7 +10,7 @@ use crate::geth_errors::*;
 use crate::operation::container::OperationContainer;
 use crate::operation::RW;
 use crate::operation::{Op, Operation};
-use crate::state_db::StateDB;
+use crate::state_db::{CodeDB, StateDB};
 use crate::Error;
 use core::fmt::Debug;
 use ethers_core::utils::{get_contract_address, get_create2_address};
@@ -252,6 +252,8 @@ pub struct Call {
     is_root: bool,
     /// Address where this call is being executed
     pub address: Address,
+    /// Code Source
+    code_source: CodeSource,
     /// Code Hash
     code_hash: Hash,
 }
@@ -341,27 +343,40 @@ pub struct Transaction {
 
 impl Transaction {
     /// Create a new Self.
-    pub fn new(eth_tx: &eth_types::Transaction) -> Self {
+    pub fn new(
+        sdb: &StateDB,
+        code_db: &mut CodeDB,
+        eth_tx: &eth_types::Transaction,
+    ) -> Result<Self, Error> {
         let mut calls = Vec::new();
-        let code_hash = Hash::zero();
         if let Some(address) = eth_tx.to {
+            // Contract Call / Transfer
+            let (found, account) = sdb.get_account(&address);
+            if !found {
+                return Err(Error::AccountNotFound(address));
+            }
+            let code_hash = account.code_hash;
             calls.push(Call {
                 kind: CallKind::Call,
                 is_static: false,
                 is_root: true,
                 address,
+                code_source: CodeSource::Address(address),
                 code_hash,
             });
         } else {
+            // Contract creation
+            let code_hash = code_db.insert(eth_tx.input.to_vec());
             calls.push(Call {
                 kind: CallKind::Create,
                 is_static: false,
                 is_root: true,
-                address: Address::zero(),
+                address: get_contract_address(eth_tx.from, eth_tx.nonce),
+                code_source: CodeSource::Tx,
                 code_hash,
             });
         }
-        Self {
+        Ok(Self {
             nonce: eth_tx.nonce.as_u64(),
             gas: eth_tx.gas.as_u64(),
             from: eth_tx.from,
@@ -371,7 +386,7 @@ impl Transaction {
 
             calls,
             steps: Vec::new(),
-        }
+        })
     }
 
     /// Wether this [`Transaction`] is a create one
@@ -394,15 +409,17 @@ impl Transaction {
         parent_index: usize,
         kind: CallKind,
         address: Address,
+        code_source: CodeSource,
+        code_hash: Hash,
     ) -> usize {
         let is_static =
             kind == CallKind::StaticCall || self.calls[parent_index].is_static;
-        let code_hash = Hash::zero();
         self.calls.push(Call {
             kind,
             is_static,
             is_root: false,
             address,
+            code_source,
             code_hash,
         });
         self.calls.len() - 1
@@ -414,6 +431,8 @@ impl Transaction {
 pub struct CircuitInputStateRef<'a> {
     /// StateDB
     pub sdb: &'a mut StateDB,
+    /// CodeDB
+    pub code_db: &'a mut CodeDB,
     /// Block
     pub block: &'a mut Block,
     /// Block Context
@@ -424,18 +443,6 @@ pub struct CircuitInputStateRef<'a> {
     pub tx_ctx: &'a mut TransactionContext,
     /// Step
     pub step: &'a mut ExecStep,
-}
-
-/// Helper function to push a call into a Transaction and TransactionContext
-fn push_call(
-    tx: &mut Transaction,
-    tx_ctx: &mut TransactionContext,
-    kind: CallKind,
-    address: Address,
-) {
-    let parent_index = tx_ctx.call_index();
-    let index = tx.push_call(parent_index, kind, address);
-    tx_ctx.push_call_index_ctx(index, CallContext { swc: 0 });
 }
 
 impl<'a> CircuitInputStateRef<'a> {
@@ -468,182 +475,25 @@ impl<'a> CircuitInputStateRef<'a> {
 
     /// Push a new [`Call`] into the [`Transaction`], and add its index and
     /// [`CallContext`] in the `call_stack` of the [`TransactionContext`]
-    pub fn push_call(&mut self, kind: CallKind, address: Address) {
-        push_call(self.tx, self.tx_ctx, kind, address)
-    }
-}
-
-#[derive(Debug)]
-/// Builder to generate a complete circuit input from data gathered from a geth
-/// instance. This structure is the centre of the crate and is intended to be
-/// the only entry point to it. The `CircuitInputBuilder` works in several
-/// steps:
-///
-/// 1. Take a [`eth_types::Block`] to build the circuit input associated with
-/// the block. 2. For each [`eth_types::Transaction`] in the block, take the
-/// [`eth_types::GethExecTrace`] to    build the circuit input associated with
-/// each transaction, and the bus-mapping operations    associated with each
-/// `eth_types::GethExecStep`] in the [`eth_types::GethExecTrace`].
-///
-/// The generated bus-mapping operations are:
-/// [`StackOp`](crate::operation::StackOp)s,
-/// [`MemoryOp`](crate::operation::MemoryOp)s and
-/// [`StorageOp`](crate::operation::StorageOp), which correspond to each
-/// [`OpcodeId`](crate::evm::OpcodeId)s used in each `ExecTrace` step so that
-/// the State Proof witnesses are already generated on a structured manner and
-/// ready to be added into the State circuit.
-pub struct CircuitInputBuilder {
-    /// StateDB key-value DB
-    pub sdb: StateDB,
-    /// Map of account codes by code hash
-    pub codes: HashMap<Hash, Vec<u8>>,
-    /// Block
-    pub block: Block,
-    /// Block Context
-    pub block_ctx: BlockContext,
-}
-
-impl<'a> CircuitInputBuilder {
-    /// Create a new CircuitInputBuilder from the given `eth_block` and
-    /// `constants`.
-    pub fn new<TX>(
-        eth_block: &eth_types::Block<TX>,
-        constants: ChainConstants,
-    ) -> Self {
-        Self {
-            sdb: StateDB::new(),
-            codes: HashMap::new(),
-            block: Block::new(eth_block, constants),
-            block_ctx: BlockContext::new(),
-        }
-    }
-
-    /// Obtain a mutable reference to the state that the `CircuitInputBuilder`
-    /// maintains, contextualized to a particular transaction and a
-    /// particular execution step in that transaction.
-    pub fn state_ref(
-        &'a mut self,
-        tx: &'a mut Transaction,
-        tx_ctx: &'a mut TransactionContext,
-        step: &'a mut ExecStep,
-    ) -> CircuitInputStateRef {
-        CircuitInputStateRef {
-            sdb: &mut self.sdb,
-            block: &mut self.block,
-            block_ctx: &mut self.block_ctx,
-            tx,
-            tx_ctx,
-            step,
-        }
-    }
-
-    /// Handle a transaction with its corresponding execution trace to generate
-    /// all the associated operations.  Each operation is registered in
-    /// `self.block.container`, and each step stores the [`OperationRef`] to
-    /// each of the generated operations.
-    pub fn handle_tx(
+    pub fn push_call(
         &mut self,
-        eth_tx: &eth_types::Transaction,
-        geth_trace: &GethExecTrace,
-    ) -> Result<(), Error> {
-        let mut tx = Transaction::new(eth_tx);
-        let mut tx_ctx = TransactionContext::new(eth_tx);
-        for (index, geth_step) in geth_trace.struct_logs.iter().enumerate() {
-            let mut step = ExecStep::new(
-                geth_step,
-                tx_ctx.call_index(),
-                self.block_ctx.gc,
-                tx_ctx.call_ctx().swc,
-            );
-            let mut state_ref = self.state_ref(&mut tx, &mut tx_ctx, &mut step);
-            geth_step.op.gen_associated_ops(
-                &mut state_ref,
-                &geth_trace.struct_logs[index..],
-            )?;
-
-            if let Some(geth_next_step) = geth_trace.struct_logs.get(index + 1)
-            {
-                if geth_step.depth + 1 == geth_next_step.depth {
-                    // Handle *CALL*/CREATE*
-                    let address = state_ref.call_address(geth_step)?;
-                    let kind = CallKind::try_from(geth_step.op)?;
-                    push_call(&mut tx, &mut tx_ctx, kind, address);
-                } else if geth_step.depth - 1 == geth_next_step.depth {
-                    // Handle *CALL*/CREATE* return
-                    if tx_ctx.call_stack.len() == 1 {
-                        return Err(Error::InvalidGethExecStep(
-                            "handle_tx: call stack will be empty",
-                            Box::new(geth_step.clone()),
-                        ));
-                    }
-                    let (_, call_ctx) = tx_ctx
-                        .pop_call_index_ctx()
-                        .expect("call stack is empty");
-                    // If the return was successful, accumulate the swc from the
-                    // subcall.
-                    if !geth_next_step.stack.last()?.is_zero() {
-                        tx_ctx.call_ctx_mut().swc += call_ctx.swc;
-                    }
-                }
-            }
-            tx.steps.push(step);
-        }
-        self.block.txs.push(tx);
-        Ok(())
+        kind: CallKind,
+        address: Address,
+        code_source: CodeSource,
+        code_hash: Hash,
+    ) {
+        let parent_index = self.tx_ctx.call_index();
+        let index = self.tx.push_call(
+            parent_index,
+            kind,
+            address,
+            code_source,
+            code_hash,
+        );
+        self.tx_ctx
+            .push_call_index_ctx(index, CallContext { swc: 0 });
     }
-}
 
-fn get_step_reported_error(op: &OpcodeId, error: &str) -> ExecError {
-    if error == GETH_ERR_WRITE_PROTECTION {
-        ExecError::WriteProtection
-    } else if error == GETH_ERR_OUT_OF_GAS
-        || error == GETH_ERR_GAS_UINT_OVERFLOW
-    {
-        // NOTE: We report a GasUintOverflow error as an OutOfGas error
-        let oog_err = match op {
-            OpcodeId::SHA3 => OogError::Sha3,
-            OpcodeId::CALLDATACOPY => OogError::CallDataCopy,
-            OpcodeId::CODECOPY => OogError::CodeCopy,
-            OpcodeId::EXTCODECOPY => OogError::ExtCodeCopy,
-            OpcodeId::RETURNDATACOPY => OogError::ReturnDataCopy,
-            OpcodeId::LOG0
-            | OpcodeId::LOG2
-            | OpcodeId::LOG3
-            | OpcodeId::LOG4 => OogError::Log,
-            OpcodeId::CALL => OogError::Call,
-            OpcodeId::CALLCODE => OogError::CallCode,
-            OpcodeId::DELEGATECALL => OogError::DelegateCall,
-            OpcodeId::CREATE2 => OogError::Create2,
-            OpcodeId::STATICCALL => OogError::StaticCall,
-            OpcodeId::MLOAD
-            | OpcodeId::MSTORE
-            | OpcodeId::MSTORE8
-            | OpcodeId::CREATE
-            | OpcodeId::RETURN
-            | OpcodeId::REVERT => OogError::PureMemory,
-            _ => OogError::Constant,
-        };
-        ExecError::OutOfGas(oog_err)
-    } else if error.starts_with(GETH_ERR_STACK_OVERFLOW) {
-        ExecError::StackOverflow
-    } else if error.starts_with(GETH_ERR_STACK_UNDERFLOW) {
-        ExecError::StackUnderflow
-    } else if error.starts_with(GETH_ERR_INVALID_OPCODE) {
-        ExecError::InvalidOpcode
-    } else {
-        panic!("Unknown GethExecStep.error: {}", error);
-    }
-}
-
-/// Retreive the init_code from memory for {CREATE, CREATE2}
-pub fn get_create_init_code(step: &GethExecStep) -> Result<&[u8], Error> {
-    let offset = step.stack.nth_last(1)?;
-    let length = step.stack.nth_last(2)?;
-    Ok(&step.memory.0[offset.low_u64() as usize
-        ..(offset.low_u64() + length.low_u64()) as usize])
-}
-
-impl<'a> CircuitInputStateRef<'a> {
     /// Return the contract address of a CREATE step.  This is calculated by
     /// inspecting the current address and its nonce from the StateDB.
     fn create_address(&self) -> Result<Address, Error> {
@@ -678,6 +528,53 @@ impl<'a> CircuitInputStateRef<'a> {
             OpcodeId::CREATE2 => self.create2_address(step)?,
             _ => return Err(Error::OpcodeIdNotCallType),
         })
+    }
+
+    /// Handle a *CALL*/CREATE* step.
+    fn handle_call_create(&mut self, step: &GethExecStep) -> Result<(), Error> {
+        let kind = CallKind::try_from(step.op)?;
+        let address = self.call_address(step)?;
+        let (code_source, code_hash) = match kind {
+            CallKind::Create | CallKind::Create2 => {
+                let init_code = get_create_init_code(step)?;
+                let code_hash = self.code_db.insert(init_code.to_vec());
+                (CodeSource::Memory, code_hash)
+            }
+            _ => {
+                let (found, account) = self.sdb.get_account(&address);
+                if !found {
+                    return Err(Error::AccountNotFound(address));
+                }
+                (CodeSource::Address(address), (account.code_hash))
+            }
+        };
+        self.push_call(kind, address, code_source, code_hash);
+        Ok(())
+    }
+
+    /// Handle a return step caused by any opcode that causes a return to the
+    /// previous call context.
+    fn handle_return(
+        &mut self,
+        step: &GethExecStep,
+        next_step: &GethExecStep,
+    ) -> Result<(), Error> {
+        if self.tx_ctx.call_stack.len() == 1 {
+            return Err(Error::InvalidGethExecStep(
+                "handle_tx: call stack will be empty",
+                Box::new(step.clone()),
+            ));
+        }
+        let (_, call_ctx) = self
+            .tx_ctx
+            .pop_call_index_ctx()
+            .expect("call stack is empty");
+        // If the return was successful, accumulate the swc from the
+        // subcall.
+        if !next_step.stack.last()?.is_zero() {
+            self.tx_ctx.call_ctx_mut().swc += call_ctx.swc;
+        }
+        Ok(())
     }
 
     fn get_step_err(
@@ -827,6 +724,172 @@ impl<'a> CircuitInputStateRef<'a> {
     }
 }
 
+#[derive(Debug)]
+/// Builder to generate a complete circuit input from data gathered from a geth
+/// instance. This structure is the centre of the crate and is intended to be
+/// the only entry point to it. The `CircuitInputBuilder` works in several
+/// steps:
+///
+/// 1. Take a [`eth_types::Block`] to build the circuit input associated with
+/// the block. 2. For each [`eth_types::Transaction`] in the block, take the
+/// [`eth_types::GethExecTrace`] to    build the circuit input associated with
+/// each transaction, and the bus-mapping operations    associated with each
+/// `eth_types::GethExecStep`] in the [`eth_types::GethExecTrace`].
+///
+/// The generated bus-mapping operations are:
+/// [`StackOp`](crate::operation::StackOp)s,
+/// [`MemoryOp`](crate::operation::MemoryOp)s and
+/// [`StorageOp`](crate::operation::StorageOp), which correspond to each
+/// [`OpcodeId`](crate::evm::OpcodeId)s used in each `ExecTrace` step so that
+/// the State Proof witnesses are already generated on a structured manner and
+/// ready to be added into the State circuit.
+pub struct CircuitInputBuilder {
+    /// StateDB key-value DB
+    pub sdb: StateDB,
+    /// Map of account codes by code hash
+    pub code_db: CodeDB,
+    /// Block
+    pub block: Block,
+    /// Block Context
+    pub block_ctx: BlockContext,
+}
+
+impl<'a> CircuitInputBuilder {
+    /// Create a new CircuitInputBuilder from the given `eth_block` and
+    /// `constants`.
+    pub fn new<TX>(
+        sdb: StateDB,
+        code_db: CodeDB,
+        eth_block: &eth_types::Block<TX>,
+        constants: ChainConstants,
+    ) -> Self {
+        Self {
+            sdb,
+            code_db,
+            block: Block::new(eth_block, constants),
+            block_ctx: BlockContext::new(),
+        }
+    }
+
+    /// Obtain a mutable reference to the state that the `CircuitInputBuilder`
+    /// maintains, contextualized to a particular transaction and a
+    /// particular execution step in that transaction.
+    pub fn state_ref(
+        &'a mut self,
+        tx: &'a mut Transaction,
+        tx_ctx: &'a mut TransactionContext,
+        step: &'a mut ExecStep,
+    ) -> CircuitInputStateRef {
+        CircuitInputStateRef {
+            sdb: &mut self.sdb,
+            code_db: &mut self.code_db,
+            block: &mut self.block,
+            block_ctx: &mut self.block_ctx,
+            tx,
+            tx_ctx,
+            step,
+        }
+    }
+
+    /// Create a new Transaction from a [`eth_types::Transaction`].
+    pub fn new_tx(
+        &mut self,
+        eth_tx: &eth_types::Transaction,
+    ) -> Result<Transaction, Error> {
+        Transaction::new(&self.sdb, &mut self.code_db, eth_tx)
+    }
+
+    /// Handle a transaction with its corresponding execution trace to generate
+    /// all the associated operations.  Each operation is registered in
+    /// `self.block.container`, and each step stores the [`OperationRef`] to
+    /// each of the generated operations.
+    pub fn handle_tx(
+        &mut self,
+        eth_tx: &eth_types::Transaction,
+        geth_trace: &GethExecTrace,
+    ) -> Result<(), Error> {
+        let mut tx = self.new_tx(eth_tx)?;
+        let mut tx_ctx = TransactionContext::new(eth_tx);
+        for (index, geth_step) in geth_trace.struct_logs.iter().enumerate() {
+            let mut step = ExecStep::new(
+                geth_step,
+                tx_ctx.call_index(),
+                self.block_ctx.gc,
+                tx_ctx.call_ctx().swc,
+            );
+            let mut state_ref = self.state_ref(&mut tx, &mut tx_ctx, &mut step);
+            geth_step.op.gen_associated_ops(
+                &mut state_ref,
+                &geth_trace.struct_logs[index..],
+            )?;
+
+            if let Some(geth_next_step) = geth_trace.struct_logs.get(index + 1)
+            {
+                if geth_step.depth + 1 == geth_next_step.depth {
+                    // Handle *CALL*/CREATE*
+                    state_ref.handle_call_create(geth_step)?;
+                } else if geth_step.depth - 1 == geth_next_step.depth {
+                    // Handle return
+                    state_ref.handle_return(geth_step, geth_next_step)?;
+                }
+            }
+            tx.steps.push(step);
+        }
+        self.block.txs.push(tx);
+        Ok(())
+    }
+}
+
+fn get_step_reported_error(op: &OpcodeId, error: &str) -> ExecError {
+    if error == GETH_ERR_WRITE_PROTECTION {
+        ExecError::WriteProtection
+    } else if error == GETH_ERR_OUT_OF_GAS
+        || error == GETH_ERR_GAS_UINT_OVERFLOW
+    {
+        // NOTE: We report a GasUintOverflow error as an OutOfGas error
+        let oog_err = match op {
+            OpcodeId::SHA3 => OogError::Sha3,
+            OpcodeId::CALLDATACOPY => OogError::CallDataCopy,
+            OpcodeId::CODECOPY => OogError::CodeCopy,
+            OpcodeId::EXTCODECOPY => OogError::ExtCodeCopy,
+            OpcodeId::RETURNDATACOPY => OogError::ReturnDataCopy,
+            OpcodeId::LOG0
+            | OpcodeId::LOG2
+            | OpcodeId::LOG3
+            | OpcodeId::LOG4 => OogError::Log,
+            OpcodeId::CALL => OogError::Call,
+            OpcodeId::CALLCODE => OogError::CallCode,
+            OpcodeId::DELEGATECALL => OogError::DelegateCall,
+            OpcodeId::CREATE2 => OogError::Create2,
+            OpcodeId::STATICCALL => OogError::StaticCall,
+            OpcodeId::MLOAD
+            | OpcodeId::MSTORE
+            | OpcodeId::MSTORE8
+            | OpcodeId::CREATE
+            | OpcodeId::RETURN
+            | OpcodeId::REVERT => OogError::PureMemory,
+            _ => OogError::Constant,
+        };
+        ExecError::OutOfGas(oog_err)
+    } else if error.starts_with(GETH_ERR_STACK_OVERFLOW) {
+        ExecError::StackOverflow
+    } else if error.starts_with(GETH_ERR_STACK_UNDERFLOW) {
+        ExecError::StackUnderflow
+    } else if error.starts_with(GETH_ERR_INVALID_OPCODE) {
+        ExecError::InvalidOpcode
+    } else {
+        panic!("Unknown GethExecStep.error: {}", error);
+    }
+}
+
+/// Retreive the init_code from memory for {CREATE, CREATE2}
+pub fn get_create_init_code(step: &GethExecStep) -> Result<&[u8], Error> {
+    let offset = step.stack.nth_last(1)?;
+    let length = step.stack.nth_last(2)?;
+    Ok(&step.memory.0[offset.low_u64() as usize
+        ..(offset.low_u64() + length.low_u64()) as usize])
+}
+
 /// State and Code Access with "keys/index" used in the access operation.
 #[derive(Debug, PartialEq)]
 pub enum AccessValue {
@@ -918,7 +981,7 @@ impl From<Vec<Access>> for AccessSet {
 }
 
 /// Source of the code in the EVM execution.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum CodeSource {
     /// Code comes from a deployed contract at `Address`.
     Address(Address),
@@ -1101,12 +1164,11 @@ mod tracer_tests {
 
     impl CircuitInputBuilderTx {
         fn new(block: &mock::BlockData, geth_step: &GethExecStep) -> Self {
+            let mut builder = block.new_circuit_input_builder();
+            let tx = builder.new_tx(&block.eth_tx).unwrap();
             Self {
-                builder: CircuitInputBuilder::new(
-                    &block.eth_block,
-                    block.ctants.clone(),
-                ),
-                tx: Transaction::new(&block.eth_tx),
+                builder,
+                tx,
                 tx_ctx: TransactionContext::new(&block.eth_tx),
                 step: ExecStep::new(geth_step, 0, GlobalCounter(0), 0),
             }
@@ -1349,7 +1411,12 @@ mod tracer_tests {
 
         let mut builder = CircuitInputBuilderTx::new(&block, step);
         // Set up call context at CREATE2
-        builder.state_ref().push_call(CallKind::Create, *ADDR_B);
+        builder.state_ref().push_call(
+            CallKind::Create,
+            *ADDR_B,
+            CodeSource::Memory,
+            Hash::zero(),
+        );
         // Set up account and contract that exist during the second CREATE2
         builder.builder.sdb.set_account(
             &ADDR_B,
@@ -1456,7 +1523,12 @@ mod tracer_tests {
 
         let mut builder = CircuitInputBuilderTx::new(&block, step);
         // Set up call context at CREATE
-        builder.state_ref().push_call(CallKind::Create, *ADDR_B);
+        builder.state_ref().push_call(
+            CallKind::Create,
+            *ADDR_B,
+            CodeSource::Memory,
+            Hash::zero(),
+        );
         assert_eq!(
             builder.state_ref().get_step_err(step, next_step).unwrap(),
             Some(ExecError::CodeStoreOutOfGas)
@@ -1545,7 +1617,12 @@ mod tracer_tests {
 
         let mut builder = CircuitInputBuilderTx::new(&block, step);
         // Set up call context at RETURN
-        builder.state_ref().push_call(CallKind::Create, *ADDR_B);
+        builder.state_ref().push_call(
+            CallKind::Create,
+            *ADDR_B,
+            CodeSource::Memory,
+            Hash::zero(),
+        );
         assert_eq!(
             builder.state_ref().get_step_err(step, next_step).unwrap(),
             Some(ExecError::InvalidCode)
@@ -1632,7 +1709,12 @@ mod tracer_tests {
 
         let mut builder = CircuitInputBuilderTx::new(&block, step);
         // Set up call context at RETURN
-        builder.state_ref().push_call(CallKind::Create, *ADDR_B);
+        builder.state_ref().push_call(
+            CallKind::Create,
+            *ADDR_B,
+            CodeSource::Memory,
+            Hash::zero(),
+        );
         assert_eq!(
             builder.state_ref().get_step_err(step, next_step).unwrap(),
             Some(ExecError::MaxCodeSizeExceeded)
@@ -1704,7 +1786,12 @@ mod tracer_tests {
 
         let mut builder = CircuitInputBuilderTx::new(&block, step);
         // Set up call context at STOP
-        builder.state_ref().push_call(CallKind::Create, *ADDR_B);
+        builder.state_ref().push_call(
+            CallKind::Create,
+            *ADDR_B,
+            CodeSource::Memory,
+            Hash::zero(),
+        );
         assert_eq!(
             builder.state_ref().get_step_err(step, next_step).unwrap(),
             None
@@ -2184,7 +2271,12 @@ mod tracer_tests {
             .unwrap();
         let mut builder = CircuitInputBuilderTx::new(&block, step_create2);
         // Set up call context at CREATE2
-        builder.state_ref().push_call(CallKind::Create, *ADDR_B);
+        builder.state_ref().push_call(
+            CallKind::Create,
+            *ADDR_B,
+            CodeSource::Memory,
+            Hash::zero(),
+        );
         let addr = builder.state_ref().create2_address(step_create2).unwrap();
 
         assert_eq!(addr.to_word(), addr_expect);
@@ -2272,7 +2364,12 @@ mod tracer_tests {
             .unwrap();
         let mut builder = CircuitInputBuilderTx::new(&block, step_create);
         // Set up call context at CREATE
-        builder.state_ref().push_call(CallKind::Create, *ADDR_B);
+        builder.state_ref().push_call(
+            CallKind::Create,
+            *ADDR_B,
+            CodeSource::Memory,
+            Hash::zero(),
+        );
         builder.builder.sdb.set_account(
             &ADDR_B,
             Account {

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -404,6 +404,11 @@ impl Transaction {
         &mut self.steps
     }
 
+    /// Return the list of calls of this transaction.
+    pub fn calls(&self) -> &[Call] {
+        &self.calls
+    }
+
     fn push_call(
         &mut self,
         parent_index: usize,

--- a/bus-mapping/src/evm/opcodes/dup.rs
+++ b/bus-mapping/src/evm/opcodes/dup.rs
@@ -37,9 +37,7 @@ mod dup_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         evm::StackAddress,
         mock, word,
     };
@@ -62,13 +60,11 @@ mod dup_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate steps corresponding to DUP1, DUP3, DUP5

--- a/bus-mapping/src/evm/opcodes/mload.rs
+++ b/bus-mapping/src/evm/opcodes/mload.rs
@@ -65,9 +65,7 @@ mod mload_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         eth_types::Word,
         evm::StackAddress,
         mock,
@@ -89,13 +87,11 @@ mod mload_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to MLOAD

--- a/bus-mapping/src/evm/opcodes/mstore.rs
+++ b/bus-mapping/src/evm/opcodes/mstore.rs
@@ -64,9 +64,7 @@ mod mstore_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         eth_types::Word,
         evm::{MemoryAddress, StackAddress},
         mock,
@@ -88,13 +86,11 @@ mod mstore_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to MSTORE
@@ -160,15 +156,11 @@ mod mstore_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            &block.eth_block.clone(),
-            block.ctants.clone(),
-        );
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to MSTORE

--- a/bus-mapping/src/evm/opcodes/pc.rs
+++ b/bus-mapping/src/evm/opcodes/pc.rs
@@ -34,9 +34,7 @@ mod pc_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         eth_types::Word,
         evm::StackAddress,
         mock,
@@ -57,13 +55,11 @@ mod pc_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to MLOAD

--- a/bus-mapping/src/evm/opcodes/pop.rs
+++ b/bus-mapping/src/evm/opcodes/pop.rs
@@ -34,9 +34,7 @@ mod pop_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         eth_types::Word,
         evm::StackAddress,
         mock,
@@ -56,15 +54,11 @@ mod pop_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder = CircuitInputBuilder::new(
-            &block.eth_block.clone(),
-            block.ctants.clone(),
-        );
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to POP

--- a/bus-mapping/src/evm/opcodes/push.rs
+++ b/bus-mapping/src/evm/opcodes/push.rs
@@ -37,9 +37,7 @@ mod push_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         evm::StackAddress,
         mock, word,
     };
@@ -59,13 +57,11 @@ mod push_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate steps corresponding to PUSH1 80, PUSH2 1234,

--- a/bus-mapping/src/evm/opcodes/sload.rs
+++ b/bus-mapping/src/evm/opcodes/sload.rs
@@ -52,9 +52,7 @@ mod sload_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         eth_types::{Address, Word},
         evm::StackAddress,
         mock,
@@ -80,13 +78,11 @@ mod sload_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to SLOAD

--- a/bus-mapping/src/evm/opcodes/stackonlyop.rs
+++ b/bus-mapping/src/evm/opcodes/stackonlyop.rs
@@ -47,9 +47,7 @@ mod stackonlyop_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         eth_types::Word,
         evm::StackAddress,
         mock, word,
@@ -69,13 +67,11 @@ mod stackonlyop_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to NOT
@@ -131,13 +127,11 @@ mod stackonlyop_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to ADD
@@ -207,13 +201,11 @@ mod stackonlyop_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate step corresponding to ADDMOD

--- a/bus-mapping/src/evm/opcodes/swap.rs
+++ b/bus-mapping/src/evm/opcodes/swap.rs
@@ -55,9 +55,7 @@ mod swap_tests {
     use super::*;
     use crate::{
         bytecode,
-        circuit_input_builder::{
-            CircuitInputBuilder, ExecStep, Transaction, TransactionContext,
-        },
+        circuit_input_builder::{ExecStep, TransactionContext},
         eth_types::Word,
         evm::StackAddress,
         mock,
@@ -84,13 +82,11 @@ mod swap_tests {
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
 
-        let mut builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
+        let mut builder = block.new_circuit_input_builder();
         builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-        let mut test_builder =
-            CircuitInputBuilder::new(&block.eth_block, block.ctants.clone());
-        let mut tx = Transaction::new(&block.eth_tx);
+        let mut test_builder = block.new_circuit_input_builder();
+        let mut tx = test_builder.new_tx(&block.eth_tx).unwrap();
         let mut tx_ctx = TransactionContext::new(&block.eth_tx);
 
         // Generate steps corresponding to DUP1, DUP3, DUP5

--- a/bus-mapping/src/exec_trace.rs
+++ b/bus-mapping/src/exec_trace.rs
@@ -16,6 +16,11 @@ impl fmt::Debug for OperationRef {
                 Target::Memory => "Memory",
                 Target::Stack => "Stack",
                 Target::Storage => "Storage",
+                Target::TxAccessListAccount => "TxAccessListAccount",
+                Target::TxAccessListStorageSlot => "TxAccessListStorageSlot",
+                Target::TxRefund => "TxRefund",
+                Target::Account => "Account",
+                Target::AccountDestructed => "AccountDestructed",
             },
             self.1
         ))
@@ -28,6 +33,17 @@ impl From<(Target, usize)> for OperationRef {
             Target::Memory => Self(Target::Memory, op_ref_data.1),
             Target::Stack => Self(Target::Stack, op_ref_data.1),
             Target::Storage => Self(Target::Storage, op_ref_data.1),
+            Target::TxAccessListAccount => {
+                Self(Target::TxAccessListAccount, op_ref_data.1)
+            }
+            Target::TxAccessListStorageSlot => {
+                Self(Target::TxAccessListStorageSlot, op_ref_data.1)
+            }
+            Target::TxRefund => Self(Target::TxRefund, op_ref_data.1),
+            Target::Account => Self(Target::Account, op_ref_data.1),
+            Target::AccountDestructed => {
+                Self(Target::AccountDestructed, op_ref_data.1)
+            }
         }
     }
 }

--- a/bus-mapping/src/external_tracer.rs
+++ b/bus-mapping/src/external_tracer.rs
@@ -1,5 +1,7 @@
 //! This module generates traces by connecting to an external tracer
-use crate::eth_types::{self, Address, Block, GethExecStep, Hash, Word, U64};
+use crate::eth_types::{
+    self, Address, Block, Bytes, GethExecStep, Hash, Word, U64,
+};
 use crate::Error;
 use geth_utils;
 use serde::Serialize;
@@ -94,7 +96,7 @@ pub struct Account {
     /// Balance
     pub balance: Word,
     /// EVM Code
-    pub code: String,
+    pub code: Bytes,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -51,6 +51,7 @@
 //! use bus_mapping::Error;
 //! use bus_mapping::evm::Gas;
 //! use bus_mapping::mock;
+//! use bus_mapping::state_db::{self, StateDB, CodeDB};
 //! use bus_mapping::eth_types::{
 //!     self, Address, Word, Hash, U64, GethExecTrace, GethExecStep, ChainConstants
 //! };
@@ -113,9 +114,11 @@
 //! // We use some mock data as context for the trace
 //! let eth_block = mock::new_block();
 //! let eth_tx = mock::new_tx(&eth_block);
+//! let mut sdb = StateDB::new();
+//! sdb.set_account(&Address::zero(), state_db::Account::zero());
 //!
 //! let mut builder =
-//!     CircuitInputBuilder::new(&eth_block, ctants);
+//!     CircuitInputBuilder::new(sdb, CodeDB::new(), &eth_block, ctants);
 //!
 //! let geth_steps: Vec<GethExecStep> = serde_json::from_str(input_trace).unwrap();
 //! let geth_trace = GethExecTrace {

--- a/bus-mapping/src/operation/container.rs
+++ b/bus-mapping/src/operation/container.rs
@@ -1,4 +1,8 @@
-use super::{MemoryOp, Op, OpEnum, Operation, StackOp, StorageOp, Target};
+use super::{
+    AccountDestructedOp, AccountOp, MemoryOp, Op, OpEnum, Operation, StackOp,
+    StorageOp, Target, TxAccessListAccountOp, TxAccessListStorageSlotOp,
+    TxRefundOp,
+};
 use crate::exec_trace::OperationRef;
 use itertools::Itertools;
 
@@ -21,6 +25,14 @@ pub struct OperationContainer {
     pub(crate) memory: Vec<Operation<MemoryOp>>,
     pub(crate) stack: Vec<Operation<StackOp>>,
     pub(crate) storage: Vec<Operation<StorageOp>>,
+    pub(crate) tx_access_list_account: Vec<Operation<TxAccessListAccountOp>>,
+    pub(crate) tx_access_list_storage_slot:
+        Vec<Operation<TxAccessListStorageSlotOp>>,
+    pub(crate) tx_refund: Vec<Operation<TxRefundOp>>,
+    pub(crate) account: Vec<Operation<AccountOp>>,
+    pub(crate) account_destructed: Vec<Operation<AccountDestructedOp>>,
+    /* TODO
+     * pub(crate) call_context: Vec<Operation<CallContextOp>>, */
 }
 
 impl Default for OperationContainer {
@@ -37,6 +49,11 @@ impl OperationContainer {
             memory: Vec::new(),
             stack: Vec::new(),
             storage: Vec::new(),
+            tx_access_list_account: Vec::new(),
+            tx_access_list_storage_slot: Vec::new(),
+            tx_refund: Vec::new(),
+            account: Vec::new(),
+            account_destructed: Vec::new(),
         }
     }
 
@@ -58,6 +75,36 @@ impl OperationContainer {
             OpEnum::Storage(op) => {
                 self.storage.push(Operation::new(gc, op));
                 OperationRef::from((Target::Storage, self.storage.len()))
+            }
+            OpEnum::TxAccessListAccount(op) => {
+                self.tx_access_list_account.push(Operation::new(gc, op));
+                OperationRef::from((
+                    Target::TxAccessListAccount,
+                    self.tx_access_list_account.len(),
+                ))
+            }
+            OpEnum::TxAccessListStorageSlot(op) => {
+                self.tx_access_list_storage_slot
+                    .push(Operation::new(gc, op));
+                OperationRef::from((
+                    Target::TxAccessListStorageSlot,
+                    self.tx_access_list_storage_slot.len(),
+                ))
+            }
+            OpEnum::TxRefund(op) => {
+                self.tx_refund.push(Operation::new(gc, op));
+                OperationRef::from((Target::TxRefund, self.tx_refund.len()))
+            }
+            OpEnum::Account(op) => {
+                self.account.push(Operation::new(gc, op));
+                OperationRef::from((Target::Account, self.account.len()))
+            }
+            OpEnum::AccountDestructed(op) => {
+                self.account_destructed.push(Operation::new(gc, op));
+                OperationRef::from((
+                    Target::AccountDestructed,
+                    self.account_destructed.len(),
+                ))
             }
         }
     }

--- a/geth-utils/lib/lib.go
+++ b/geth-utils/lib/lib.go
@@ -5,7 +5,6 @@ package main
 */
 import "C"
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"main/gethutil"
@@ -76,7 +75,7 @@ type Transaction struct {
 type AccountData struct {
 	Address common.Address `json:"address"`
 	Balance *hexutil.Big   `json:"balance"`
-	Code    string         `json:"code"`
+	Code    hexutil.Bytes  `json:"code"`
 }
 
 type JsonConfig struct {
@@ -122,10 +121,7 @@ func (this *GethConfig) UnmarshalJSON(b []byte) error {
 	for _, contract := range jConfig.Accounts {
 		address := contract.Address
 		balance := contract.Balance.ToInt()
-		code, err := hex.DecodeString(contract.Code)
-		if err != nil {
-			return err
-		}
+		code := contract.Code
 		this.contracts = append(this.contracts, gethutil.Account{Address: address, Balance: balance, Bytecode: code})
 	}
 

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -233,11 +233,7 @@ mod test {
         block_trace.geth_trace.struct_logs = block_trace.geth_trace.struct_logs
             [bytecode.get_pos("start")..]
             .to_vec();
-        let mut builder =
-            bus_mapping::circuit_input_builder::CircuitInputBuilder::new(
-                &block_trace.eth_block.clone(),
-                block_trace.ctants.clone(),
-            );
+        let mut builder = block_trace.new_circuit_input_builder();
         builder
             .handle_tx(&block_trace.eth_tx, &block_trace.geth_trace)
             .unwrap();

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -379,6 +379,7 @@ fn step_convert(
                     bus_mapping::operation::Target::Storage => {
                         index + stack_ops_len + memory_ops_len
                     }
+                    _ => unimplemented!(),
                 }
             })
             .collect(),

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -355,7 +355,7 @@ impl From<&bus_mapping::circuit_input_builder::ExecStep> for ExecutionState {
 
 impl From<&bus_mapping::bytecode::Bytecode> for Bytecode {
     fn from(b: &bus_mapping::bytecode::Bytecode) -> Self {
-        Bytecode::new(b.to_bytes())
+        Bytecode::new(b.to_vec())
     }
 }
 
@@ -498,11 +498,7 @@ pub fn build_block_from_trace_code_at_start(
             bytecode,
         )
         .unwrap();
-    let mut builder =
-        bus_mapping::circuit_input_builder::CircuitInputBuilder::new(
-            &block.eth_block.clone(),
-            block.ctants.clone(),
-        );
+    let mut builder = block.new_circuit_input_builder();
     builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
     block_convert(bytecode, &builder.block)


### PR DESCRIPTION
NOTE: this PR contains 2 commits. They can be reviewed independently.

# bus-mapping: Handle code_hash in CircuitInputBuilder
- circuit_input_builder:
    - Add `code_source` in Call to distinguish the executed contract
      code from the contract address.
    - In every `*CALL*/CREATE*`, properly set the `code_hash` on the
      resutling `Call` object.  To do this we make use of the StateDB to
      query the `code_hash` of an address at a given execution step.
    - Require a partially-populated `StateDB` in the
      `CircuitInputBuilder` to `handle_tx`.  The accounts that are
      accessed in the block must be present in the `StateDB`.  Now the
      `CircuitInputBuilder` constructor takes a `StateDB` and `CodeDB`.
    - Move all methods of `CircuitInputStateRef` to the same impl block.
- state_db:
    - Add `CodeDB` to store contract code indexed by code hash.
- mock:
    - Introduce a helper method for the `mock::BlockData` to create a
      `CircuitInputBuilder` with the context and StateDB from the
      `BlockData`.  This way, tests don't need to manually populate the
      `StateDB` to work with the `CircuitInputBuilder`.
- zkevm-circuits:
    - Replace hardcoded geth trace in `state_circuit` test by dynamic
      trace generation using the `external_tracer`.

# bus-mapping: Define more Operations
- Define TxAccessListAccount, TxAccessListStorageSlot, TxRefund,
  Account, AccountDestructed in bus-mapping.  The only missing one now
  is CallContext.
- Resolve #173