### PR TITLE
Extend memory gadgets to handle dynamic offset and length

### DIFF
--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -164,6 +164,10 @@ impl GasCost {
     pub const TX: Self = Self(21000);
     /// Constant cost for creation transaction
     pub const CREATION_TX: Self = Self(53000);
+    /// Denominator of quadratic part of memory expansion gas cost
+    pub const MEMORY_EXPANSION_QUAD_DENOMINATOR: Self = Self(512);
+    /// Coefficient of linear part of memory expansion gas cost
+    pub const MEMORY_EXPANSION_LINEAR_COEFF: Self = Self(3);
 }
 
 impl GasCost {

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -328,6 +328,7 @@ mod test {
         eth_types::{self, Address, ToLittleEndian, ToWord, Word},
         evm::{GasCost, OpcodeId},
     };
+    use std::convert::TryInto;
 
     fn test_ok(tx: eth_types::Transaction, result: bool) {
         let rw_counter_end_of_reversion = if result { 0 } else { 20 };
@@ -355,8 +356,8 @@ mod test {
             randomness,
             txs: vec![Transaction {
                 id: 1,
-                nonce: tx.nonce.low_u64(),
-                gas: tx.gas.low_u64(),
+                nonce: tx.nonce.try_into().unwrap(),
+                gas: tx.gas.try_into().unwrap(),
                 gas_price: tx.gas_price.unwrap_or_else(Word::zero),
                 caller_address: tx.from,
                 callee_address: tx.to.unwrap_or_else(Address::zero),

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{MAX_GAS_SIZE_IN_BYTES, STACK_CAPACITY},
+        param::{N_BYTES_GAS, STACK_CAPACITY},
         step::ExecutionState,
         table::{AccountFieldTag, CallContextFieldTag, TxContextFieldTag},
         util::{
@@ -38,7 +38,7 @@ pub(crate) struct BeginTxGadget<F> {
     tx_call_data_gas_cost: Cell<F>,
     rw_counter_end_of_reversion: Cell<F>,
     is_persistent: Cell<F>,
-    sufficient_gas_left: RangeCheckGadget<F, MAX_GAS_SIZE_IN_BYTES>,
+    sufficient_gas_left: RangeCheckGadget<F, N_BYTES_GAS>,
     transfer_with_gas_fee: TransferWithGasFeeGadget<F>,
     code_hash: Cell<F>,
 }

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
@@ -130,7 +130,7 @@ impl<F: FieldExt> ExecutionGadget<F> for ErrorOOGPureMemoryGadget<F> {
             region,
             offset,
             step.memory_word_size(),
-            [address_low::value::<F>(address.to_le_bytes())
+            [address_low::value(address.to_le_bytes())
                 + if is_mstore8 == F::one() { 1 } else { 32 }],
         )?;
 

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
@@ -131,8 +131,7 @@ impl<F: FieldExt> ExecutionGadget<F> for ErrorOOGPureMemoryGadget<F> {
             offset,
             step.memory_word_size(),
             [address_low::value::<F>(address.to_le_bytes())
-                + 1
-                + if is_mstore8 == F::one() { 0 } else { 31 }],
+                + if is_mstore8 == F::one() { 1 } else { 32 }],
         )?;
 
         // Gas insufficient check

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
@@ -1,11 +1,11 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::MAX_MEMORY_SIZE_IN_BYTES,
+        param::{N_BYTES_GAS, N_BYTES_MEMORY_WORD_SIZE},
         step::ExecutionState,
         util::{
             constraint_builder::ConstraintBuilder,
-            math_gadget::{IsEqualGadget, IsZeroGadget, LtGadget},
+            math_gadget::{IsEqualGadget, IsZeroGadget, RangeCheckGadget},
             memory_gadget::{address_high, address_low, MemoryExpansionGadget},
             Cell, Word,
         },
@@ -21,9 +21,15 @@ pub(crate) struct ErrorOOGPureMemoryGadget<F> {
     opcode: Cell<F>,
     address: Word<F>,
     address_in_range: IsZeroGadget<F>,
+    // Allow memory size to expand to 5 bytes, because memory address could be
+    // at most 2^40 - 1, after constant division by 32, the memory word size
+    // then could be at most 2^35 - 1.
     memory_expansion:
-        MemoryExpansionGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 - 1 }>,
-    insufficient_gas: LtGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 - 1 }>,
+        MemoryExpansionGadget<F, 1, { N_BYTES_MEMORY_WORD_SIZE + 1 }>,
+    // Even memory size at most could be 2^35 - 1, the qudratic part of memory
+    // expansion gas cost could be at most 2^61 - 2^27, due to the constant
+    // division by 512, which still fits in 8 bytes.
+    insufficient_gas: RangeCheckGadget<F, N_BYTES_GAS>,
     is_mstore8: IsEqualGadget<F>,
 }
 
@@ -52,9 +58,9 @@ impl<F: FieldExt> ExecutionGadget<F> for ErrorOOGPureMemoryGadget<F> {
         let memory_expansion = MemoryExpansionGadget::construct(
             cb,
             cb.curr.state.memory_word_size.expr(),
-            address_low::expr(&address)
+            [address_low::expr(&address)
                 + 1.expr()
-                + (is_not_mstore8 * 31.expr()),
+                + (is_not_mstore8 * 31.expr())],
         );
 
         // Check if the memory address is too large
@@ -62,20 +68,14 @@ impl<F: FieldExt> ExecutionGadget<F> for ErrorOOGPureMemoryGadget<F> {
             IsZeroGadget::construct(cb, address_high::expr(&address));
         // Check if the amount of gas available is less than the amount of gas
         // required
-        let insufficient_gas = LtGadget::construct(
-            cb,
-            cb.curr.state.gas_left.expr(),
-            OpcodeId::MLOAD.constant_gas_cost().expr()
-                + memory_expansion.gas_cost(),
-        );
-
-        // Make sure we are out of gas
-        // Out of gas when either the address is too big and/or the amount of
-        // gas available is lower than what is required.
-        cb.require_zero(
-            "Either the address is too big or insufficient gas",
-            address_in_range.expr() * (1.expr() - insufficient_gas.expr()),
-        );
+        let insufficient_gas = cb.condition(address_in_range.expr(), |cb| {
+            RangeCheckGadget::construct(
+                cb,
+                OpcodeId::MLOAD.constant_gas_cost().expr()
+                    + memory_expansion.gas_cost()
+                    - cb.curr.state.gas_left.expr(),
+            )
+        });
 
         // Pop the address from the stack
         // We still have to do this to verify the correctness of `address`
@@ -130,9 +130,9 @@ impl<F: FieldExt> ExecutionGadget<F> for ErrorOOGPureMemoryGadget<F> {
             region,
             offset,
             step.memory_word_size(),
-            address_low::value::<F>(address.to_le_bytes())
+            [address_low::value::<F>(address.to_le_bytes())
                 + 1
-                + if is_mstore8 == F::one() { 0 } else { 31 },
+                + if is_mstore8 == F::one() { 0 } else { 31 }],
         )?;
 
         // Gas insufficient check
@@ -140,8 +140,7 @@ impl<F: FieldExt> ExecutionGadget<F> for ErrorOOGPureMemoryGadget<F> {
         self.insufficient_gas.assign(
             region,
             offset,
-            F::from(step.gas_left),
-            F::from(step.gas_cost),
+            F::from(step.gas_cost - step.gas_left),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_pure_memory.rs
@@ -24,6 +24,9 @@ pub(crate) struct ErrorOOGPureMemoryGadget<F> {
     // Allow memory size to expand to 5 bytes, because memory address could be
     // at most 2^40 - 1, after constant division by 32, the memory word size
     // then could be at most 2^35 - 1.
+    // So generic N_BYTES_MEMORY_WORD_SIZE for MemoryExpansionGadget needs to
+    // be larger by 1 than normal usage (to be 5), to be able to contain
+    // number up to 2^35 - 1.
     memory_expansion:
         MemoryExpansionGadget<F, 1, { N_BYTES_MEMORY_WORD_SIZE + 1 }>,
     // Even memory size at most could be 2^35 - 1, the qudratic part of memory

--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::NUM_BYTES_PROGRAM_COUNTER,
+        param::N_BYTES_PROGRAM_COUNTER,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -22,7 +22,7 @@ use std::convert::TryInto;
 #[derive(Clone, Debug)]
 pub(crate) struct JumpGadget<F> {
     same_context: SameContextGadget<F>,
-    destination: RandomLinearCombination<F, NUM_BYTES_PROGRAM_COUNTER>,
+    destination: RandomLinearCombination<F, N_BYTES_PROGRAM_COUNTER>,
 }
 
 impl<F: FieldExt> ExecutionGadget<F> for JumpGadget<F> {
@@ -31,10 +31,7 @@ impl<F: FieldExt> ExecutionGadget<F> for JumpGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::JUMP;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
-        let destination = RandomLinearCombination::new(
-            cb.query_bytes(),
-            cb.power_of_randomness(),
-        );
+        let destination = cb.query_rlc();
 
         // Pop the value from the stack
         cb.stack_pop(destination.expr());
@@ -83,7 +80,7 @@ impl<F: FieldExt> ExecutionGadget<F> for JumpGadget<F> {
             region,
             offset,
             Some(
-                destination.to_le_bytes()[..NUM_BYTES_PROGRAM_COUNTER]
+                destination.to_le_bytes()[..N_BYTES_PROGRAM_COUNTER]
                     .try_into()
                     .unwrap(),
             ),

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::NUM_BYTES_PROGRAM_COUNTER,
+        param::N_BYTES_PROGRAM_COUNTER,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -24,7 +24,7 @@ use std::convert::TryInto;
 #[derive(Clone, Debug)]
 pub(crate) struct JumpiGadget<F> {
     same_context: SameContextGadget<F>,
-    destination: RandomLinearCombination<F, NUM_BYTES_PROGRAM_COUNTER>,
+    destination: RandomLinearCombination<F, N_BYTES_PROGRAM_COUNTER>,
     condition: Cell<F>,
     is_condition_zero: IsZeroGadget<F>,
 }
@@ -35,10 +35,7 @@ impl<F: FieldExt> ExecutionGadget<F> for JumpiGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::JUMPI;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
-        let destination = RandomLinearCombination::new(
-            cb.query_bytes(),
-            cb.power_of_randomness(),
-        );
+        let destination = cb.query_rlc();
         let condition = cb.query_cell();
 
         // Pop the value from the stack
@@ -111,7 +108,7 @@ impl<F: FieldExt> ExecutionGadget<F> for JumpiGadget<F> {
             region,
             offset,
             Some(
-                destination.to_le_bytes()[..NUM_BYTES_PROGRAM_COUNTER]
+                destination.to_le_bytes()[..N_BYTES_PROGRAM_COUNTER]
                     .try_into()
                     .unwrap(),
             ),

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -193,9 +193,7 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
             region,
             offset,
             step.memory_word_size(),
-            [address.as_u64()
-                + 1
-                + if is_mstore8 == F::one() { 0 } else { 31 }],
+            [address.as_u64() + if is_mstore8 == F::one() { 1 } else { 32 }],
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::{MAX_GAS_SIZE_IN_BYTES, NUM_ADDRESS_BYTES_USED},
+        param::{N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE},
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -27,7 +27,7 @@ pub(crate) struct MemoryGadget<F> {
     same_context: SameContextGadget<F>,
     address: MemoryAddress<F>,
     value: Word<F>,
-    memory_expansion: MemoryExpansionGadget<F, MAX_GAS_SIZE_IN_BYTES>,
+    memory_expansion: MemoryExpansionGadget<F, 1, N_BYTES_MEMORY_WORD_SIZE>,
     is_mload: IsEqualGadget<F>,
     is_mstore8: IsEqualGadget<F>,
 }
@@ -41,8 +41,7 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
         let opcode = cb.query_cell();
 
         // In successful case the address must be in 5 bytes
-        let address =
-            MemoryAddress::new(cb.query_bytes(), cb.power_of_randomness());
+        let address = cb.query_rlc();
         let value = cb.query_word();
 
         // Check if this is an MLOAD
@@ -64,9 +63,9 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
         let memory_expansion = MemoryExpansionGadget::construct(
             cb,
             cb.curr.state.memory_word_size.expr(),
-            from_bytes::expr(&address.cells)
+            [from_bytes::expr(&address.cells)
                 + 1.expr()
-                + (is_not_mstore8.clone() * 31.expr()),
+                + (is_not_mstore8.clone() * 31.expr())],
         );
 
         /* Stack operations */
@@ -166,7 +165,7 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
             region,
             offset,
             Some(
-                address.to_le_bytes()[..NUM_ADDRESS_BYTES_USED]
+                address.to_le_bytes()[..N_BYTES_MEMORY_ADDRESS]
                     .try_into()
                     .unwrap(),
             ),
@@ -194,7 +193,9 @@ impl<F: FieldExt> ExecutionGadget<F> for MemoryGadget<F> {
             region,
             offset,
             step.memory_word_size(),
-            address.as_u64() + 1 + if is_mstore8 == F::one() { 0 } else { 31 },
+            [address.as_u64()
+                + 1
+                + if is_mstore8 == F::one() { 0 } else { 31 }],
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/execution/msize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/msize.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
-        param::NUM_BYTES_WORD,
+        param::N_BYTES_WORD,
         step::ExecutionState,
         util::{
             common_gadget::SameContextGadget,
@@ -14,7 +14,6 @@ use crate::{
     },
     util::Expr,
 };
-use array_init::array_init;
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Error};
 
 #[derive(Clone, Debug)]
@@ -29,17 +28,16 @@ impl<F: FieldExt> ExecutionGadget<F> for MsizeGadget<F> {
     const EXECUTION_STATE: ExecutionState = ExecutionState::MSIZE;
 
     fn configure(cb: &mut ConstraintBuilder<F>) -> Self {
+        let value = cb.query_rlc();
+
         // memory_size is limited to 64 bits so we only consider 8 bytes
-        let bytes = array_init(|_| cb.query_cell());
         cb.require_equal(
             "Constrain memory_size equal to stack value",
-            from_bytes::expr(&bytes),
-            cb.curr.state.memory_word_size.expr() * NUM_BYTES_WORD.expr(),
+            from_bytes::expr(&value.cells),
+            cb.curr.state.memory_word_size.expr() * N_BYTES_WORD.expr(),
         );
 
         // Push the value on the stack
-        let value =
-            RandomLinearCombination::new(bytes, cb.power_of_randomness());
         cb.stack_push(value.expr());
 
         // State transition
@@ -76,7 +74,7 @@ impl<F: FieldExt> ExecutionGadget<F> for MsizeGadget<F> {
         self.value.assign(
             region,
             offset,
-            Some(step.memory_size.to_le_bytes()),
+            Some((step.memory_size as u64).to_le_bytes()),
         )?;
 
         Ok(())

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -2,28 +2,33 @@
 pub(crate) const STEP_WIDTH: usize = 32;
 /// Step height
 pub const STEP_HEIGHT: usize = 14;
-pub(crate) const NUM_CELLS_STEP_STATE: usize = 10;
+pub(crate) const N_CELLS_STEP_STATE: usize = 10;
 
-// The number of bytes an u64 has.
-pub(crate) const NUM_BYTES_U64: usize = 8;
-// The number of bytes in EVM word.
-pub(crate) const NUM_BYTES_WORD: usize = 32;
+/// Maximum number of bytes that an integer can fit in field without wrapping
+/// around.
+pub(crate) const MAX_N_BYTES_INTEGER: usize = 31;
 
-/// The maximum number of bytes that a field element
-/// can be broken down into without causing the value it
-/// represents to overflow a single field element.
-pub(crate) const MAX_BYTES_FIELD: usize = 31;
+// Number of bytes an EVM word has.
+pub(crate) const N_BYTES_WORD: usize = 32;
+
+// Number of bytes an u64 has.
+pub(crate) const N_BYTES_U64: usize = 8;
+
+pub(crate) const N_BYTES_GAS: usize = N_BYTES_U64;
+
+pub(crate) const N_BYTES_ACCOUNT_ADDRESS: usize = 20;
+
+// Number of bytes that will be used of the memory address and size.
+// If any of the other more signficant bytes are used it will always result in
+// an out-of-gas error.
+pub(crate) const N_BYTES_MEMORY_ADDRESS: usize = 5;
+pub(crate) const N_BYTES_MEMORY_WORD_SIZE: usize = 4;
 
 pub(crate) const STACK_CAPACITY: usize = 1024;
-pub(crate) const MAX_GAS_SIZE_IN_BYTES: usize = 8;
-// Number of bytes that will be used of the address word.
-// If any of the other more signficant bytes are used it will
-// always result in an out-of-gas error.
-pub(crate) const NUM_ADDRESS_BYTES_USED: usize = 5;
-pub(crate) const MAX_MEMORY_SIZE_IN_BYTES: usize = 5;
+
 // Number of bytes that will be used of prorgam counter. Although the maximum
 // size of execution bytecode could be at most 128kB due to the size limit of a
 // transaction, which could be covered by 3 bytes, we still support program
 // counter to u64 as go-ethereum in case transaction size is allowed larger in
 // the future.
-pub(crate) const NUM_BYTES_PROGRAM_COUNTER: usize = NUM_BYTES_U64;
+pub(crate) const N_BYTES_PROGRAM_COUNTER: usize = N_BYTES_U64;

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -1,6 +1,6 @@
 use crate::{
     evm_circuit::{
-        param::{NUM_CELLS_STEP_STATE, STEP_HEIGHT, STEP_WIDTH},
+        param::{N_CELLS_STEP_STATE, STEP_HEIGHT, STEP_WIDTH},
         util::Cell,
         witness::{Call, ExecStep},
     },
@@ -438,7 +438,7 @@ impl<F: FieldExt> Step<F> {
         advices: [Column<Advice>; STEP_WIDTH],
         is_next_step: bool,
     ) -> Self {
-        let num_state_cells = ExecutionState::amount() + NUM_CELLS_STEP_STATE;
+        let num_state_cells = ExecutionState::amount() + N_CELLS_STEP_STATE;
 
         let state = {
             let mut cells = VecDeque::with_capacity(num_state_cells);

--- a/zkevm-circuits/src/evm_circuit/util.rs
+++ b/zkevm-circuits/src/evm_circuit/util.rs
@@ -1,4 +1,4 @@
-use crate::{evm_circuit::param::MAX_MEMORY_SIZE_IN_BYTES, util::Expr};
+use crate::{evm_circuit::param::N_BYTES_MEMORY_ADDRESS, util::Expr};
 use bus_mapping::eth_types::U256;
 use halo2::{
     arithmetic::FieldExt,
@@ -140,7 +140,7 @@ impl<F: FieldExt, const N: usize> Expr<F> for RandomLinearCombination<F, N> {
 
 pub(crate) type Word<F> = RandomLinearCombination<F, 32>;
 pub(crate) type MemoryAddress<F> =
-    RandomLinearCombination<F, MAX_MEMORY_SIZE_IN_BYTES>;
+    RandomLinearCombination<F, N_BYTES_MEMORY_ADDRESS>;
 
 /// Returns the sum of the passed in cells
 pub(crate) mod sum {
@@ -218,11 +218,14 @@ pub(crate) mod select {
 
 /// Decodes a field element from its byte representation
 pub(crate) mod from_bytes {
-    use crate::{evm_circuit::param::MAX_BYTES_FIELD, util::Expr};
+    use crate::{evm_circuit::param::MAX_N_BYTES_INTEGER, util::Expr};
     use halo2::{arithmetic::FieldExt, plonk::Expression};
 
     pub(crate) fn expr<F: FieldExt, E: Expr<F>>(bytes: &[E]) -> Expression<F> {
-        assert!(bytes.len() <= MAX_BYTES_FIELD, "number of bytes too large");
+        assert!(
+            bytes.len() <= MAX_N_BYTES_INTEGER,
+            "Too many bytes to compose an integer in field"
+        );
         let mut value = 0.expr();
         let mut multiplier = F::one();
         for byte in bytes.iter() {
@@ -233,7 +236,10 @@ pub(crate) mod from_bytes {
     }
 
     pub(crate) fn value<F: FieldExt>(bytes: &[u8]) -> F {
-        assert!(bytes.len() <= MAX_BYTES_FIELD, "number of bytes too large");
+        assert!(
+            bytes.len() <= MAX_N_BYTES_INTEGER,
+            "Too many bytes to compose an integer in field"
+        );
         let mut value = F::zero();
         let mut multiplier = F::one();
         for byte in bytes.iter() {

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -1,6 +1,6 @@
 use crate::{
     evm_circuit::{
-        param::MAX_GAS_SIZE_IN_BYTES,
+        param::N_BYTES_GAS,
         table::{AccountFieldTag, FixedTableTag, Lookup},
         util::{
             constraint_builder::{
@@ -26,7 +26,7 @@ use halo2::{
 #[derive(Clone, Debug)]
 pub(crate) struct SameContextGadget<F> {
     opcode: Cell<F>,
-    sufficient_gas_left: RangeCheckGadget<F, MAX_GAS_SIZE_IN_BYTES>,
+    sufficient_gas_left: RangeCheckGadget<F, N_BYTES_GAS>,
 }
 
 impl<F: FieldExt> SameContextGadget<F> {

--- a/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/util/constraint_builder.rs
@@ -5,7 +5,7 @@ use crate::{
             AccountFieldTag, CallContextFieldTag, FixedTableTag, Lookup,
             RwTableTag, TxContextFieldTag,
         },
-        util::{Cell, Word},
+        util::{Cell, RandomLinearCombination, Word},
     },
     util::Expr,
 };
@@ -189,7 +189,16 @@ impl<'a, F: FieldExt> ConstraintBuilder<'a, F> {
     }
 
     pub(crate) fn query_word(&mut self) -> Word<F> {
-        Word::new(self.query_bytes(), self.power_of_randomness)
+        self.query_rlc()
+    }
+
+    pub(crate) fn query_rlc<const N: usize>(
+        &mut self,
+    ) -> RandomLinearCombination<F, N> {
+        RandomLinearCombination::<F, N>::new(
+            self.query_bytes(),
+            self.power_of_randomness,
+        )
     }
 
     pub(crate) fn query_bytes<const N: usize>(&mut self) -> [Cell<F>; N] {

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -1,10 +1,7 @@
 use crate::{
-    evm_circuit::{
-        param::MAX_BYTES_FIELD,
-        util::{
-            self, constraint_builder::ConstraintBuilder, from_bytes,
-            pow_of_two, pow_of_two_expr, select, split_u256, sum, Cell,
-        },
+    evm_circuit::util::{
+        self, constraint_builder::ConstraintBuilder, from_bytes, pow_of_two,
+        pow_of_two_expr, select, split_u256, sum, Cell,
     },
     util::Expr,
 };
@@ -493,20 +490,19 @@ impl<F: FieldExt> MulWordByU64Gadget<F> {
 }
 
 /// Requires that the passed in value is within the specified range.
-/// `NUM_BYTES` is required to be `<= 31`.
+/// `N_BYTES` is required to be `<= MAX_N_BYTES_INTEGER`.
 #[derive(Clone, Debug)]
-pub struct RangeCheckGadget<F, const NUM_BYTES: usize> {
-    parts: [Cell<F>; NUM_BYTES],
+pub struct RangeCheckGadget<F, const N_BYTES: usize> {
+    parts: [Cell<F>; N_BYTES],
 }
 
-impl<F: FieldExt, const NUM_BYTES: usize> RangeCheckGadget<F, NUM_BYTES> {
+impl<F: FieldExt, const N_BYTES: usize> RangeCheckGadget<F, N_BYTES> {
     pub(crate) fn construct(
         cb: &mut ConstraintBuilder<F>,
         value: Expression<F>,
     ) -> Self {
-        assert!(NUM_BYTES <= 31, "number of bytes too large");
-
         let parts = cb.query_bytes();
+
         // Require that the reconstructed value from the parts equals the
         // original value
         cb.require_equal(
@@ -533,33 +529,31 @@ impl<F: FieldExt, const NUM_BYTES: usize> RangeCheckGadget<F, NUM_BYTES> {
 }
 
 /// Returns `1` when `lhs < rhs`, and returns `0` otherwise.
-/// lhs and rhs `< 256**NUM_BYTES`
-/// `NUM_BYTES` is required to be `<= MAX_BYTES_FIELD` to prevent overflow:
-/// values are stored in a single field element and two of these
-/// are added together.
+/// lhs and rhs `< 256**N_BYTES`
+/// `N_BYTES` is required to be `<= MAX_N_BYTES_INTEGER` to prevent overflow:
+/// values are stored in a single field element and two of these are added
+/// together.
 /// The equation that is enforced is `lhs - rhs == diff - (lt * range)`.
-/// Because all values are `<= 256**NUM_BYTES` and `lt` is boolean,
-///  `lt` can only be `1` when `lhs < rhs`.
+/// Because all values are `<= 256**N_BYTES` and `lt` is boolean, `lt` can only
+/// be `1` when `lhs < rhs`.
 #[derive(Clone, Debug)]
-pub struct LtGadget<F, const NUM_BYTES: usize> {
+pub struct LtGadget<F, const N_BYTES: usize> {
     lt: Cell<F>, // `1` when `lhs < rhs`, `0` otherwise.
-    diff: [Cell<F>; NUM_BYTES], /* The byte values of `diff`.
+    diff: [Cell<F>; N_BYTES], /* The byte values of `diff`.
                   * `diff` equals `lhs - rhs` if `lhs >= rhs`,
                   * `lhs - rhs + range` otherwise. */
-    range: F, // The range of the inputs, `256**NUM_BYTES`
+    range: F, // The range of the inputs, `256**N_BYTES`
 }
 
-impl<F: FieldExt, const NUM_BYTES: usize> LtGadget<F, NUM_BYTES> {
+impl<F: FieldExt, const N_BYTES: usize> LtGadget<F, N_BYTES> {
     pub(crate) fn construct(
         cb: &mut ConstraintBuilder<F>,
         lhs: Expression<F>,
         rhs: Expression<F>,
     ) -> Self {
-        assert!(NUM_BYTES <= MAX_BYTES_FIELD, "unsupported number of bytes");
-
         let lt = cb.query_bool();
         let diff = cb.query_bytes();
-        let range = pow_of_two(NUM_BYTES * 8);
+        let range = pow_of_two(N_BYTES * 8);
 
         // The equation we require to hold: `lhs - rhs == diff - (lt * range)`.
         cb.require_equal(
@@ -587,7 +581,7 @@ impl<F: FieldExt, const NUM_BYTES: usize> LtGadget<F, NUM_BYTES> {
         self.lt.assign(
             region,
             offset,
-            Some(F::from(if lt { 1 } else { 0 })),
+            Some(if lt { F::one() } else { F::zero() }),
         )?;
 
         // Set the bytes of diff
@@ -608,21 +602,21 @@ impl<F: FieldExt, const NUM_BYTES: usize> LtGadget<F, NUM_BYTES> {
 /// Returns (lt, eq):
 /// - `lt` is `1` when `lhs < rhs`, `0` otherwise.
 /// - `eq` is `1` when `lhs == rhs`, `0` otherwise.
-/// lhs and rhs `< 256**NUM_BYTES`
-/// `NUM_BYTES` is required to be `<= MAX_BYTES_FIELD`.
+/// lhs and rhs `< 256**N_BYTES`
+/// `N_BYTES` is required to be `<= MAX_N_BYTES_INTEGER`.
 #[derive(Clone, Debug)]
-pub struct ComparisonGadget<F, const NUM_BYTES: usize> {
-    lt: LtGadget<F, NUM_BYTES>,
+pub struct ComparisonGadget<F, const N_BYTES: usize> {
+    lt: LtGadget<F, N_BYTES>,
     eq: IsZeroGadget<F>,
 }
 
-impl<F: FieldExt, const NUM_BYTES: usize> ComparisonGadget<F, NUM_BYTES> {
+impl<F: FieldExt, const N_BYTES: usize> ComparisonGadget<F, N_BYTES> {
     pub(crate) fn construct(
         cb: &mut ConstraintBuilder<F>,
         lhs: Expression<F>,
         rhs: Expression<F>,
     ) -> Self {
-        let lt = LtGadget::<F, NUM_BYTES>::construct(cb, lhs, rhs);
+        let lt = LtGadget::<F, N_BYTES>::construct(cb, lhs, rhs);
         let eq = IsZeroGadget::<F>::construct(cb, sum::expr(&lt.diff_bytes()));
 
         Self { lt, eq }
@@ -705,55 +699,58 @@ impl<F: FieldExt> PairSelectGadget<F> {
     }
 }
 
-/// Returns (quotient: numerator/divisor, remainder: numerator%divisor),
-/// with `numerator` an expression and `divisor` a constant.
+/// Returns (quotient: numerator/denominator, remainder: numerator%denominator),
+/// with `numerator` an expression and `denominator` a constant.
 /// Input requirements:
-/// - `quotient < 256**NUM_BYTES`
-/// - `quotient * divisor < field size`
-/// - `remainder < divisor` currently requires a lookup table for `divisor`
+/// - `quotient < 256**N_BYTES`
+/// - `quotient * denominator < field size`
+/// - `remainder < denominator` requires a range lookup table for `denominator`
 #[derive(Clone, Debug)]
-pub struct ConstantDivisionGadget<F, const NUM_BYTES: usize> {
+pub struct ConstantDivisionGadget<F, const N_BYTES: usize> {
     quotient: Cell<F>,
     remainder: Cell<F>,
-    divisor: u64,
-    quotient_range_check: RangeCheckGadget<F, NUM_BYTES>,
+    denominator: u64,
+    quotient_range_check: RangeCheckGadget<F, N_BYTES>,
 }
 
-impl<F: FieldExt, const NUM_BYTES: usize> ConstantDivisionGadget<F, NUM_BYTES> {
+impl<F: FieldExt, const N_BYTES: usize> ConstantDivisionGadget<F, N_BYTES> {
     pub(crate) fn construct(
         cb: &mut ConstraintBuilder<F>,
         numerator: Expression<F>,
-        divisor: u64,
+        denominator: u64,
     ) -> Self {
         let quotient = cb.query_cell();
         let remainder = cb.query_cell();
 
-        // Require that remainder < divisor
-        cb.range_lookup(remainder.expr(), divisor);
+        // Require that remainder < denominator
+        cb.range_lookup(remainder.expr(), denominator);
 
-        // Require that quotient < 2**NUM_BYTES
-        // so we can't have any overflow when doing `quotient * divisor`.
+        // Require that quotient < 2**N_BYTES
+        // so we can't have any overflow when doing `quotient * denominator`.
         let quotient_range_check =
             RangeCheckGadget::construct(cb, quotient.expr());
 
         // Check if the division was done correctly
         cb.require_equal(
-            "lhnumerator - remainder == quotient ⋅ divisor",
+            "numerator - remainder == quotient ⋅ denominator",
             numerator - remainder.expr(),
-            quotient.expr() * divisor.expr(),
+            quotient.expr() * denominator.expr(),
         );
 
         Self {
             quotient,
             remainder,
-            divisor,
+            denominator,
             quotient_range_check,
         }
     }
 
-    pub(crate) fn expr(&self) -> (Expression<F>, Expression<F>) {
-        // Return the quotient and the remainder
-        (self.quotient.expr(), self.remainder.expr())
+    pub(crate) fn quotient(&self) -> Expression<F> {
+        self.quotient.expr()
+    }
+
+    pub(crate) fn remainder(&self) -> Expression<F> {
+        self.remainder.expr()
     }
 
     pub(crate) fn assign(
@@ -762,9 +759,10 @@ impl<F: FieldExt, const NUM_BYTES: usize> ConstantDivisionGadget<F, NUM_BYTES> {
         offset: usize,
         numerator: u128,
     ) -> Result<(u128, u128), Error> {
-        let divisor = self.divisor as u128;
-        let quotient = numerator / divisor;
-        let remainder = numerator % divisor;
+        let denominator = self.denominator as u128;
+        let quotient = numerator / denominator;
+        let remainder = numerator % denominator;
+
         self.quotient
             .assign(region, offset, Some(F::from_u128(quotient)))?;
         self.remainder
@@ -781,27 +779,33 @@ impl<F: FieldExt, const NUM_BYTES: usize> ConstantDivisionGadget<F, NUM_BYTES> {
 }
 
 /// Returns `rhs` when `lhs < rhs`, and returns `lhs` otherwise.
-/// lhs and rhs `< 256**NUM_BYTES`
-/// `NUM_BYTES` is required to be `<= 31`.
+/// lhs and rhs `< 256**N_BYTES`
+/// `N_BYTES` is required to be `<= MAX_N_BYTES_INTEGER`.
 #[derive(Clone, Debug)]
-pub struct MaxGadget<F, const NUM_BYTES: usize> {
-    lt: LtGadget<F, NUM_BYTES>,
+pub struct MinMaxGadget<F, const N_BYTES: usize> {
+    lt: LtGadget<F, N_BYTES>,
+    min: Expression<F>,
     max: Expression<F>,
 }
 
-impl<F: FieldExt, const NUM_BYTES: usize> MaxGadget<F, NUM_BYTES> {
+impl<F: FieldExt, const N_BYTES: usize> MinMaxGadget<F, N_BYTES> {
     pub(crate) fn construct(
         cb: &mut ConstraintBuilder<F>,
         lhs: Expression<F>,
         rhs: Expression<F>,
     ) -> Self {
         let lt = LtGadget::construct(cb, lhs.clone(), rhs.clone());
-        let max = select::expr(lt.expr(), rhs, lhs);
+        let max = select::expr(lt.expr(), rhs.clone(), lhs.clone());
+        let min = select::expr(lt.expr(), lhs, rhs);
 
-        Self { lt, max }
+        Self { lt, min, max }
     }
 
-    pub(crate) fn expr(&self) -> Expression<F> {
+    pub(crate) fn min(&self) -> Expression<F> {
+        self.min.clone()
+    }
+
+    pub(crate) fn max(&self) -> Expression<F> {
         self.max.clone()
     }
 
@@ -811,8 +815,12 @@ impl<F: FieldExt, const NUM_BYTES: usize> MaxGadget<F, NUM_BYTES> {
         offset: usize,
         lhs: F,
         rhs: F,
-    ) -> Result<F, Error> {
+    ) -> Result<(F, F), Error> {
         let (lt, _) = self.lt.assign(region, offset, lhs, rhs)?;
-        Ok(select::value(lt, rhs, lhs))
+        Ok(if lt.is_zero_vartime() {
+            (rhs, lhs)
+        } else {
+            (lhs, rhs)
+        })
     }
 }

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -1,31 +1,43 @@
-use crate::evm_circuit::{
-    param::MAX_MEMORY_SIZE_IN_BYTES,
-    util::{
-        constraint_builder::ConstraintBuilder,
-        math_gadget::{ConstantDivisionGadget, MaxGadget},
-        Address, MemorySize,
+use std::convert::TryInto;
+
+use crate::{
+    evm_circuit::{
+        param::{
+            N_BYTES_GAS, N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE,
+        },
+        util::{
+            constraint_builder::ConstraintBuilder,
+            from_bytes,
+            math_gadget::IsZeroGadget,
+            math_gadget::{ConstantDivisionGadget, MinMaxGadget},
+            sum, Cell, MemoryAddress, Word,
+        },
     },
+    util::Expr,
 };
-use crate::util::Expr;
-use bus_mapping::evm::GasCost;
+use array_init::array_init;
+use bus_mapping::{
+    eth_types::{ToLittleEndian, U256},
+    evm::GasCost,
+};
 use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
 
 /// Decodes the usable part of an address stored in a Word
 pub(crate) mod address_low {
     use crate::evm_circuit::{
-        param::NUM_ADDRESS_BYTES_USED,
-        util::{from_bytes, Address, Word},
+        param::N_BYTES_MEMORY_ADDRESS,
+        util::{from_bytes, Word},
     };
     use halo2::{arithmetic::FieldExt, plonk::Expression};
 
     pub(crate) fn expr<F: FieldExt>(address: &Word<F>) -> Expression<F> {
-        from_bytes::expr(&address.cells[0..NUM_ADDRESS_BYTES_USED])
+        from_bytes::expr(&address.cells[..N_BYTES_MEMORY_ADDRESS])
     }
 
-    pub(crate) fn value<F: FieldExt>(address: [u8; 32]) -> Address {
-        from_bytes::value::<F>(&address[0..NUM_ADDRESS_BYTES_USED])
-            .get_lower_128() as Address
+    pub(crate) fn value<F: FieldExt>(address: [u8; 32]) -> u64 {
+        from_bytes::value::<F>(&address[..N_BYTES_MEMORY_ADDRESS])
+            .get_lower_128() as u64
     }
 }
 
@@ -33,17 +45,116 @@ pub(crate) mod address_low {
 /// address
 pub(crate) mod address_high {
     use crate::evm_circuit::{
-        param::NUM_ADDRESS_BYTES_USED,
+        param::N_BYTES_MEMORY_ADDRESS,
         util::{sum, Word},
     };
     use halo2::{arithmetic::FieldExt, plonk::Expression};
 
     pub(crate) fn expr<F: FieldExt>(address: &Word<F>) -> Expression<F> {
-        sum::expr(&address.cells[NUM_ADDRESS_BYTES_USED..32])
+        sum::expr(&address.cells[N_BYTES_MEMORY_ADDRESS..])
     }
 
     pub(crate) fn value<F: FieldExt>(address: [u8; 32]) -> F {
-        sum::value::<F>(&address[NUM_ADDRESS_BYTES_USED..32])
+        sum::value::<F>(&address[N_BYTES_MEMORY_ADDRESS..])
+    }
+}
+
+/// Convert the dynamic memory offset and length from random linear combiation
+/// to integer. It handles the "no expansion" feature when length is zero.
+#[derive(Clone, Debug)]
+pub(crate) struct MemoryAddressGadget<F> {
+    memory_offset: Cell<F>,
+    memory_offset_bytes: MemoryAddress<F>,
+    memory_length: MemoryAddress<F>,
+    memory_length_is_zero: IsZeroGadget<F>,
+}
+
+impl<F: FieldExt> MemoryAddressGadget<F> {
+    pub(crate) fn construct(
+        cb: &mut ConstraintBuilder<F>,
+        memory_offset: Cell<F>,
+        memory_length: MemoryAddress<F>,
+    ) -> Self {
+        let memory_length_is_zero =
+            IsZeroGadget::construct(cb, sum::expr(&memory_length.cells));
+        let memory_offset_bytes = cb.query_rlc();
+
+        let has_length = 1.expr() - memory_length_is_zero.expr();
+        cb.condition(has_length, |cb| {
+            cb.require_equal(
+                "Offset decomposition into 5 bytes",
+                memory_offset_bytes.expr(),
+                memory_offset.expr(),
+            );
+        });
+
+        Self {
+            memory_offset,
+            memory_offset_bytes,
+            memory_length,
+            memory_length_is_zero,
+        }
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        memory_offset: U256,
+        memory_length: U256,
+        randomness: F,
+    ) -> Result<u64, Error> {
+        let memory_offset_bytes = memory_offset.to_le_bytes();
+        let memory_length_bytes = memory_length.to_le_bytes();
+        let memory_length_is_zero = memory_length.is_zero();
+        self.memory_offset.assign(
+            region,
+            offset,
+            Some(Word::random_linear_combine(memory_offset_bytes, randomness)),
+        )?;
+        self.memory_offset_bytes.assign(
+            region,
+            offset,
+            Some(if memory_length_is_zero {
+                [0; 5]
+            } else {
+                memory_offset_bytes[..N_BYTES_MEMORY_ADDRESS]
+                    .try_into()
+                    .unwrap()
+            }),
+        )?;
+        self.memory_length.assign(
+            region,
+            offset,
+            Some(
+                memory_length_bytes[..N_BYTES_MEMORY_ADDRESS]
+                    .try_into()
+                    .unwrap(),
+            ),
+        )?;
+        self.memory_length_is_zero.assign(
+            region,
+            offset,
+            sum::value(&memory_length_bytes),
+        )?;
+        Ok(if memory_length_is_zero {
+            0
+        } else {
+            memory_offset.low_u64() + memory_length.low_u64()
+        })
+    }
+
+    pub(crate) fn offset(&self) -> Expression<F> {
+        (1.expr() - self.memory_length_is_zero.expr())
+            * from_bytes::expr(&self.memory_offset_bytes.cells)
+    }
+
+    pub(crate) fn length(&self) -> Expression<F> {
+        from_bytes::expr(&self.memory_length.cells)
+    }
+
+    pub(crate) fn address(&self) -> Expression<F> {
+        self.offset() + self.length()
     }
 }
 
@@ -52,7 +163,7 @@ pub(crate) mod address_high {
 /// `memory_word_size = ceil(address/32) = floor((address + 31) / 32)`
 #[derive(Clone, Debug)]
 pub(crate) struct MemoryWordSizeGadget<F> {
-    memory_word_size: ConstantDivisionGadget<F, MAX_MEMORY_SIZE_IN_BYTES>,
+    memory_word_size: ConstantDivisionGadget<F, N_BYTES_MEMORY_WORD_SIZE>,
 }
 
 impl<F: FieldExt> MemoryWordSizeGadget<F> {
@@ -67,22 +178,21 @@ impl<F: FieldExt> MemoryWordSizeGadget<F> {
     }
 
     pub(crate) fn expr(&self) -> Expression<F> {
-        let (quotient, _) = self.memory_word_size.expr();
-        quotient
+        self.memory_word_size.quotient()
     }
 
     pub(crate) fn assign(
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        address: Address,
-    ) -> Result<MemorySize, Error> {
+        address: u64,
+    ) -> Result<u64, Error> {
         let (quotient, _) = self.memory_word_size.assign(
             region,
             offset,
             (address as u128) + 31,
         )?;
-        Ok(quotient as MemorySize)
+        Ok(quotient as u64)
     }
 }
 
@@ -92,21 +202,22 @@ impl<F: FieldExt> MemoryWordSizeGadget<F> {
 /// `memory_cost = Gmem * memory_word_size + floor(memory_word_size *
 /// memory_word_size / 512)`
 #[derive(Clone, Debug)]
-pub(crate) struct MemoryExpansionGadget<F, const MAX_QUAD_COST_IN_BYTES: usize>
-{
-    addr_memory_word_size: MemoryWordSizeGadget<F>,
-    next_memory_word_size: MaxGadget<F, MAX_MEMORY_SIZE_IN_BYTES>,
-    curr_quad_memory_cost: ConstantDivisionGadget<F, MAX_QUAD_COST_IN_BYTES>,
-    next_quad_memory_cost: ConstantDivisionGadget<F, MAX_QUAD_COST_IN_BYTES>,
+pub(crate) struct MemoryExpansionGadget<
+    F,
+    const N: usize,
+    const N_BYTES_MEMORY_WORD_SIZE: usize,
+> {
+    memory_word_sizes: [MemoryWordSizeGadget<F>; N],
+    max_memory_word_sizes: [MinMaxGadget<F, N_BYTES_MEMORY_WORD_SIZE>; N],
+    curr_quad_memory_cost: ConstantDivisionGadget<F, N_BYTES_GAS>,
+    next_quad_memory_cost: ConstantDivisionGadget<F, N_BYTES_GAS>,
+    next_memory_word_size: Expression<F>,
     gas_cost: Expression<F>,
 }
 
-impl<F: FieldExt, const MAX_QUAD_COST_IN_BYTES: usize>
-    MemoryExpansionGadget<F, MAX_QUAD_COST_IN_BYTES>
+impl<F: FieldExt, const N: usize, const N_BYTES_MEMORY_WORD_SIZE: usize>
+    MemoryExpansionGadget<F, N, N_BYTES_MEMORY_WORD_SIZE>
 {
-    pub const GAS_MEM: GasCost = GasCost::MEMORY;
-    pub const QUAD_COEFF_DIV: u64 = 512u64;
-
     /// Input requirements:
     /// - `curr_memory_word_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
     /// - `address < 32 * 256**MAX_MEMORY_SIZE_IN_BYTES`
@@ -117,21 +228,26 @@ impl<F: FieldExt, const MAX_QUAD_COST_IN_BYTES: usize>
     pub(crate) fn construct(
         cb: &mut ConstraintBuilder<F>,
         curr_memory_word_size: Expression<F>,
-        address: Expression<F>,
+        addresses: [Expression<F>; N],
     ) -> Self {
         // Calculate the memory size of the memory access
-        // `addr_memory_word_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
-        let addr_memory_word_size =
-            MemoryWordSizeGadget::construct(cb, address);
+        // `address_memory_word_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+        let memory_word_sizes = addresses
+            .map(|address| MemoryWordSizeGadget::construct(cb, address));
 
         // The memory size needs to be updated if this memory access
         // requires expanding the memory.
         // `next_memory_word_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
-        let next_memory_word_size = MaxGadget::construct(
-            cb,
-            addr_memory_word_size.expr(),
-            curr_memory_word_size.clone(),
-        );
+        let mut next_memory_word_size = curr_memory_word_size.clone();
+        let max_memory_word_sizes = array_init(|idx| {
+            let max_memory_word_size = MinMaxGadget::construct(
+                cb,
+                next_memory_word_size.clone(),
+                memory_word_sizes[idx].expr(),
+            );
+            next_memory_word_size = max_memory_word_size.max();
+            max_memory_word_size
+        });
 
         // Calculate the quad memory cost for the current and next memory size.
         // These quad costs will also be range limited to `<
@@ -139,34 +255,36 @@ impl<F: FieldExt, const MAX_QUAD_COST_IN_BYTES: usize>
         let curr_quad_memory_cost = ConstantDivisionGadget::construct(
             cb,
             curr_memory_word_size.clone() * curr_memory_word_size.clone(),
-            Self::QUAD_COEFF_DIV,
+            GasCost::MEMORY_EXPANSION_QUAD_DENOMINATOR.as_u64(),
         );
         let next_quad_memory_cost = ConstantDivisionGadget::construct(
             cb,
-            next_memory_word_size.expr() * next_memory_word_size.expr(),
-            Self::QUAD_COEFF_DIV,
+            next_memory_word_size.clone() * next_memory_word_size.clone(),
+            GasCost::MEMORY_EXPANSION_QUAD_DENOMINATOR.as_u64(),
         );
 
         // Calculate the gas cost for the memory expansion.
         // This gas cost is the difference between the next and current memory
         // costs. `gas_cost <=
         // GAS_MEM*256**MAX_MEMORY_SIZE_IN_BYTES + 256**MAX_QUAD_COST_IN_BYTES`
-        let gas_cost = (next_memory_word_size.expr() - curr_memory_word_size)
-            * Self::GAS_MEM.expr()
-            + (next_quad_memory_cost.expr().0 - curr_quad_memory_cost.expr().0);
+        let gas_cost = GasCost::MEMORY_EXPANSION_LINEAR_COEFF.expr()
+            * (next_memory_word_size.clone() - curr_memory_word_size)
+            + (next_quad_memory_cost.quotient()
+                - curr_quad_memory_cost.quotient());
 
         Self {
-            addr_memory_word_size,
-            next_memory_word_size,
+            memory_word_sizes,
+            max_memory_word_sizes,
             curr_quad_memory_cost,
             next_quad_memory_cost,
+            next_memory_word_size,
             gas_cost,
         }
     }
 
     pub(crate) fn next_memory_word_size(&self) -> Expression<F> {
-        // Return the new memory word size
-        self.next_memory_word_size.expr()
+        // Return the new memory size
+        self.next_memory_word_size.clone()
     }
 
     pub(crate) fn gas_cost(&self) -> Expression<F> {
@@ -178,23 +296,34 @@ impl<F: FieldExt, const MAX_QUAD_COST_IN_BYTES: usize>
         &self,
         region: &mut Region<'_, F>,
         offset: usize,
-        curr_memory_word_size: MemorySize,
-        address: Address,
-    ) -> Result<(MemorySize, u128), Error> {
-        // Calculate the active memory word size
-        let addr_memory_word_size =
-            self.addr_memory_word_size.assign(region, offset, address)?;
+        curr_memory_word_size: u64,
+        addresses: [u64; N],
+    ) -> Result<(u64, u64), Error> {
+        // Calculate the active memory size
+        let memory_word_sizes = self
+            .memory_word_sizes
+            .iter()
+            .zip(addresses.iter())
+            .map(|(memory_word_size, address)| {
+                memory_word_size.assign(region, offset, *address)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
-        // Calculate the next memory word size
-        let next_memory_word_size = self
-            .next_memory_word_size
-            .assign(
+        // Calculate the next memory size
+        let mut next_memory_word_size = curr_memory_word_size as u64;
+        for (max_memory_word_sizes, memory_word_size) in self
+            .max_memory_word_sizes
+            .iter()
+            .zip(memory_word_sizes.iter())
+        {
+            let (_, max) = max_memory_word_sizes.assign(
                 region,
                 offset,
-                F::from(addr_memory_word_size),
-                F::from(curr_memory_word_size),
-            )?
-            .get_lower_128() as MemorySize;
+                F::from(next_memory_word_size as u64),
+                F::from(*memory_word_size),
+            )?;
+            next_memory_word_size = max.get_lower_128() as u64;
+        }
 
         // Calculate the quad gas cost for the memory size
         let (curr_quad_memory_cost, _) = self.curr_quad_memory_cost.assign(
@@ -209,10 +338,9 @@ impl<F: FieldExt, const MAX_QUAD_COST_IN_BYTES: usize>
         )?;
 
         // Calculate the gas cost for the expansian
-        let memory_cost = (next_memory_word_size - curr_memory_word_size)
-            as u128
-            * (Self::GAS_MEM.as_u64() as u128)
-            + (next_quad_memory_cost - curr_quad_memory_cost);
+        let memory_cost = GasCost::MEMORY_EXPANSION_LINEAR_COEFF.as_u64()
+            * (next_memory_word_size - curr_memory_word_size as u64)
+            + (next_quad_memory_cost - curr_quad_memory_cost) as u64;
 
         // Return the new memory size and the memory expansion gas cost
         Ok((next_memory_word_size, memory_cost))

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::{
     evm_circuit::{
         param::{
@@ -22,6 +20,7 @@ use bus_mapping::{
 };
 use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
+use std::convert::TryInto;
 
 /// Decodes the usable part of an address stored in a Word
 pub(crate) mod address_low {
@@ -35,9 +34,10 @@ pub(crate) mod address_low {
         from_bytes::expr(&address.cells[..N_BYTES_MEMORY_ADDRESS])
     }
 
-    pub(crate) fn value<F: FieldExt>(address: [u8; 32]) -> u64 {
-        from_bytes::value::<F>(&address[..N_BYTES_MEMORY_ADDRESS])
-            .get_lower_128() as u64
+    pub(crate) fn value(address: [u8; 32]) -> u64 {
+        let mut bytes = [0; 8];
+        bytes.copy_from_slice(&address[..N_BYTES_MEMORY_ADDRESS]);
+        u64::from_le_bytes(bytes)
     }
 }
 
@@ -140,7 +140,8 @@ impl<F: FieldExt> MemoryAddressGadget<F> {
         Ok(if memory_length_is_zero {
             0
         } else {
-            memory_offset.low_u64() + memory_length.low_u64()
+            address_low::value(memory_offset_bytes)
+                + address_low::value(memory_length_bytes)
         })
     }
 

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 use crate::evm_circuit::{
-    param::{NUM_BYTES_WORD, STACK_CAPACITY},
+    param::{N_BYTES_WORD, STACK_CAPACITY},
     step::ExecutionState,
     table::{
         AccountFieldTag, BlockContextFieldTag, CallContextFieldTag, RwTableTag,
@@ -295,8 +295,8 @@ impl ExecStep {
         // EVM always pads the memory size to word size
         // https://github.com/ethereum/go-ethereum/blob/master/core/vm/interpreter.go#L212-L216
         // Thus, the memory size must be a multiple of 32 bytes.
-        assert_eq!(self.memory_size % NUM_BYTES_WORD as u64, 0);
-        self.memory_size / NUM_BYTES_WORD as u64
+        assert_eq!(self.memory_size % N_BYTES_WORD as u64, 0);
+        self.memory_size / N_BYTES_WORD as u64
     }
 }
 

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -472,7 +472,7 @@ impl Rw {
                 value_prev,
             } => {
                 let to_scalar = |value: &Word| match field_tag {
-                    AccountFieldTag::Nonce => F::from(value.low_u64()),
+                    AccountFieldTag::Nonce => value.to_scalar().unwrap(),
                     _ => RandomLinearCombination::random_linear_combine(
                         value.to_le_bytes(),
                         randomness,
@@ -512,7 +512,7 @@ impl Rw {
                     CallContextFieldTag::CallerAddress
                     | CallContextFieldTag::CalleeAddress
                     | CallContextFieldTag::Result => value.to_scalar().unwrap(),
-                    _ => F::from(value.low_u64()),
+                    _ => value.to_scalar().unwrap(),
                 },
                 F::zero(),
                 F::zero(),


### PR DESCRIPTION
This PR is part of #278, which extends memory gadgets to add/extend

- `MemoryAddressGadget` - To handle dynamic offset and length expansion. It's also useful for memory expansion opcode like `CALLDATACOPY`. 
- `MemoryExpansionGadget` - To support multiple expansion size. It's useful for `*CALL*` which assign 2 memory chunks as expansion targets.

It also refactors some frequently used constant and methods. For main changes, please refer to [`memory_gadget.rs`](https://github.com/appliedzkp/zkevm-circuits/pull/279/files#diff-19306e3baf34b1f4a23a09ee03e0f5bb5187d2e885af70cab30d81b4419c62a9)