### PR TITLE
Add initial integration test with circuits

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,6 @@
 name: Integration Tests
 
 on:
-  pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -30,11 +28,16 @@ jobs:
           wget -q https://github.com/ethereum/solidity/releases/download/v0.8.10/solc-static-linux -O $HOME/bin/solc
           chmod u+x "$HOME/bin/solc"
           solc --version
-      # Run an initial build in a sepparate step to split the build time from execution time
-      - name: Build gendata bin
+      # Run an initial build in a separate step to split the build time from execution time
+      - name: Build bins
         run: cargo build --bin gen_blockchain_data
+      - name: Build tests
+        run: for testname in rpc circuit_input_builder circuits; do cargo test --profile release --test $testname --features $testname --no-run; done
       - run: ./run.sh --steps "setup"
       - run: ./run.sh --steps "gendata"
       - run: ./run.sh --steps "tests" --tests "rpc"
       - run: ./run.sh --steps "tests" --tests "circuit_input_builder"
+      # Uncomment once the evm and state circuits tests pass for the block
+      # where Greeter.sol is deployed.
+      # - run: ./run.sh --steps "tests" --tests "circuits"
       - run: ./run.sh --steps "cleanup"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,13 +1952,16 @@ dependencies = [
  "bus-mapping",
  "env_logger",
  "ethers",
+ "halo2",
  "lazy_static",
  "log",
+ "pairing_bn256",
  "pretty_assertions",
  "serde",
  "serde_json",
  "tokio",
  "url",
+ "zkevm-circuits",
 ]
 
 [[package]]

--- a/bus-mapping/src/eth_types.rs
+++ b/bus-mapping/src/eth_types.rs
@@ -188,7 +188,7 @@ struct GethExecStepInternal {
     pc: ProgramCounter,
     op: OpcodeId,
     gas: Gas,
-    #[serde(alias = "gasCost")]
+    #[serde(rename = "gasCost")]
     gas_cost: GasCost,
     depth: u16,
     error: Option<String>,
@@ -310,7 +310,7 @@ pub struct GethExecTraceInternal {
     pub gas: Gas,
     pub failed: bool,
     // return_value is a hex encoded byte array
-    #[serde(alias = "structLogs")]
+    #[serde(rename = "structLogs")]
     pub struct_logs: Vec<GethExecStep>,
 }
 

--- a/bus-mapping/src/external_tracer.rs
+++ b/bus-mapping/src/external_tracer.rs
@@ -150,6 +150,6 @@ mod trace_test {
 
         let block =
             mock::BlockData::new_single_tx_trace_code_at_start(&code).unwrap();
-        assert_eq!(block.geth_trace.struct_logs[2].memory.0.len(), 0)
+        assert_eq!(block.geth_trace.struct_logs[2].memory.0.len(), 0);
     }
 }

--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -166,7 +166,7 @@ impl fmt::Debug for StackOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("StackOp { ")?;
         f.write_fmt(format_args!(
-            "{:?}, addr: {:?}, val: {:?}",
+            "{:?}, addr: {:?}, val: 0x{:x}",
             self.rw, self.address, self.value
         ))?;
         f.write_str(" }")
@@ -250,7 +250,7 @@ impl fmt::Debug for StorageOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("StorageOp { ")?;
         f.write_fmt(format_args!(
-            "{:?}, addr: {:?}, key: {:?}, val_prev: {:?}, val: {:?}",
+            "{:?}, addr: {:?}, key: {:?}, val_prev: 0x{:x}, val: 0x{:x}",
             self.rw, self.address, self.key, self.value_prev, self.value,
         ))?;
         f.write_str(" }")
@@ -389,7 +389,7 @@ impl fmt::Debug for TxAccessListAccountStorageOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("TxAccessListAccountStorageOp { ")?;
         f.write_fmt(format_args!(
-            "tx_id: {:?}, addr: {:?}, key: {:?}, val_prev: {:?}, val: {:?}",
+            "tx_id: {:?}, addr: {:?}, key: 0x{:x}, val_prev: {:?}, val: {:?}",
             self.tx_id, self.address, self.key, self.value_prev, self.value
         ))?;
         f.write_str(" }")
@@ -437,7 +437,7 @@ impl fmt::Debug for TxRefundOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("TxRefundOp { ")?;
         f.write_fmt(format_args!(
-            "{:?} tx_id: {:?}, val_prev: {:?}, val: {:?}",
+            "{:?} tx_id: {:?}, val_prev: 0x{:x}, val: 0x{:x}",
             self.rw, self.tx_id, self.value_prev, self.value
         ))?;
         f.write_str(" }")
@@ -495,7 +495,7 @@ impl fmt::Debug for AccountOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AccountOp { ")?;
         f.write_fmt(format_args!(
-            "{:?}, addr: {:?}, field: {:?}, val_prev: {:?}, val: {:?}",
+            "{:?}, addr: {:?}, field: {:?}, val_prev: 0x{:x}, val: 0x{:x}",
             self.rw, self.address, self.field, self.value_prev, self.value
         ))?;
         f.write_str(" }")

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -11,11 +11,14 @@ ethers = "0.6"
 serde_json = "1.0.66"
 serde = {version = "1.0.130", features = ["derive"] }
 bus-mapping = { path = "../bus-mapping"}
+zkevm-circuits = { path = "../zkevm-circuits"}
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
 url = "2.2.2"
 pretty_assertions = "1.0.0"
 log = "0.4.14"
 env_logger = "0.9"
+halo2 = { git = "https://github.com/appliedzkp/halo2.git", rev = "b78c39cacc1c79d287032f1b5f94beb661b3fb42" }
+pairing = { git = 'https://github.com/appliedzkp/pairing', package = "pairing_bn256" }
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
@@ -24,3 +27,4 @@ pretty_assertions = "1.0.0"
 default = []
 rpc = []
 circuit_input_builder = []
+circuits = []

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -3,7 +3,7 @@ set -e
 
 ARG_DEFAULT_SUDO=
 ARG_DEFAULT_STEPS="setup gendata tests cleanup"
-ARG_DEFAULT_TESTS="rpc circuit_input_builder"
+ARG_DEFAULT_TESTS="rpc circuit_input_builder circuits"
 
 usage() {
     cat >&2 << EOF
@@ -97,7 +97,7 @@ fi
 if [ -n "$STEP_TESTS" ]; then
     for testname in $ARG_TESTS; do
         echo "+ Running test group $testname"
-        cargo test --test $testname --features $testname -- --nocapture
+        cargo test --profile release --test $testname --features $testname -- --nocapture
     done
 fi
 

--- a/integration-tests/tests/circuit_input_builder.rs
+++ b/integration-tests/tests/circuit_input_builder.rs
@@ -1,16 +1,9 @@
 #![cfg(feature = "circuit_input_builder")]
 
-use bus_mapping::circuit_input_builder::{
-    gen_state_access_trace, AccessSet, CircuitInputBuilder,
-};
-use bus_mapping::eth_types::{Address, Word};
-use bus_mapping::state_db::{self, CodeDB, StateDB};
-use integration_tests::{
-    get_chain_constants, get_client, log_init, GenDataOutput,
-};
+use bus_mapping::circuit_input_builder::BuilderClient;
+use integration_tests::{get_client, log_init, GenDataOutput};
 use lazy_static::lazy_static;
 use log::trace;
-use std::collections::HashMap;
 
 lazy_static! {
     pub static ref GEN_DATA: GenDataOutput = GenDataOutput::load();
@@ -24,86 +17,27 @@ async fn test_circuit_input_builder_block_a() {
     let (block_num, _address) = GEN_DATA.deployments.get("Greeter").unwrap();
     let cli = get_client();
 
+    let cli = BuilderClient::new(cli).await.unwrap();
+
     // 1. Query geth for Block, Txs and TxExecTraces
-    let eth_block = cli.get_block_by_number((*block_num).into()).await.unwrap();
-    let geth_trace = cli
-        .trace_block_by_number((*block_num).into())
-        .await
-        .unwrap();
-    let tx_index = 0;
+    let (eth_block, geth_trace) = cli.get_block(*block_num).await.unwrap();
 
     // 2. Get State Accesses from TxExecTraces
-    let access_trace = gen_state_access_trace(
-        &eth_block,
-        &eth_block.transactions[tx_index],
-        &geth_trace[tx_index],
-    )
-    .unwrap();
-    trace!("AccessTrace:");
-    for access in &access_trace {
-        trace!("{:#?}", access);
-    }
-
-    let access_set = AccessSet::from(access_trace);
+    let access_set = cli.get_state_accesses(&eth_block, &geth_trace).unwrap();
     trace!("AccessSet: {:#?}", access_set);
 
     // 3. Query geth for all accounts, storage keys, and codes from Accesses
-    let mut proofs = Vec::new();
-    for (address, key_set) in access_set.state {
-        let mut keys: Vec<Word> = key_set.iter().cloned().collect();
-        keys.sort();
-        let proof = cli
-            .get_proof(address, keys, (*block_num - 1).into())
-            .await
-            .unwrap();
-        proofs.push(proof);
-    }
-    let mut codes: HashMap<Address, Vec<u8>> = HashMap::new();
-    for address in access_set.code {
-        let code = cli
-            .get_code(address, (*block_num - 1).into())
-            .await
-            .unwrap();
-        codes.insert(address, code);
-    }
+    let (proofs, codes) = cli.get_state(*block_num, access_set).await.unwrap();
 
     // 4. Build a partial StateDB from step 3
-    let mut sdb = StateDB::new();
-    for proof in proofs {
-        let mut storage = HashMap::new();
-        for storage_proof in proof.storage_proof {
-            storage.insert(storage_proof.key, storage_proof.value);
-        }
-        sdb.set_account(
-            &proof.address,
-            state_db::Account {
-                nonce: proof.nonce,
-                balance: proof.balance,
-                storage,
-                code_hash: proof.code_hash,
-            },
-        )
-    }
-    trace!("StateDB: {:#?}", sdb);
-
-    let mut code_db = CodeDB::new();
-    for (_address, code) in codes {
-        code_db.insert(code.clone());
-    }
-    let constants = get_chain_constants().await;
-    let mut builder =
-        CircuitInputBuilder::new(sdb, code_db, &eth_block, constants);
+    let (state_db, code_db) = cli.build_state_code_db(proofs, codes);
+    trace!("StateDB: {:#?}", state_db);
 
     // 5. For each step in TxExecTraces, gen the associated ops and state
     // circuit inputs
-    let block_geth_trace = cli
-        .trace_block_by_number((*block_num).into())
-        .await
+    let builder = cli
+        .gen_inputs_from_state(state_db, code_db, &eth_block, &geth_trace)
         .unwrap();
-    for (tx_index, tx) in eth_block.transactions.iter().enumerate() {
-        let geth_trace = &block_geth_trace[tx_index];
-        builder.handle_tx(tx, geth_trace).unwrap();
-    }
 
     trace!("CircuitInputBuilder: {:#?}", builder);
 }

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -241,7 +241,7 @@ mod test {
         builder
             .handle_tx(&block_trace.eth_tx, &block_trace.geth_trace)
             .unwrap();
-        let block = witness::block_convert(&bytecode, &builder.block);
+        let block = witness::block_convert(bytecode.code(), &builder.block);
         assert_eq!(run_test_circuit_incomplete_fixed_table(block), Ok(()));
     }
 

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,6 +1,7 @@
 // Step dimension
 pub(crate) const STEP_WIDTH: usize = 32;
-pub(crate) const STEP_HEIGHT: usize = 10;
+/// Step height
+pub const STEP_HEIGHT: usize = 10;
 pub(crate) const NUM_CELLS_STEP_STATE: usize = 10;
 
 // The number of bytes an u64 has.

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -424,11 +424,11 @@ fn tx_convert(
 }
 
 pub fn block_convert(
-    bytecode: &bus_mapping::bytecode::Bytecode,
+    bytecode: &[u8],
     b: &bus_mapping::circuit_input_builder::Block,
 ) -> Block<Fp> {
     let randomness = Fp::rand();
-    let bytecode = bytecode.into();
+    let bytecode = Bytecode::new(bytecode.to_vec());
 
     // here stack_ops/memory_ops/etc are merged into a single array
     // in EVM circuit, we need rwc-sorted ops
@@ -489,5 +489,5 @@ pub fn build_block_from_trace_code_at_start(
     let mut builder = block.new_circuit_input_builder();
     builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
 
-    block_convert(bytecode, &builder.block)
+    block_convert(bytecode.code(), &builder.block)
 }

--- a/zkevm-circuits/src/state_circuit/state.rs
+++ b/zkevm-circuits/src/state_circuit/state.rs
@@ -1162,9 +1162,12 @@ pub struct StateCircuit<
     const STACK_ADDRESS_MAX: usize,
     const STORAGE_ROWS_MAX: usize,
 > {
-    memory_ops: Vec<Operation<MemoryOp>>,
-    stack_ops: Vec<Operation<StackOp>>,
-    storage_ops: Vec<Operation<StorageOp>>,
+    /// Memory Operations
+    pub memory_ops: Vec<Operation<MemoryOp>>,
+    /// Stack Operations
+    pub stack_ops: Vec<Operation<StackOp>>,
+    /// Storage Operations
+    pub storage_ops: Vec<Operation<StorageOp>>,
 }
 
 impl<


### PR DESCRIPTION
Add an integration tests for the evm and state circuits, using the input
generated by the circuit input builder and data queried from geth.

bus-mapping: Introduce `BuilderClient` which wraps a GethClient and
contains methods to generate the complete circuit inputs by doing all
the necessary steps: query geth, build partial state_db, etc.  Use this
`BuilderClient` in both the circuits and circuit_input_builder
integration tests.

---

For the state circuit I've used the `pub StateCircuit`.

For the evm circuit, I didn't find a pub circuit, so I copied the `TestCircuit` used in the evm circuit tests.  I don't know if this is the best approach, please let me know if you have a better idea!

I haven't included the state_circuit integration tests into the CI because, even though the evm_circuit is passing, the state_circuit is not working.
The test tries to build the proof based on the block in which the [Greeter.sol](https://github.com/appliedzkp/zkevm-circuits/blob/main/integration-tests/contracts/greeter/Greeter.sol) contract is deployed.
Here's a log that includes the generated memory, stack and storage ops, as well as the verification error that the MockProver outputs: https://gist.github.com/ed255/ba4991427bb4cee0fa909f498e9e5786
Is the state circuit supposed to fail?  Does anybody have an idea of what may be failing, based on the generated ops by the circuit input builder?

The state circuit integration test can be reproduced following these steps:
### Setup
```sh
cd integration-tests
./run.sh --steps "setup"
./run.sh --steps "gendata"
```
### Test
```sh
RUST_LOG=circuits=trace cargo test --profile release --test circuits --features circuits test_state_circuit_block_a -- --nocapture
```
---

With the addition of the circuit integration tests, the integration tests github action take between 16m an 20m. For this reason I have disabled the trigger on pull request and left only the trigger on push to main.