### PR TITLE
fix tx_convert in witness

### DIFF
--- a/bus-mapping/src/eth_types.rs
+++ b/bus-mapping/src/eth_types.rs
@@ -330,7 +330,7 @@ pub struct GethExecTrace {
 
 /// Truncate the memory in each step to the memory size before the step is
 /// executed (and before the memory is expanded).  This is required because geth
-/// sets the memory in each step as the memroy before execution but after
+/// sets the memory in each step as the memory before execution but after
 /// expansion.
 pub fn fix_geth_trace_memory_size(trace: &mut [GethExecStep]) {
     let mut mem_sizes = vec![0; trace.len()];

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -404,7 +404,7 @@ fn tx_convert(
     tx: &bus_mapping::circuit_input_builder::Transaction,
     ops_len: (usize, usize, usize),
 ) -> Transaction<Fp> {
-    let mut result: Transaction<Fp> = Transaction::<Fp> {
+    Transaction::<Fp> {
         calls: vec![Call {
             id: 1,
             is_root: true,
@@ -414,14 +414,13 @@ fn tx_convert(
                 randomness,
             ),
         }],
+        steps: tx
+            .steps()
+            .iter()
+            .map(|step| step_convert(step, ops_len))
+            .collect(),
         ..Default::default()
-    };
-    result.steps = tx
-        .steps()
-        .iter()
-        .map(|step| step_convert(step, ops_len))
-        .collect();
-    result
+    }
 }
 
 pub fn block_convert(

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -416,9 +416,11 @@ fn tx_convert(
         }],
         ..Default::default()
     };
-    let _ = tx.steps().iter().map(|step| {
-        result.steps.push(step_convert(step, ops_len));
-    });
+    result.steps = tx
+        .steps()
+        .iter()
+        .map(|step| step_convert(step, ops_len))
+        .collect();
     result
 }
 


### PR DESCRIPTION
in a [previous commit](https://github.com/appliedzkp/zkevm-circuits/pull/240/files#diff-09bf944a4f9216c1053a271fea0ff2f7a985380789b990f8e4ac530159214df2R419-R421), in witness.rs, the tx steps for evm citcuit are incorrectly converted to empty vec, as a result, no steps are really tested. 