### PR TITLE
bus-mapping: Add call_id in StackOp and MemoryOp

### DIFF
--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -55,39 +55,39 @@ impl ProgramCounter {
 /// Wrapper type over `usize` which represents the global counter associated to
 /// an [`ExecStep`](crate::circuit_input_builder::ExecStep) or
 /// [`Operation`](crate::operation::Operation). The purpose of the
-/// `GlobalCounter` is to enforce that each Opcode/Instruction and Operation is
+/// `RWCounter` is to enforce that each Opcode/Instruction and Operation is
 /// unique and just executed once.
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
-pub struct GlobalCounter(pub(crate) usize);
+pub struct RWCounter(pub(crate) usize);
 
-impl fmt::Debug for GlobalCounter {
+impl fmt::Debug for RWCounter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{}", self.0))
     }
 }
 
-impl From<GlobalCounter> for usize {
-    fn from(addr: GlobalCounter) -> usize {
+impl From<RWCounter> for usize {
+    fn from(addr: RWCounter) -> usize {
         addr.0
     }
 }
 
-impl From<usize> for GlobalCounter {
-    fn from(gc: usize) -> Self {
-        GlobalCounter(gc)
+impl From<usize> for RWCounter {
+    fn from(rwc: usize) -> Self {
+        RWCounter(rwc)
     }
 }
 
-impl Default for GlobalCounter {
+impl Default for RWCounter {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl GlobalCounter {
-    /// Create a new GlobalCounter with the initial default value
+impl RWCounter {
+    /// Create a new RWCounter with the initial default value
     pub fn new() -> Self {
-        Self(0)
+        Self(1)
     }
 
     /// Increase Self by one

--- a/bus-mapping/src/evm/opcodes/dup.rs
+++ b/bus-mapping/src/evm/opcodes/dup.rs
@@ -1,10 +1,7 @@
 use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
-use crate::{
-    operation::{StackOp, RW},
-    Error,
-};
+use crate::{operation::RW, Error};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the `OpcodeId::DUP*` `OpcodeId`.
@@ -20,13 +17,13 @@ impl<const N: usize> Opcode for Dup<N> {
 
         let stack_value_read = step.stack.nth_last(N - 1)?;
         let stack_position = step.stack.nth_last_filled(N - 1);
-        state.push_op(StackOp::new(RW::READ, stack_position, stack_value_read));
+        state.push_stack_op(RW::READ, stack_position, stack_value_read);
 
-        state.push_op(StackOp::new(
+        state.push_stack_op(
             RW::WRITE,
             step.stack.last_filled().map(|a| a - 1),
             stack_value_read,
-        ));
+        );
 
         Ok(())
     }
@@ -75,23 +72,23 @@ mod dup_tests {
             let mut step = ExecStep::new(
                 &block.geth_trace.struct_logs[i],
                 0,
-                test_builder.block_ctx.gc,
+                test_builder.block_ctx.rwc,
                 0,
             );
             let mut state_ref =
                 test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
 
-            state_ref.push_op(StackOp::new(
+            state_ref.push_stack_op(
                 RW::READ,
                 StackAddress(1024 - 3 + i),
                 *word,
-            ));
+            );
 
-            state_ref.push_op(StackOp::new(
+            state_ref.push_stack_op(
                 RW::WRITE,
                 StackAddress(1024 - 4 - i),
                 *word,
-            ));
+            );
 
             tx.steps_mut().push(step);
         }

--- a/bus-mapping/src/evm/opcodes/jump.rs
+++ b/bus-mapping/src/evm/opcodes/jump.rs
@@ -1,10 +1,7 @@
 use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
-use crate::{
-    operation::{StackOp, RW},
-    Error,
-};
+use crate::{operation::RW, Error};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the [`OpcodeId::JUMP`](crate::evm::OpcodeId::JUMP)
@@ -20,12 +17,11 @@ impl Opcode for Jump {
         let step = &steps[0];
 
         // `JUMP` needs only one read operation
-        let op = StackOp::new(
+        state.push_stack_op(
             RW::READ,
             step.stack.nth_last_filled(0),
             step.stack.nth_last(0)?,
         );
-        state.push_op(op);
 
         Ok(())
     }
@@ -75,18 +71,18 @@ mod jump_tests {
         let mut step = ExecStep::new(
             &block.geth_trace.struct_logs[0],
             0,
-            test_builder.block_ctx.gc,
+            test_builder.block_ctx.rwc,
             0,
         );
         let mut state_ref =
             test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
 
         // Add the last Stack read
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress::from(1023),
             Word::from(destination),
-        ));
+        );
 
         tx.steps_mut().push(step);
         test_builder.block.txs_mut().push(tx);

--- a/bus-mapping/src/evm/opcodes/jumpi.rs
+++ b/bus-mapping/src/evm/opcodes/jumpi.rs
@@ -1,10 +1,7 @@
 use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
-use crate::{
-    operation::{StackOp, RW},
-    Error,
-};
+use crate::{operation::RW, Error};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the [`OpcodeId::JUMPI`](crate::evm::OpcodeId::JUMPI)
@@ -19,16 +16,16 @@ impl Opcode for Jumpi {
     ) -> Result<(), Error> {
         let step = &steps[0];
         // `JUMPI` needs two read operation
-        state.push_op(StackOp::new(
+        state.push_stack_op(
             RW::READ,
             step.stack.nth_last_filled(0),
             step.stack.nth_last(0)?,
-        ));
-        state.push_op(StackOp::new(
+        );
+        state.push_stack_op(
             RW::READ,
             step.stack.nth_last_filled(1),
             step.stack.nth_last(1)?,
-        ));
+        );
 
         Ok(())
     }
@@ -81,23 +78,23 @@ mod jumpi_tests {
         let mut step = ExecStep::new(
             &block.geth_trace.struct_logs[0],
             0,
-            test_builder.block_ctx.gc,
+            test_builder.block_ctx.rwc,
             0,
         );
         let mut state_ref =
             test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
 
         // Add the last 2 Stack reads
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress::from(1022),
             Word::from(destination),
-        ));
-        state_ref.push_op(StackOp::new(
+        );
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress::from(1023),
             Word::from(condition),
-        ));
+        );
 
         tx.steps_mut().push(step);
         test_builder.block.txs_mut().push(tx);

--- a/bus-mapping/src/evm/opcodes/pc.rs
+++ b/bus-mapping/src/evm/opcodes/pc.rs
@@ -1,10 +1,7 @@
 use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
-use crate::{
-    operation::{StackOp, RW},
-    Error,
-};
+use crate::{operation::RW, Error};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the [`OpcodeId::PC`](crate::evm::OpcodeId::PC) `OpcodeId`.
@@ -19,11 +16,11 @@ impl Opcode for Pc {
         let step = &steps[0];
         // Get value result from next step and do stack write
         let value = steps[1].stack.last()?;
-        state.push_op(StackOp::new(
+        state.push_stack_op(
             RW::WRITE,
             step.stack.last_filled().map(|a| a - 1),
             value,
-        ));
+        );
 
         Ok(())
     }
@@ -66,18 +63,18 @@ mod pc_tests {
         let mut step = ExecStep::new(
             &block.geth_trace.struct_logs[0],
             0,
-            test_builder.block_ctx.gc,
+            test_builder.block_ctx.rwc,
             0,
         );
         let mut state_ref =
             test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
 
         // Add the last Stack write
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::WRITE,
             StackAddress::from(1024 - 3),
             Word::from(0x4),
-        ));
+        );
 
         tx.steps_mut().push(step);
         test_builder.block.txs_mut().push(tx);

--- a/bus-mapping/src/evm/opcodes/pop.rs
+++ b/bus-mapping/src/evm/opcodes/pop.rs
@@ -1,10 +1,7 @@
 use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
-use crate::{
-    operation::{StackOp, RW},
-    Error,
-};
+use crate::{operation::RW, Error};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the POP stack operation
@@ -18,12 +15,11 @@ impl Opcode for Pop {
     ) -> Result<(), Error> {
         let step = &steps[0];
         // `POP` needs only one read operation
-        let op = StackOp::new(
+        state.push_stack_op(
             RW::READ,
             step.stack.nth_last_filled(0),
             step.stack.nth_last(0)?,
         );
-        state.push_op(op);
 
         Ok(())
     }
@@ -65,17 +61,17 @@ mod pop_tests {
         let mut step = ExecStep::new(
             &block.geth_trace.struct_logs[0],
             0,
-            test_builder.block_ctx.gc,
+            test_builder.block_ctx.rwc,
             0,
         );
         let mut state_ref =
             test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
         // Add StackOp associated to the stack pop.
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress::from(1023),
             Word::from(0x80u32),
-        ));
+        );
         tx.steps_mut().push(step);
         test_builder.block.txs_mut().push(tx);
 

--- a/bus-mapping/src/evm/opcodes/push.rs
+++ b/bus-mapping/src/evm/opcodes/push.rs
@@ -1,15 +1,12 @@
 use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
-use crate::{
-    operation::{StackOp, RW},
-    Error,
-};
+use crate::{operation::RW, Error};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to the `OpcodeId::PUSH*` `OpcodeId`.
-/// This is responsible of generating all of the associated [`StackOp`]s and
-/// place them inside the trace's
+/// This is responsible of generating all of the associated
+/// [`crate::operation::StackOp`]s and place them inside the trace's
 /// [`OperationContainer`](crate::operation::OperationContainer).
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct Push<const N: usize>;
@@ -20,13 +17,13 @@ impl<const N: usize> Opcode for Push<N> {
         steps: &[GethExecStep],
     ) -> Result<(), Error> {
         let step = &steps[0];
-        state.push_op(StackOp::new(
+        state.push_stack_op(
             RW::WRITE,
             // Get the value and addr from the next step. Being the last
             // position filled with an element in the stack
             step.stack.last_filled().map(|a| a - 1),
             steps[1].stack.last()?,
-        ));
+        );
 
         Ok(())
     }
@@ -77,18 +74,18 @@ mod push_tests {
             let mut step = ExecStep::new(
                 &block.geth_trace.struct_logs[i],
                 0,
-                test_builder.block_ctx.gc,
+                test_builder.block_ctx.rwc,
                 0,
             );
             let mut state_ref =
                 test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
 
             // Add StackOp associated to the push at the latest Stack pos.
-            state_ref.push_op(StackOp::new(
+            state_ref.push_stack_op(
                 RW::WRITE,
                 StackAddress::from(1023 - i),
                 *word,
-            ));
+            );
             tx.steps_mut().push(step);
         }
 

--- a/bus-mapping/src/evm/opcodes/sload.rs
+++ b/bus-mapping/src/evm/opcodes/sload.rs
@@ -2,7 +2,7 @@ use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
 use crate::{
-    operation::{StackOp, StorageOp, RW},
+    operation::{StorageOp, RW},
     Error,
 };
 
@@ -24,7 +24,7 @@ impl Opcode for Sload {
         let stack_position = step.stack.last_filled();
 
         // Manage first stack read at latest stack position
-        state.push_op(StackOp::new(RW::READ, stack_position, stack_value_read));
+        state.push_stack_op(RW::READ, stack_position, stack_value_read);
 
         // Storage read
         let storage_value_read = step.storage.get_or_err(&stack_value_read)?;
@@ -37,11 +37,7 @@ impl Opcode for Sload {
         ));
 
         // First stack write
-        state.push_op(StackOp::new(
-            RW::WRITE,
-            stack_position,
-            storage_value_read,
-        ));
+        state.push_stack_op(RW::WRITE, stack_position, storage_value_read);
 
         Ok(())
     }
@@ -89,17 +85,17 @@ mod sload_tests {
         let mut step = ExecStep::new(
             &block.geth_trace.struct_logs[0],
             0,
-            test_builder.block_ctx.gc,
+            test_builder.block_ctx.rwc,
             0,
         );
         let mut state_ref =
             test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
         // Add StackOp associated to the stack pop.
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress::from(1023),
             Word::from(0x0u32),
-        ));
+        );
         // Add StorageOp associated to the storage read.
         state_ref.push_op(StorageOp::new(
             RW::READ,
@@ -109,11 +105,11 @@ mod sload_tests {
             Word::from(0x6fu32),
         ));
         // Add StackOp associated to the stack push.
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::WRITE,
             StackAddress::from(1023),
             Word::from(0x6fu32),
-        ));
+        );
         tx.steps_mut().push(step);
         test_builder.block.txs_mut().push(tx);
 

--- a/bus-mapping/src/evm/opcodes/stackonlyop.rs
+++ b/bus-mapping/src/evm/opcodes/stackonlyop.rs
@@ -1,10 +1,7 @@
 use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
 use crate::eth_types::GethExecStep;
-use crate::{
-    operation::{StackOp, RW},
-    Error,
-};
+use crate::{operation::RW, Error};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
 /// corresponding to all the Stack only operations: take N words and return one.
@@ -23,20 +20,20 @@ impl<const N: usize> Opcode for StackOnlyOpcode<N> {
         let step = &steps[0];
         // N stack reads
         for i in 0..N {
-            state.push_op(StackOp::new(
+            state.push_stack_op(
                 RW::READ,
                 step.stack.nth_last_filled(i),
                 step.stack.nth_last(i)?,
-            ));
+            );
         }
 
         // Get operator result from next step and do stack write
         let result_value = steps[1].stack.last()?;
-        state.push_op(StackOp::new(
+        state.push_stack_op(
             RW::WRITE,
             step.stack.nth_last_filled(N - 1),
             result_value,
-        ));
+        );
 
         Ok(())
     }
@@ -78,25 +75,25 @@ mod stackonlyop_tests {
         let mut step = ExecStep::new(
             &block.geth_trace.struct_logs[0],
             0,
-            test_builder.block_ctx.gc,
+            test_builder.block_ctx.rwc,
             0,
         );
         let mut state_ref =
             test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
 
         // Read a
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress(1024 - 1),
             word!("0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"),
-        ));
+        );
 
         // Write ~a
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::WRITE,
             StackAddress(1024 - 1),
             word!("0xfffefdfcfbfaf9f8f7f6f5f4f3f2f1f0efeeedecebeae9e8e7e6e5e4e3e2e1e0"),
-        ));
+        );
 
         tx.steps_mut().push(step);
         test_builder.block.txs_mut().push(tx);
@@ -138,7 +135,7 @@ mod stackonlyop_tests {
         let mut step = ExecStep::new(
             &block.geth_trace.struct_logs[0],
             0,
-            test_builder.block_ctx.gc,
+            test_builder.block_ctx.rwc,
             0,
         );
         let mut state_ref =
@@ -151,25 +148,17 @@ mod stackonlyop_tests {
         let sum = Word::from(0x100);
 
         // Manage first stack read at latest stack position
-        state_ref.push_op(StackOp::new(
-            RW::READ,
-            last_stack_pointer,
-            stack_value_a,
-        ));
+        state_ref.push_stack_op(RW::READ, last_stack_pointer, stack_value_a);
 
         // Manage second stack read at second latest stack position
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::READ,
             second_last_stack_pointer,
             stack_value_b,
-        ));
+        );
 
         // Add StackOp associated to the 0x80 push at the latest Stack pos.
-        state_ref.push_op(StackOp::new(
-            RW::WRITE,
-            second_last_stack_pointer,
-            sum,
-        ));
+        state_ref.push_stack_op(RW::WRITE, second_last_stack_pointer, sum);
 
         tx.steps_mut().push(step);
         test_builder.block.txs_mut().push(tx);
@@ -212,35 +201,35 @@ mod stackonlyop_tests {
         let mut step = ExecStep::new(
             &block.geth_trace.struct_logs[0],
             0,
-            test_builder.block_ctx.gc,
+            test_builder.block_ctx.rwc,
             0,
         );
         let mut state_ref =
             test_builder.state_ref(&mut tx, &mut tx_ctx, &mut step);
 
         // Read a, b, n
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress(1024 - 3),
             Word::from(0x12345),
-        ));
-        state_ref.push_op(StackOp::new(
+        );
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress(1024 - 2),
             Word::from(0x6789a),
-        ));
-        state_ref.push_op(StackOp::new(
+        );
+        state_ref.push_stack_op(
             RW::READ,
             StackAddress(1024 - 1),
             Word::from(0xbcdef),
-        ));
+        );
 
         // Write a + b % n
-        state_ref.push_op(StackOp::new(
+        state_ref.push_stack_op(
             RW::WRITE,
             StackAddress(1024 - 1),
             Word::from(0x79bdf),
-        ));
+        );
 
         tx.steps_mut().push(step);
         test_builder.block.txs_mut().push(tx);

--- a/bus-mapping/src/exec_trace.rs
+++ b/bus-mapping/src/exec_trace.rs
@@ -17,7 +17,8 @@ impl fmt::Debug for OperationRef {
                 Target::Stack => "Stack",
                 Target::Storage => "Storage",
                 Target::TxAccessListAccount => "TxAccessListAccount",
-                Target::TxAccessListStorageSlot => "TxAccessListStorageSlot",
+                Target::TxAccessListAccountStorage =>
+                    "TxAccessListAccountStorage",
                 Target::TxRefund => "TxRefund",
                 Target::Account => "Account",
                 Target::AccountDestructed => "AccountDestructed",
@@ -36,8 +37,8 @@ impl From<(Target, usize)> for OperationRef {
             Target::TxAccessListAccount => {
                 Self(Target::TxAccessListAccount, op_ref_data.1)
             }
-            Target::TxAccessListStorageSlot => {
-                Self(Target::TxAccessListStorageSlot, op_ref_data.1)
+            Target::TxAccessListAccountStorage => {
+                Self(Target::TxAccessListAccountStorage, op_ref_data.1)
             }
             Target::TxRefund => Self(Target::TxRefund, op_ref_data.1),
             Target::Account => Self(Target::Account, op_ref_data.1),

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -6,7 +6,7 @@
 //!   [`OperationContainer`].
 pub(crate) mod container;
 
-pub use super::evm::{GlobalCounter, MemoryAddress, StackAddress};
+pub use super::evm::{MemoryAddress, RWCounter, StackAddress};
 use crate::eth_types::{Address, Word};
 pub use container::OperationContainer;
 use core::cmp::Ordering;
@@ -48,8 +48,8 @@ pub enum Target {
     Storage,
     /// Means the target of the operation is the TxAccessListAccount.
     TxAccessListAccount,
-    /// Means the target of the operation is the TxAccessListStorageSlot.
-    TxAccessListStorageSlot,
+    /// Means the target of the operation is the TxAccessListAccountStorage.
+    TxAccessListAccountStorage,
     /// Means the target of the operation is the TxRefund.
     TxRefund,
     /// Means the target of the operation is the Account.
@@ -72,6 +72,8 @@ pub trait Op: Eq + Ord {
 pub struct MemoryOp {
     /// RW
     pub rw: RW,
+    /// Call ID
+    pub call_id: usize,
     /// Memory Address
     pub address: MemoryAddress,
     /// Value
@@ -91,8 +93,18 @@ impl fmt::Debug for MemoryOp {
 
 impl MemoryOp {
     /// Create a new instance of a `MemoryOp` from it's components.
-    pub fn new(rw: RW, address: MemoryAddress, value: u8) -> MemoryOp {
-        MemoryOp { rw, address, value }
+    pub fn new(
+        rw: RW,
+        call_id: usize,
+        address: MemoryAddress,
+        value: u8,
+    ) -> MemoryOp {
+        MemoryOp {
+            rw,
+            call_id,
+            address,
+            value,
+        }
     }
 
     /// Returns the internal [`RW`] which says whether the operation corresponds
@@ -131,7 +143,7 @@ impl PartialOrd for MemoryOp {
 
 impl Ord for MemoryOp {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.address.cmp(&other.address)
+        (&self.call_id, &self.address).cmp(&(&other.call_id, &other.address))
     }
 }
 
@@ -142,6 +154,8 @@ impl Ord for MemoryOp {
 pub struct StackOp {
     /// RW
     pub rw: RW,
+    /// Call ID
+    pub call_id: usize,
     /// Stack Address
     pub address: StackAddress,
     /// Value
@@ -161,8 +175,18 @@ impl fmt::Debug for StackOp {
 
 impl StackOp {
     /// Create a new instance of a `MemoryOp` from it's components.
-    pub const fn new(rw: RW, address: StackAddress, value: Word) -> StackOp {
-        StackOp { rw, address, value }
+    pub const fn new(
+        rw: RW,
+        call_id: usize,
+        address: StackAddress,
+        value: Word,
+    ) -> StackOp {
+        StackOp {
+            rw,
+            call_id,
+            address,
+            value,
+        }
     }
 
     /// Returns the internal [`RW`] which says whether the operation corresponds
@@ -201,7 +225,7 @@ impl PartialOrd for StackOp {
 
 impl Ord for StackOp {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.address.cmp(&other.address)
+        (&self.call_id, &self.address).cmp(&(&other.call_id, &other.address))
     }
 }
 
@@ -297,10 +321,7 @@ impl PartialOrd for StorageOp {
 
 impl Ord for StorageOp {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.address.cmp(&other.address) {
-            Ordering::Equal => self.key.cmp(&other.key),
-            ord => ord,
-        }
+        (&self.address, &self.key).cmp(&(&other.address, &other.key))
     }
 }
 
@@ -338,10 +359,7 @@ impl PartialOrd for TxAccessListAccountOp {
 
 impl Ord for TxAccessListAccountOp {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.tx_id.cmp(&other.tx_id) {
-            Ordering::Equal => self.address.cmp(&other.address),
-            ord => ord,
-        }
+        (&self.tx_id, &self.address).cmp(&(&other.tx_id, &other.address))
     }
 }
 
@@ -354,7 +372,7 @@ impl Op for TxAccessListAccountOp {
 /// Represents a change in the Storage AccessList implied by an `SSTORE` or
 /// `SLOAD` step of the [`ExecStep`](crate::circuit_input_builder::ExecStep).
 #[derive(Clone, PartialEq, Eq)]
-pub struct TxAccessListStorageSlotOp {
+pub struct TxAccessListAccountStorageOp {
     /// Transaction ID: Transaction index in the block starting at 1.
     pub tx_id: usize,
     /// Account Address
@@ -367,9 +385,9 @@ pub struct TxAccessListStorageSlotOp {
     pub value_prev: bool,
 }
 
-impl fmt::Debug for TxAccessListStorageSlotOp {
+impl fmt::Debug for TxAccessListAccountStorageOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("TxAccessListStorageSlotOp { ")?;
+        f.write_str("TxAccessListAccountStorageOp { ")?;
         f.write_fmt(format_args!(
             "tx_id: {:?}, addr: {:?}, key: {:?}, val_prev: {:?}, val: {:?}",
             self.tx_id, self.address, self.key, self.value_prev, self.value
@@ -378,27 +396,25 @@ impl fmt::Debug for TxAccessListStorageSlotOp {
     }
 }
 
-impl PartialOrd for TxAccessListStorageSlotOp {
+impl PartialOrd for TxAccessListAccountStorageOp {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for TxAccessListStorageSlotOp {
+impl Ord for TxAccessListAccountStorageOp {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.tx_id.cmp(&other.tx_id) {
-            Ordering::Equal => match self.address.cmp(&other.address) {
-                Ordering::Equal => self.key.cmp(&other.key),
-                ord => ord,
-            },
-            ord => ord,
-        }
+        (&self.tx_id, &self.address, &self.key).cmp(&(
+            &other.tx_id,
+            &other.address,
+            &other.key,
+        ))
     }
 }
 
-impl Op for TxAccessListStorageSlotOp {
+impl Op for TxAccessListAccountStorageOp {
     fn into_enum(self) -> OpEnum {
-        OpEnum::TxAccessListStorageSlot(self)
+        OpEnum::TxAccessListAccountStorage(self)
     }
 }
 
@@ -494,10 +510,7 @@ impl PartialOrd for AccountOp {
 
 impl Ord for AccountOp {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.address.cmp(&other.address) {
-            Ordering::Equal => self.field.cmp(&other.field),
-            ord => ord,
-        }
+        (&self.address, &self.field).cmp(&(&other.address, &other.field))
     }
 }
 
@@ -540,10 +553,7 @@ impl PartialOrd for AccountDestructedOp {
 
 impl Ord for AccountDestructedOp {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.tx_id.cmp(&other.tx_id) {
-            Ordering::Equal => self.address.cmp(&other.address),
-            ord => ord,
-        }
+        (&self.tx_id, &self.address).cmp(&(&other.tx_id, &other.address))
     }
 }
 
@@ -568,8 +578,8 @@ pub enum OpEnum {
     Storage(StorageOp),
     /// TxAccessListAccount
     TxAccessListAccount(TxAccessListAccountOp),
-    /// TxAccessListStorageSlot
-    TxAccessListStorageSlot(TxAccessListStorageSlotOp),
+    /// TxAccessListAccountStorage
+    TxAccessListAccountStorage(TxAccessListAccountStorageOp),
     /// TxRefund
     TxRefund(TxRefundOp),
     /// Account
@@ -580,10 +590,10 @@ pub enum OpEnum {
      * CallContext(CallContextOp), */
 }
 
-/// Operation is a Wrapper over a type that implements Op with a GlobalCounter.
+/// Operation is a Wrapper over a type that implements Op with a RWCounter.
 #[derive(Debug, Clone)]
 pub struct Operation<T: Op> {
-    gc: GlobalCounter,
+    rwc: RWCounter,
     /// True when this Operation is a revert of its mirror
     revert: bool,
     op: T,
@@ -591,7 +601,7 @@ pub struct Operation<T: Op> {
 
 impl<T: Op> PartialEq for Operation<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.op.eq(&other.op) && self.gc == other.gc
+        self.op.eq(&other.op) && self.rwc == other.rwc
     }
 }
 
@@ -606,25 +616,25 @@ impl<T: Op> PartialOrd for Operation<T> {
 impl<T: Op> Ord for Operation<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.op.cmp(&other.op) {
-            Ordering::Equal => self.gc.cmp(&other.gc),
+            Ordering::Equal => self.rwc.cmp(&other.rwc),
             ord => ord,
         }
     }
 }
 
 impl<T: Op> Operation<T> {
-    /// Create a new Operation from an `op` with a `gc`
-    pub fn new(gc: GlobalCounter, op: T) -> Self {
+    /// Create a new Operation from an `op` with a `rwc`
+    pub fn new(rwc: RWCounter, op: T) -> Self {
         Self {
-            gc,
+            rwc,
             revert: false,
             op,
         }
     }
 
-    /// Return this `Operation` `gc`
-    pub fn gc(&self) -> GlobalCounter {
-        self.gc
+    /// Return this `Operation` `rwc`
+    pub fn rwc(&self) -> RWCounter {
+        self.rwc
     }
 
     /// Return this `Operation` `op`
@@ -693,16 +703,20 @@ mod operation_tests {
 
     #[test]
     fn unchecked_op_transmutations_are_safe() {
-        let stack_op =
-            StackOp::new(RW::WRITE, StackAddress::from(1024), Word::from(0x40));
+        let stack_op = StackOp::new(
+            RW::WRITE,
+            1,
+            StackAddress::from(1024),
+            Word::from(0x40),
+        );
 
         let stack_op_as_operation =
-            Operation::new(GlobalCounter(1), stack_op.clone());
+            Operation::new(RWCounter(1), stack_op.clone());
 
-        let memory_op = MemoryOp::new(RW::WRITE, MemoryAddress(0x40), 0x40);
+        let memory_op = MemoryOp::new(RW::WRITE, 1, MemoryAddress(0x40), 0x40);
 
         let memory_op_as_operation =
-            Operation::new(GlobalCounter(1), memory_op.clone());
+            Operation::new(RWCounter(1), memory_op.clone());
 
         assert_eq!(stack_op, stack_op_as_operation.op);
         assert_eq!(memory_op, memory_op_as_operation.op)

--- a/bus-mapping/src/operation/container.rs
+++ b/bus-mapping/src/operation/container.rs
@@ -1,6 +1,6 @@
 use super::{
     AccountDestructedOp, AccountOp, MemoryOp, Op, OpEnum, Operation, StackOp,
-    StorageOp, Target, TxAccessListAccountOp, TxAccessListStorageSlotOp,
+    StorageOp, Target, TxAccessListAccountOp, TxAccessListAccountStorageOp,
     TxRefundOp,
 };
 use crate::exec_trace::OperationRef;
@@ -27,7 +27,7 @@ pub struct OperationContainer {
     pub(crate) storage: Vec<Operation<StorageOp>>,
     pub(crate) tx_access_list_account: Vec<Operation<TxAccessListAccountOp>>,
     pub(crate) tx_access_list_storage_slot:
-        Vec<Operation<TxAccessListStorageSlotOp>>,
+        Vec<Operation<TxAccessListAccountStorageOp>>,
     pub(crate) tx_refund: Vec<Operation<TxRefundOp>>,
     pub(crate) account: Vec<Operation<AccountOp>>,
     pub(crate) account_destructed: Vec<Operation<AccountDestructedOp>>,
@@ -62,45 +62,45 @@ impl OperationContainer {
     /// location of the inserted operation inside the corresponding container
     /// vector.
     pub fn insert<T: Op>(&mut self, op: Operation<T>) -> OperationRef {
-        let gc = op.gc();
+        let rwc = op.rwc();
         match op.op.into_enum() {
             OpEnum::Memory(op) => {
-                self.memory.push(Operation::new(gc, op));
+                self.memory.push(Operation::new(rwc, op));
                 OperationRef::from((Target::Memory, self.memory.len()))
             }
             OpEnum::Stack(op) => {
-                self.stack.push(Operation::new(gc, op));
+                self.stack.push(Operation::new(rwc, op));
                 OperationRef::from((Target::Stack, self.stack.len()))
             }
             OpEnum::Storage(op) => {
-                self.storage.push(Operation::new(gc, op));
+                self.storage.push(Operation::new(rwc, op));
                 OperationRef::from((Target::Storage, self.storage.len()))
             }
             OpEnum::TxAccessListAccount(op) => {
-                self.tx_access_list_account.push(Operation::new(gc, op));
+                self.tx_access_list_account.push(Operation::new(rwc, op));
                 OperationRef::from((
                     Target::TxAccessListAccount,
                     self.tx_access_list_account.len(),
                 ))
             }
-            OpEnum::TxAccessListStorageSlot(op) => {
+            OpEnum::TxAccessListAccountStorage(op) => {
                 self.tx_access_list_storage_slot
-                    .push(Operation::new(gc, op));
+                    .push(Operation::new(rwc, op));
                 OperationRef::from((
-                    Target::TxAccessListStorageSlot,
+                    Target::TxAccessListAccountStorage,
                     self.tx_access_list_storage_slot.len(),
                 ))
             }
             OpEnum::TxRefund(op) => {
-                self.tx_refund.push(Operation::new(gc, op));
+                self.tx_refund.push(Operation::new(rwc, op));
                 OperationRef::from((Target::TxRefund, self.tx_refund.len()))
             }
             OpEnum::Account(op) => {
-                self.account.push(Operation::new(gc, op));
+                self.account.push(Operation::new(rwc, op));
                 OperationRef::from((Target::Account, self.account.len()))
             }
             OpEnum::AccountDestructed(op) => {
-                self.account_destructed.push(Operation::new(gc, op));
+                self.account_destructed.push(Operation::new(rwc, op));
                 OperationRef::from((
                     Target::AccountDestructed,
                     self.account_destructed.len(),
@@ -134,21 +134,21 @@ mod container_test {
 
     use crate::{
         eth_types::{Address, Word},
-        evm::{GlobalCounter, MemoryAddress, StackAddress},
+        evm::{MemoryAddress, RWCounter, StackAddress},
         operation::RW,
     };
 
     #[test]
     fn operation_container_test() {
-        let mut global_counter = GlobalCounter::default();
+        let mut global_counter = RWCounter::default();
         let mut operation_container = OperationContainer::default();
         let stack_operation = Operation::new(
             global_counter.inc_pre(),
-            StackOp::new(RW::WRITE, StackAddress(1023), Word::from(0x100)),
+            StackOp::new(RW::WRITE, 1, StackAddress(1023), Word::from(0x100)),
         );
         let memory_operation = Operation::new(
             global_counter.inc_pre(),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(1), 1),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(1), 1),
         );
         let storage_operation = Operation::new(
             global_counter.inc_pre(),

--- a/zkevm-circuits/src/state_circuit/state.rs
+++ b/zkevm-circuits/src/state_circuit/state.rs
@@ -712,7 +712,7 @@ impl<
         for (index, oper) in ops.iter().enumerate() {
             let op = oper.op();
             let address = F::from_bytes(&op.address().to_le_bytes()).unwrap();
-            let gc = usize::from(oper.gc());
+            let rwc = usize::from(oper.rwc());
             let val = F::from(op.value() as u64);
 
             let mut target = 1;
@@ -736,7 +736,7 @@ impl<
                 region,
                 offset,
                 address,
-                gc,
+                rwc,
                 val,
                 op.rw().is_write(),
                 target,
@@ -770,7 +770,7 @@ impl<
         for (index, oper) in ops.iter().enumerate() {
             let op = oper.op();
             let address = F::from(usize::from(*op.address()) as u64);
-            let gc = usize::from(oper.gc());
+            let rwc = usize::from(oper.rwc());
             let val = op.value().to_scalar().unwrap();
 
             let mut target = 1;
@@ -782,7 +782,7 @@ impl<
                 region,
                 offset,
                 address,
-                gc,
+                rwc,
                 val,
                 op.rw().is_write(),
                 target,
@@ -824,7 +824,7 @@ impl<
         for (index, oper) in ops.iter().enumerate() {
             let op = oper.op();
             let address = op.address().to_scalar().unwrap();
-            let gc = usize::from(oper.gc());
+            let rwc = usize::from(oper.rwc());
             let val = op.value().to_scalar().unwrap();
             let val_prev = op.value_prev().to_scalar().unwrap();
             let storage_key = op.key().to_scalar().unwrap();
@@ -838,7 +838,7 @@ impl<
                 region,
                 offset,
                 address,
-                gc,
+                rwc,
                 val,
                 op.rw().is_write(),
                 target,
@@ -1226,7 +1226,7 @@ mod tests {
     use bus_mapping::address;
     use bus_mapping::bytecode;
     use bus_mapping::eth_types::Word;
-    use bus_mapping::evm::{GlobalCounter, MemoryAddress, StackAddress};
+    use bus_mapping::evm::{MemoryAddress, RWCounter, StackAddress};
     use bus_mapping::mock;
 
     use bus_mapping::operation::{MemoryOp, Operation, StackOp, StorageOp, RW};
@@ -1300,34 +1300,34 @@ mod tests {
     #[test]
     fn state_circuit() {
         let memory_op_0 = Operation::new(
-            GlobalCounter::from(12),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(0), 32),
+            RWCounter::from(12),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(0), 32),
         );
         let memory_op_1 = Operation::new(
-            GlobalCounter::from(24),
-            MemoryOp::new(RW::READ, MemoryAddress::from(0), 32),
+            RWCounter::from(24),
+            MemoryOp::new(RW::READ, 1, MemoryAddress::from(0), 32),
         );
 
         let memory_op_2 = Operation::new(
-            GlobalCounter::from(17),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(1), 32),
+            RWCounter::from(17),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(1), 32),
         );
         let memory_op_3 = Operation::new(
-            GlobalCounter::from(87),
-            MemoryOp::new(RW::READ, MemoryAddress::from(1), 32),
+            RWCounter::from(87),
+            MemoryOp::new(RW::READ, 1, MemoryAddress::from(1), 32),
         );
 
         let stack_op_0 = Operation::new(
-            GlobalCounter::from(17),
-            StackOp::new(RW::WRITE, StackAddress::from(1), Word::from(32)),
+            RWCounter::from(17),
+            StackOp::new(RW::WRITE, 1, StackAddress::from(1), Word::from(32)),
         );
         let stack_op_1 = Operation::new(
-            GlobalCounter::from(87),
-            StackOp::new(RW::READ, StackAddress::from(1), Word::from(32)),
+            RWCounter::from(87),
+            StackOp::new(RW::READ, 1, StackAddress::from(1), Word::from(32)),
         );
 
         let storage_op_0 = Operation::new(
-            GlobalCounter::from(17),
+            RWCounter::from(17),
             StorageOp::new(
                 RW::WRITE,
                 address!("0x0000000000000000000000000000000000000001"),
@@ -1337,7 +1337,7 @@ mod tests {
             ),
         );
         let storage_op_1 = Operation::new(
-            GlobalCounter::from(18),
+            RWCounter::from(18),
             StorageOp::new(
                 RW::WRITE,
                 address!("0x0000000000000000000000000000000000000001"),
@@ -1347,7 +1347,7 @@ mod tests {
             ),
         );
         let storage_op_2 = Operation::new(
-            GlobalCounter::from(19),
+            RWCounter::from(19),
             StorageOp::new(
                 RW::WRITE,
                 address!("0x0000000000000000000000000000000000000001"),
@@ -1375,30 +1375,30 @@ mod tests {
     #[test]
     fn no_stack_padding() {
         let memory_op_0 = Operation::new(
-            GlobalCounter::from(12),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(0), 32),
+            RWCounter::from(12),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(0), 32),
         );
         let memory_op_1 = Operation::new(
-            GlobalCounter::from(24),
-            MemoryOp::new(RW::READ, MemoryAddress::from(0), 32),
+            RWCounter::from(24),
+            MemoryOp::new(RW::READ, 1, MemoryAddress::from(0), 32),
         );
 
         let memory_op_2 = Operation::new(
-            GlobalCounter::from(17),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(1), 32),
+            RWCounter::from(17),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(1), 32),
         );
         let memory_op_3 = Operation::new(
-            GlobalCounter::from(87),
-            MemoryOp::new(RW::READ, MemoryAddress::from(1), 32),
+            RWCounter::from(87),
+            MemoryOp::new(RW::READ, 1, MemoryAddress::from(1), 32),
         );
 
         let stack_op_0 = Operation::new(
-            GlobalCounter::from(17),
-            StackOp::new(RW::WRITE, StackAddress::from(1), Word::from(32)),
+            RWCounter::from(17),
+            StackOp::new(RW::WRITE, 1, StackAddress::from(1), Word::from(32)),
         );
         let stack_op_1 = Operation::new(
-            GlobalCounter::from(87),
-            StackOp::new(RW::READ, StackAddress::from(1), Word::from(32)),
+            RWCounter::from(87),
+            StackOp::new(RW::READ, 1, StackAddress::from(1), Word::from(32)),
         );
 
         const STACK_ROWS_MAX: usize = 2;
@@ -1420,13 +1420,14 @@ mod tests {
     #[test]
     fn same_address_read() {
         let memory_op_0 = Operation::new(
-            GlobalCounter::from(12),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(0), 31),
+            RWCounter::from(12),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(0), 31),
         );
         let memory_op_1 = Operation::new(
-            GlobalCounter::from(24),
+            RWCounter::from(24),
             MemoryOp::new(
                 RW::READ,
+                1,
                 MemoryAddress::from(0),
                 32,
                 /* This should fail as it not the same value as in previous
@@ -1435,13 +1436,14 @@ mod tests {
         );
 
         let stack_op_0 = Operation::new(
-            GlobalCounter::from(19),
-            StackOp::new(RW::WRITE, StackAddress::from(0), Word::from(12)),
+            RWCounter::from(19),
+            StackOp::new(RW::WRITE, 1, StackAddress::from(0), Word::from(12)),
         );
         let stack_op_1 = Operation::new(
-            GlobalCounter::from(28),
+            RWCounter::from(28),
             StackOp::new(
                 RW::READ,
+                1,
                 StackAddress::from(0),
                 Word::from(13),
                 /* This should fail as it not the same value as in previous
@@ -1467,12 +1469,12 @@ mod tests {
     #[test]
     fn first_write() {
         let stack_op_0 = Operation::new(
-            GlobalCounter::from(28),
-            StackOp::new(RW::READ, StackAddress::from(0), Word::from(13)),
+            RWCounter::from(28),
+            StackOp::new(RW::READ, 1, StackAddress::from(0), Word::from(13)),
         );
 
         let storage_op_0 = Operation::new(
-            GlobalCounter::from(17),
+            RWCounter::from(17),
             StorageOp::new(
                 RW::READ, /* Fails because the first storage op needs to be
                            * write. */
@@ -1483,7 +1485,7 @@ mod tests {
             ),
         );
         let storage_op_1 = Operation::new(
-            GlobalCounter::from(18),
+            RWCounter::from(18),
             StorageOp::new(
                 RW::READ, /* Fails because when storage key changes, the op
                            * needs to be write. */
@@ -1495,7 +1497,7 @@ mod tests {
         );
 
         let storage_op_2 = Operation::new(
-            GlobalCounter::from(19),
+            RWCounter::from(19),
             StorageOp::new(
                 RW::READ, /* Fails because when address changes, the op
                            * needs to be write. */
@@ -1527,76 +1529,85 @@ mod tests {
     #[test]
     fn max_values() {
         let memory_op_0 = Operation::new(
-            GlobalCounter::from(12),
+            RWCounter::from(12),
             MemoryOp::new(
                 RW::WRITE,
+                1,
                 MemoryAddress::from(MEMORY_ADDRESS_MAX),
                 32,
             ),
         );
         let memory_op_1 = Operation::new(
-            GlobalCounter::from(GLOBAL_COUNTER_MAX),
+            RWCounter::from(GLOBAL_COUNTER_MAX),
             MemoryOp::new(
                 RW::READ,
+                1,
                 MemoryAddress::from(MEMORY_ADDRESS_MAX),
                 32,
             ),
         );
         let memory_op_2 = Operation::new(
-            GlobalCounter::from(GLOBAL_COUNTER_MAX + 1),
+            RWCounter::from(GLOBAL_COUNTER_MAX + 1),
             MemoryOp::new(
                 RW::WRITE,
+                1,
                 MemoryAddress::from(MEMORY_ADDRESS_MAX),
                 32,
             ),
         );
 
         let memory_op_3 = Operation::new(
-            GlobalCounter::from(12),
+            RWCounter::from(12),
             MemoryOp::new(
                 RW::WRITE,
+                1,
                 MemoryAddress::from(MEMORY_ADDRESS_MAX + 1),
                 32,
             ),
         );
         let memory_op_4 = Operation::new(
-            GlobalCounter::from(24),
+            RWCounter::from(24),
             MemoryOp::new(
                 RW::READ,
+                1,
                 MemoryAddress::from(MEMORY_ADDRESS_MAX + 1),
                 32,
             ),
         );
 
         let stack_op_0 = Operation::new(
-            GlobalCounter::from(12),
+            RWCounter::from(12),
             StackOp::new(
                 RW::WRITE,
+                1,
                 StackAddress::from(STACK_ADDRESS_MAX),
                 Word::from(12),
             ),
         );
         let stack_op_1 = Operation::new(
-            GlobalCounter::from(24),
+            RWCounter::from(24),
             StackOp::new(
                 RW::READ,
+                1,
                 StackAddress::from(STACK_ADDRESS_MAX),
                 Word::from(12),
             ),
         );
 
         let stack_op_2 = Operation::new(
-            GlobalCounter::from(17),
+            RWCounter::from(17),
             StackOp::new(
                 RW::WRITE,
+                1,
                 StackAddress::from(STACK_ADDRESS_MAX + 1),
                 Word::from(12),
             ),
         );
         let stack_op_3 = Operation::new(
-            GlobalCounter::from(GLOBAL_COUNTER_MAX + 1),
+            RWCounter::from(GLOBAL_COUNTER_MAX + 1),
             StackOp::new(
                 RW::WRITE,
+                1,
                 StackAddress::from(STACK_ADDRESS_MAX + 1),
                 Word::from(12),
             ),
@@ -1637,9 +1648,10 @@ mod tests {
         // first row of a target needs to be checked for address to be in range
         // too
         let memory_op_0 = Operation::new(
-            GlobalCounter::from(12),
+            RWCounter::from(12),
             MemoryOp::new(
                 RW::WRITE,
+                1,
                 MemoryAddress::from(MEMORY_ADDRESS_MAX + 1),
                 // This address is not in the allowed range
                 32,
@@ -1647,17 +1659,19 @@ mod tests {
         );
 
         let stack_op_0 = Operation::new(
-            GlobalCounter::from(12),
+            RWCounter::from(12),
             StackOp::new(
                 RW::WRITE,
+                1,
                 StackAddress::from(STACK_ADDRESS_MAX + 1),
                 Word::from(12),
             ),
         );
         let stack_op_1 = Operation::new(
-            GlobalCounter::from(24),
+            RWCounter::from(24),
             StackOp::new(
                 RW::READ,
+                1,
                 StackAddress::from(STACK_ADDRESS_MAX + 1),
                 Word::from(12),
             ),
@@ -1690,35 +1704,35 @@ mod tests {
     #[test]
     fn non_monotone_global_counter() {
         let memory_op_0 = Operation::new(
-            GlobalCounter::from(1352),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(0), 32),
+            RWCounter::from(1352),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(0), 32),
         );
         let memory_op_1 = Operation::new(
-            GlobalCounter::from(1255),
-            MemoryOp::new(RW::READ, MemoryAddress::from(0), 32),
+            RWCounter::from(1255),
+            MemoryOp::new(RW::READ, 1, MemoryAddress::from(0), 32),
         );
 
         // fails because it needs to be strictly monotone
         let memory_op_2 = Operation::new(
-            GlobalCounter::from(1255),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(0), 32),
+            RWCounter::from(1255),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(0), 32),
         );
 
         let stack_op_0 = Operation::new(
-            GlobalCounter::from(228),
-            StackOp::new(RW::WRITE, StackAddress::from(1), Word::from(12)),
+            RWCounter::from(228),
+            StackOp::new(RW::WRITE, 1, StackAddress::from(1), Word::from(12)),
         );
         let stack_op_1 = Operation::new(
-            GlobalCounter::from(217),
-            StackOp::new(RW::READ, StackAddress::from(1), Word::from(12)),
+            RWCounter::from(217),
+            StackOp::new(RW::READ, 1, StackAddress::from(1), Word::from(12)),
         );
         let stack_op_2 = Operation::new(
-            GlobalCounter::from(217),
-            StackOp::new(RW::READ, StackAddress::from(1), Word::from(12)),
+            RWCounter::from(217),
+            StackOp::new(RW::READ, 1, StackAddress::from(1), Word::from(12)),
         );
 
         let storage_op_0 = Operation::new(
-            GlobalCounter::from(301),
+            RWCounter::from(301),
             StorageOp::new(
                 RW::WRITE,
                 address!("0x0000000000000000000000000000000000000001"),
@@ -1728,7 +1742,7 @@ mod tests {
             ),
         );
         let storage_op_1 = Operation::new(
-            GlobalCounter::from(302),
+            RWCounter::from(302),
             StorageOp::new(
                 RW::READ,
                 address!("0x0000000000000000000000000000000000000001"),
@@ -1738,7 +1752,7 @@ mod tests {
             ),
         );
         let storage_op_2 = Operation::new(
-            GlobalCounter::from(302),
+            RWCounter::from(302),
             StorageOp::new(
                 RW::READ,
                 /*fails because the address and
@@ -1751,7 +1765,7 @@ mod tests {
             ),
         );
         let storage_op_3 = Operation::new(
-            GlobalCounter::from(297),
+            RWCounter::from(297),
             StorageOp::new(
                 RW::WRITE,
                 // Global counter goes down, but it doesn't fail because
@@ -1764,7 +1778,7 @@ mod tests {
         );
 
         let storage_op_4 = Operation::new(
-            GlobalCounter::from(296),
+            RWCounter::from(296),
             StorageOp::new(
                 RW::WRITE,
                 // Global counter goes down, but it doesn't fail because the
@@ -1802,32 +1816,33 @@ mod tests {
     #[test]
     fn non_monotone_address() {
         let memory_op_0 = Operation::new(
-            GlobalCounter::from(1352),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(0), 32),
+            RWCounter::from(1352),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(0), 32),
         );
         let memory_op_1 = Operation::new(
-            GlobalCounter::from(1255),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(1), 32),
+            RWCounter::from(1255),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(1), 32),
         );
 
         // fails because it's not monotone
         let memory_op_2 = Operation::new(
-            GlobalCounter::from(1255),
-            MemoryOp::new(RW::WRITE, MemoryAddress::from(0), 32),
+            RWCounter::from(1255),
+            MemoryOp::new(RW::WRITE, 1, MemoryAddress::from(0), 32),
         );
 
         let stack_op_0 = Operation::new(
-            GlobalCounter::from(228),
-            StackOp::new(RW::WRITE, StackAddress::from(0), Word::from(12)),
+            RWCounter::from(228),
+            StackOp::new(RW::WRITE, 1, StackAddress::from(0), Word::from(12)),
         );
         let stack_op_1 = Operation::new(
-            GlobalCounter::from(229),
-            StackOp::new(RW::WRITE, StackAddress::from(1), Word::from(12)),
+            RWCounter::from(229),
+            StackOp::new(RW::WRITE, 1, StackAddress::from(1), Word::from(12)),
         );
         let stack_op_2 = Operation::new(
-            GlobalCounter::from(230),
+            RWCounter::from(230),
             StackOp::new(
                 RW::WRITE,
+                1,
                 StackAddress::from(0), /* this fails because the
                                         * address is not
                                         * monotone */
@@ -1853,7 +1868,7 @@ mod tests {
     #[test]
     fn storage() {
         let storage_op_0 = Operation::new(
-            GlobalCounter::from(18),
+            RWCounter::from(18),
             StorageOp::new(
                 RW::WRITE,
                 address!("0x0000000000000000000000000000000000000001"),
@@ -1863,7 +1878,7 @@ mod tests {
             ),
         );
         let storage_op_1 = Operation::new(
-            GlobalCounter::from(19),
+            RWCounter::from(19),
             StorageOp::new(
                 RW::READ,
                 address!("0x0000000000000000000000000000000000000001"),
@@ -1876,7 +1891,7 @@ mod tests {
             ),
         );
         let storage_op_2 = Operation::new(
-            GlobalCounter::from(20),
+            RWCounter::from(20),
             StorageOp::new(
                 RW::WRITE,
                 address!("0x0000000000000000000000000000000000000001"),
@@ -1888,7 +1903,7 @@ mod tests {
             ),
         );
         let storage_op_3 = Operation::new(
-            GlobalCounter::from(21),
+            RWCounter::from(21),
             StorageOp::new(
                 RW::READ,
                 address!("0x0000000000000000000000000000000000000001"),


### PR DESCRIPTION
Rename TxAccessListStorageSlot to TxAccessListAccountStorage

Rename GlobalCounter to RWCounter and gc to rwc

Since StackOp and MemoryOp now have the `call_id` field, I've added the helper functions `push_memory_op` and `push_stack_op` so that the correct `call_id` is set automatically without requiring passing the value.

I've also modified the style of the Ord implementations for the Ops to a more clean and explicit way.