### PR TITLE
Fix MSIZE opcode and add doc to step

### DIFF
--- a/bus-mapping/src/evm/memory.rs
+++ b/bus-mapping/src/evm/memory.rs
@@ -276,11 +276,6 @@ impl Memory {
             &self[addr..addr + MemoryAddress::from(32)],
         ))
     }
-
-    /// Returns the size of memory in words
-    pub fn size(&self) -> usize {
-        self.0.len() >> 5
-    }
 }
 
 #[cfg(test)]
@@ -344,21 +339,6 @@ mod memory_tests {
             mem_map.read_word(MemoryAddress::from(0x40))?,
             Word::from(0x80)
         );
-
-        Ok(())
-    }
-
-    #[test]
-    fn mem_size_works() -> Result<(), Error> {
-        let mem_map = Memory(
-            [Word::from(0), Word::from(0), Word::from(0x80)]
-                .iter()
-                .flat_map(|w| w.to_be_bytes())
-                .collect(),
-        );
-
-        // There are 3 words in memory
-        assert_eq!(mem_map.size(), 3);
 
         Ok(())
     }

--- a/bus-mapping/src/evm/opcodes/msize.rs
+++ b/bus-mapping/src/evm/opcodes/msize.rs
@@ -1,6 +1,6 @@
 use super::Opcode;
 use crate::circuit_input_builder::CircuitInputStateRef;
-use crate::eth_types::{GethExecStep, Word};
+use crate::eth_types::GethExecStep;
 use crate::{operation::RW, Error};
 
 /// Placeholder structure used to implement [`Opcode`] trait over it
@@ -16,12 +16,10 @@ impl Opcode for Msize {
     ) -> Result<(), Error> {
         let step = &steps[0];
 
-        // Get value result from next step's memory and do stack write
-        let mem_size_value = Word::from(steps[1].memory.size() as u32);
         state.push_stack_op(
             RW::WRITE,
             step.stack.last_filled().map(|a| a - 1),
-            mem_size_value,
+            steps[1].stack.last()?,
         );
 
         Ok(())

--- a/bus-mapping/src/evm/opcodes/msize.rs
+++ b/bus-mapping/src/evm/opcodes/msize.rs
@@ -70,7 +70,7 @@ mod msize_tests {
         state_ref.push_stack_op(
             RW::WRITE,
             StackAddress::from(1023),
-            Word::from(0x3_u64),
+            Word::from(96), // 3 words, 96 bytes
         );
 
         tx.steps_mut().push(step);

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -386,7 +386,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
                 let mut offset = 0;
                 for transaction in &block.txs {
                     for step in &transaction.steps {
-                        let call = &transaction.calls[step.call_idx];
+                        let call = &transaction.calls[step.call_id];
 
                         self.q_step.enable(&mut region, offset)?;
                         if offset == 0 {

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -386,7 +386,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
                 let mut offset = 0;
                 for transaction in &block.txs {
                     for step in &transaction.steps {
-                        let call = &transaction.calls[step.call_id];
+                        let call = &transaction.calls[step.call_index];
 
                         self.q_step.enable(&mut region, offset)?;
                         if offset == 0 {

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -426,7 +426,7 @@ impl<F: FieldExt> ExecutionConfig<F> {
                 let mut offset = 0;
                 for transaction in &block.txs {
                     for step in &transaction.steps {
-                        let call = &transaction.calls[step.call_idx];
+                        let call = &transaction.calls[step.call_index];
 
                         self.q_step.enable(&mut region, offset)?;
                         self.assign_exec_step(

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -198,7 +198,7 @@ impl<F: FieldExt> ExecutionGadget<F> for BeginTxGadget<F> {
             program_counter: To(0.expr()),
             stack_pointer: To(STACK_CAPACITY.expr()),
             gas_left: To(gas_left),
-            memory_size: To(0.expr()),
+            memory_word_size: To(0.expr()),
             state_write_counter: To(2.expr()),
         });
 

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
@@ -51,7 +51,7 @@ impl<F: FieldExt> ExecutionGadget<F> for ErrorOOGPureMemoryGadget<F> {
         // Get the next memory size and the gas cost for this memory access
         let memory_expansion = MemoryExpansionGadget::construct(
             cb,
-            cb.curr.state.memory_size.expr(),
+            cb.curr.state.memory_word_size.expr(),
             address_low::expr(&address)
                 + 1.expr()
                 + (is_not_mstore8 * 31.expr()),
@@ -129,7 +129,7 @@ impl<F: FieldExt> ExecutionGadget<F> for ErrorOOGPureMemoryGadget<F> {
         self.memory_expansion.assign(
             region,
             offset,
-            step.memory_size,
+            step.memory_word_size(),
             address_low::value::<F>(address.to_le_bytes())
                 + 1
                 + if is_mstore8 == F::one() { 0 } else { 31 },

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -63,7 +63,7 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
         // access
         let memory_expansion = MemoryExpansionGadget::construct(
             cb,
-            cb.curr.state.memory_size.expr(),
+            cb.curr.state.memory_word_size.expr(),
             from_bytes::expr(&address.cells)
                 + 1.expr()
                 + (is_not_mstore8.clone() * 31.expr()),
@@ -126,7 +126,7 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
             rw_counter: Delta(34.expr() - is_mstore8.expr() * 31.expr()),
             program_counter: Delta(1.expr()),
             stack_pointer: Delta(is_store * 2.expr()),
-            memory_size: To(memory_expansion.next_memory_size()),
+            memory_word_size: To(memory_expansion.next_memory_word_size()),
             ..Default::default()
         };
         let same_context = SameContextGadget::construct(
@@ -193,7 +193,7 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
         self.memory_expansion.assign(
             region,
             offset,
-            step.memory_size,
+            step.memory_word_size(),
             address.as_u64() + 1 + if is_mstore8 == F::one() { 0 } else { 31 },
         )?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/msize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/msize.rs
@@ -1,6 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
+        param::NUM_BYTES_WORD,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -33,7 +34,7 @@ impl<F: FieldExt> ExecutionGadget<F> for MsizeGadget<F> {
         cb.require_equal(
             "Constrain memory_size equal to stack value",
             from_bytes::expr(&bytes),
-            cb.curr.state.memory_size.expr(),
+            cb.curr.state.memory_word_size.expr() * NUM_BYTES_WORD.expr(),
         );
 
         // Push the value on the stack
@@ -72,7 +73,6 @@ impl<F: FieldExt> ExecutionGadget<F> for MsizeGadget<F> {
         step: &ExecStep,
     ) -> Result<(), Error> {
         self.same_context.assign_exec_step(region, offset, step)?;
-
         self.value.assign(
             region,
             offset,
@@ -91,7 +91,7 @@ mod test {
     use bus_mapping::{bytecode, eth_types::Word};
 
     #[test]
-    fn test_ok() {
+    fn msize_gadget() {
         let address = Word::from(0x10);
         let value = Word::from_big_endian(&(1..33).collect::<Vec<_>>());
         let bytecode = bytecode! {

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -6,6 +6,8 @@ pub(crate) const NUM_CELLS_STEP_STATE: usize = 10;
 
 // The number of bytes an u64 has.
 pub(crate) const NUM_BYTES_U64: usize = 8;
+// The number of bytes in EVM word.
+pub(crate) const NUM_BYTES_WORD: usize = 32;
 
 /// The maximum number of bytes that a field element
 /// can be broken down into without causing the value it

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -387,10 +387,15 @@ impl ExecutionState {
 
 #[derive(Clone, Debug)]
 pub(crate) struct StepState<F> {
+    /// The execution state for the step
     pub(crate) execution_state: Vec<Cell<F>>,
+    /// The Read/Write counter
     pub(crate) rw_counter: Cell<F>,
+    /// The call index
     pub(crate) call_id: Cell<F>,
+    /// Whether the call is root call
     pub(crate) is_root: Cell<F>,
+    /// Whether the call is a create call
     pub(crate) is_create: Cell<F>,
     // This is the identifier of current executed bytecode, which is used to
     // lookup current executed opcode and used to do code copy. In most time,
@@ -401,10 +406,15 @@ pub(crate) struct StepState<F> {
     // issue https://github.com/appliedzkp/zkevm-specs/issues/73 for more
     // discussion.
     pub(crate) opcode_source: Cell<F>,
+    /// The program counter
     pub(crate) program_counter: Cell<F>,
+    /// The stack pointer
     pub(crate) stack_pointer: Cell<F>,
+    /// Gas left in the transaction
     pub(crate) gas_left: Cell<F>,
-    pub(crate) memory_size: Cell<F>,
+    /// Memory size in words (32 bytes)
+    pub(crate) memory_word_size: Cell<F>,
+    /// The counter for state write
     pub(crate) state_write_counter: Cell<F>,
 }
 
@@ -458,7 +468,7 @@ impl<F: FieldExt> Step<F> {
                 program_counter: cells.pop_front().unwrap(),
                 stack_pointer: cells.pop_front().unwrap(),
                 gas_left: cells.pop_front().unwrap(),
-                memory_size: cells.pop_front().unwrap(),
+                memory_word_size: cells.pop_front().unwrap(),
                 state_write_counter: cells.pop_front().unwrap(),
             }
         };
@@ -548,10 +558,10 @@ impl<F: FieldExt> Step<F> {
             offset,
             Some(F::from(step.gas_left)),
         )?;
-        self.state.memory_size.assign(
+        self.state.memory_word_size.assign(
             region,
             offset,
-            Some(F::from(step.memory_size as u64)),
+            Some(F::from(step.memory_word_size())),
         )?;
         self.state.state_write_counter.assign(
             region,

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -391,7 +391,8 @@ pub(crate) struct StepState<F> {
     pub(crate) execution_state: Vec<Cell<F>>,
     /// The Read/Write counter
     pub(crate) rw_counter: Cell<F>,
-    /// The call index
+    /// The unique identifier of call in the whole proof, using the
+    /// `rw_counter` at the call step.
     pub(crate) call_id: Cell<F>,
     /// Whether the call is root call
     pub(crate) is_root: Cell<F>,

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -410,11 +410,11 @@ pub(crate) struct StepState<F> {
     pub(crate) program_counter: Cell<F>,
     /// The stack pointer
     pub(crate) stack_pointer: Cell<F>,
-    /// Gas left in the transaction
+    /// The amount of gas left
     pub(crate) gas_left: Cell<F>,
     /// Memory size in words (32 bytes)
     pub(crate) memory_word_size: Cell<F>,
-    /// The counter for state write
+    /// The counter for state writes
     pub(crate) state_write_counter: Cell<F>,
 }
 

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -45,7 +45,7 @@ pub(crate) struct StepStateTransition<F: FieldExt> {
     pub(crate) program_counter: Transition<Expression<F>>,
     pub(crate) stack_pointer: Transition<Expression<F>>,
     pub(crate) gas_left: Transition<Expression<F>>,
-    pub(crate) memory_size: Transition<Expression<F>>,
+    pub(crate) memory_word_size: Transition<Expression<F>>,
     pub(crate) state_write_counter: Transition<Expression<F>>,
 }
 
@@ -322,10 +322,10 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
                 step_state_transition.gas_left,
             ),
             (
-                "State transition constrain of memory_size",
-                &self.curr.state.memory_size,
-                &self.next.state.memory_size,
-                step_state_transition.memory_size,
+                "State transition constrain of memory_word_size",
+                &self.curr.state.memory_word_size,
+                &self.next.state.memory_word_size,
+                step_state_transition.memory_word_size,
             ),
             (
                 "State transition constrain of state_write_counter",

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -116,7 +116,7 @@ impl<F: FieldExt> BlockContext<F> {
 pub struct Transaction<F> {
     /// The transaction index in the block
     pub id: usize,
-    /// The sender account nounce of the transaction
+    /// The sender account nonce of the transaction
     pub nonce: u64,
     /// The gas limit of the transaction
     pub gas: u64,
@@ -292,7 +292,9 @@ pub struct ExecStep {
 
 impl ExecStep {
     pub fn memory_word_size(&self) -> u64 {
-        // The memory size must be multiple of words (32 bytes)
+        // EVM always pads the memory size to word size
+        // https://github.com/ethereum/go-ethereum/blob/master/core/vm/interpreter.go#L212-L216
+        // Thus, the memory size must be a multiple of 32 bytes.
         assert_eq!(self.memory_size % NUM_BYTES_WORD as u64, 0);
         self.memory_size / NUM_BYTES_WORD as u64
     }

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -19,10 +19,13 @@ use std::convert::TryInto;
 
 #[derive(Debug, Default)]
 pub struct Block<F> {
-    // randomness for random linear combination
+    /// The randomness for random linear combination
     pub randomness: F,
+    /// Transactions in the block
     pub txs: Vec<Transaction<F>>,
+    /// Read write events in the RwTable
     pub rws: Vec<Rw>,
+    /// Bytecode used in the block
     pub bytecodes: Vec<Bytecode>,
     pub context: BlockContext<F>,
 }
@@ -103,18 +106,29 @@ impl<F: FieldExt> BlockContext<F> {
 
 #[derive(Debug, Default)]
 pub struct Transaction<F> {
+    /// The transaction index in the block
     pub id: usize,
+    /// The sender account nounce of the transaction
     pub nonce: u64,
+    /// The gas limit of the transaction
     pub gas: u64,
     pub gas_price: Word,
+    /// The caller address
     pub caller_address: Address,
+    /// The callee address
     pub callee_address: Address,
+    /// Whether it's a create transaction
     pub is_create: bool,
+    /// The ether amount of the transaction
     pub value: Word,
+    /// The call data
     pub call_data: Vec<u8>,
+    /// The call data length
     pub call_data_length: usize,
     pub call_data_gas_cost: u64,
+    /// The calls made in the transaction
     pub calls: Vec<Call<F>>,
+    /// The steps executioned in the transaction
     pub steps: Vec<ExecStep>,
 }
 
@@ -223,8 +237,8 @@ pub struct Call<F> {
 
 #[derive(Clone, Debug, Default)]
 pub struct ExecStep {
-    /// The call index
-    pub call_id: usize,
+    /// The index in the Transaction calls
+    pub call_index: usize,
     /// The indices in the RW trace incurred in this step
     pub rw_indices: Vec<usize>,
     /// The execution state for the step
@@ -566,7 +580,7 @@ fn step_convert(
     ops_len: (usize, usize, usize),
 ) -> ExecStep {
     let (stack_ops_len, memory_ops_len, _storage_ops_len) = ops_len;
-    // TODO: call_id is not set in the ExecStep
+    // TODO: call_index is not set in the ExecStep
     let result = ExecStep {
         rw_indices: step
             .bus_mapping_instance

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -226,7 +226,8 @@ impl<F: FieldExt> Transaction<F> {
 
 #[derive(Debug, Default)]
 pub struct Call<F> {
-    /// The call index in the Transaction calls
+    /// The unique identifier of call in the whole proof, using the
+    /// `rw_counter` at the call step.
     pub id: usize,
     /// Indicate if the call is the root call
     pub is_root: bool,

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -27,17 +27,25 @@ pub struct Block<F> {
     pub rws: Vec<Rw>,
     /// Bytecode used in the block
     pub bytecodes: Vec<Bytecode>,
+    /// The block context
     pub context: BlockContext<F>,
 }
 
 #[derive(Debug, Default)]
 pub struct BlockContext<F> {
-    pub coinbase: Address, // u160
+    /// The address of the miner for the block
+    pub coinbase: Address,
+    /// The gas limit of the block
     pub gas_limit: u64,
+    /// The block number
     pub block_number: F,
+    /// The timestamp of the block
     pub time: u64,
+    /// The difficulty of the blcok
     pub difficulty: Word,
+    /// The base fee, the minimum amount of gas fee for a transaction
     pub base_fee: Word,
+    /// The hash of previous blocks
     pub previous_block_hashes: Vec<Word>,
 }
 
@@ -218,22 +226,40 @@ impl<F: FieldExt> Transaction<F> {
 
 #[derive(Debug, Default)]
 pub struct Call<F> {
+    /// The call index in the Transaction calls
     pub id: usize,
+    /// Indicate if the call is the root call
     pub is_root: bool,
+    /// Indicate if the call is a create call
     pub is_create: bool,
+    /// The identifier of current executed bytecode
     pub opcode_source: F,
+    /// The `rw_counter` at the end of reversion of a call if it has
+    /// `is_persistent == false`
     pub rw_counter_end_of_reversion: usize,
+    /// The call index of caller
     pub caller_call_id: usize,
+    /// The depth in the call stack
     pub depth: usize,
+    /// The caller address
     pub caller_address: Address,
+    /// The callee address
     pub callee_address: Address,
+    /// The call data offset in the memory
     pub call_data_offset: usize,
+    /// The length of call data
     pub call_data_length: usize,
+    /// The return data offset in the memory
     pub return_data_offset: usize,
+    /// The length of return data
     pub return_data_length: usize,
+    /// The ether amount of the transaction
     pub value: Word,
+    /// TBD, Han will update this field
     pub result: Word,
+    /// Indicate if this call and all its caller have `is_success == true`
     pub is_persistent: bool,
+    /// Indicate if it's a static call
     pub is_static: bool,
 }
 

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -112,6 +112,7 @@ pub struct Transaction<F> {
     pub nonce: u64,
     /// The gas limit of the transaction
     pub gas: u64,
+    /// The gas price
     pub gas_price: Word,
     /// The caller address
     pub caller_address: Address,
@@ -125,6 +126,7 @@ pub struct Transaction<F> {
     pub call_data: Vec<u8>,
     /// The call data length
     pub call_data_length: usize,
+    /// The gas cost for transaction call data
     pub call_data_gas_cost: u64,
     /// The calls made in the transaction
     pub calls: Vec<Call<F>>,


### PR DESCRIPTION
Previous the `MSIZE` circuit pushes the memory size in words to the stack. However, the memory size that needs to be pushed to stack should be the memory size in bytes (see [here](https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L571) and [here](https://github.com/ethereum/go-ethereum/blob/master/core/vm/memory.go#L102)).

In addition, the memory size stored in the `StepState` is actually word size. So I change the field name from `memory_size` to `memory_word_size` to reduce the confusion in the future. This PR also adds the document to fields in the `StepState` and `ExecStep`.
