### PR TITLE
Add integration test for ETH transfer

### DIFF
--- a/integration-tests/src/bin/gen_blockchain_data.rs
+++ b/integration-tests/src/bin/gen_blockchain_data.rs
@@ -117,6 +117,8 @@ async fn main() {
     let wallet0 = get_wallet(0);
     info!("wallet0: {:x}", wallet0.address());
 
+    let mut blocks = HashMap::new();
+
     // Transfer funds to our account.
     info!("Transferring funds from coinbase...");
     let tx = TransactionRequest::new()
@@ -128,6 +130,9 @@ async fn main() {
         .expect("cannot send tx")
         .await
         .expect("cannot confirm tx");
+    let block_num =
+        prov.get_block_number().await.expect("cannot get block_num");
+    blocks.insert("Transfer 0".to_string(), block_num.as_u64());
 
     // Deploy smart contracts
     let mut deployments = HashMap::new();
@@ -140,6 +145,7 @@ async fn main() {
     .await;
     let block_num =
         prov.get_block_number().await.expect("cannot get block_num");
+    blocks.insert("Deploy Greeter".to_string(), block_num.as_u64());
     deployments.insert(
         "Greeter".to_string(),
         (block_num.as_u64(), contract.address()),
@@ -148,6 +154,7 @@ async fn main() {
     let gen_data = GenDataOutput {
         coinbase: accounts[0],
         wallets: vec![get_wallet(0).address()],
+        blocks,
         deployments,
     };
     gen_data.store();

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env::{self, VarError};
 use std::fs::File;
+use std::sync::Once;
 use std::time::Duration;
 use url::Url;
 
@@ -42,10 +43,14 @@ lazy_static! {
     };
 }
 
+static LOG_INIT: Once = Once::new();
+
 /// Initialize log
 pub fn log_init() {
-    env_logger::Builder::from_env(Env::default().default_filter_or("info"))
-        .init();
+    LOG_INIT.call_once(|| {
+        env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+            .init();
+    });
 }
 
 /// Get the integration test [`GethClient`]
@@ -91,6 +96,8 @@ pub struct GenDataOutput {
     pub coinbase: Address,
     /// Wallets used by `gen_blockchain_data`
     pub wallets: Vec<Address>,
+    /// Block map: BlockContent -> BlockNum
+    pub blocks: HashMap<String, u64>,
     /// Contracts deployed map: ContractName -> (BlockNum, Address)
     pub deployments: HashMap<String, (u64, Address)>,
 }

--- a/integration-tests/tests/circuit_input_builder.rs
+++ b/integration-tests/tests/circuit_input_builder.rs
@@ -9,25 +9,19 @@ lazy_static! {
     pub static ref GEN_DATA: GenDataOutput = GenDataOutput::load();
 }
 
-/// This test builds the complete circuit inputs for the block where the Greeter
-/// contract is deployed.
-#[tokio::test]
-async fn test_circuit_input_builder_block_a() {
-    log_init();
-    let (block_num, _address) = GEN_DATA.deployments.get("Greeter").unwrap();
+async fn test_circuit_input_builder_block(block_num: u64) {
     let cli = get_client();
-
     let cli = BuilderClient::new(cli).await.unwrap();
 
     // 1. Query geth for Block, Txs and TxExecTraces
-    let (eth_block, geth_trace) = cli.get_block(*block_num).await.unwrap();
+    let (eth_block, geth_trace) = cli.get_block(block_num).await.unwrap();
 
     // 2. Get State Accesses from TxExecTraces
     let access_set = cli.get_state_accesses(&eth_block, &geth_trace).unwrap();
     trace!("AccessSet: {:#?}", access_set);
 
     // 3. Query geth for all accounts, storage keys, and codes from Accesses
-    let (proofs, codes) = cli.get_state(*block_num, access_set).await.unwrap();
+    let (proofs, codes) = cli.get_state(block_num, access_set).await.unwrap();
 
     // 4. Build a partial StateDB from step 3
     let (state_db, code_db) = cli.build_state_code_db(proofs, codes);
@@ -40,4 +34,22 @@ async fn test_circuit_input_builder_block_a() {
         .unwrap();
 
     trace!("CircuitInputBuilder: {:#?}", builder);
+}
+
+/// This test builds the complete circuit inputs for the block where 1 ETH is
+/// transfered.
+#[tokio::test]
+async fn test_circuit_input_builder_block_transfer_0() {
+    log_init();
+    let block_num = GEN_DATA.blocks.get("Transfer 0").unwrap();
+    test_circuit_input_builder_block(*block_num).await;
+}
+
+/// This test builds the complete circuit inputs for the block where the Greeter
+/// contract is deployed.
+#[tokio::test]
+async fn test_circuit_input_builder_block_deploy_greeter() {
+    log_init();
+    let block_num = GEN_DATA.blocks.get("Deploy Greeter").unwrap();
+    test_circuit_input_builder_block(*block_num).await;
 }

--- a/integration-tests/tests/circuits.rs
+++ b/integration-tests/tests/circuits.rs
@@ -289,16 +289,12 @@ mod test_evm_circuit {
     }
 }
 
-#[tokio::test]
-async fn test_evm_circuit_block_a() {
+async fn test_evm_circuit_block(block_num: u64) {
     use test_evm_circuit::*;
 
-    log_init();
-    let (block_num, _address) = GEN_DATA.deployments.get("Greeter").unwrap();
     let cli = get_client();
-
     let cli = BuilderClient::new(cli).await.unwrap();
-    let builder = cli.gen_inputs(*block_num).await.unwrap();
+    let builder = cli.gen_inputs(block_num).await.unwrap();
 
     // Generate evm_circuit proof
     let code_hash = builder.block.txs()[0].calls()[0].code_hash;
@@ -313,13 +309,23 @@ async fn test_evm_circuit_block_a() {
 }
 
 #[tokio::test]
-async fn test_state_circuit_block_a() {
+async fn test_evm_circuit_block_transfer_0() {
     log_init();
-    let (block_num, _address) = GEN_DATA.deployments.get("Greeter").unwrap();
-    let cli = get_client();
+    let block_num = GEN_DATA.blocks.get("Transfer 0").unwrap();
+    test_evm_circuit_block(*block_num).await;
+}
 
+#[tokio::test]
+async fn test_evm_circuit_block_deploy_greeter() {
+    log_init();
+    let block_num = GEN_DATA.blocks.get("Deploy Greeter").unwrap();
+    test_evm_circuit_block(*block_num).await;
+}
+
+async fn test_state_circuit_block(block_num: u64) {
+    let cli = get_client();
     let cli = BuilderClient::new(cli).await.unwrap();
-    let builder = cli.gen_inputs(*block_num).await.unwrap();
+    let builder = cli.gen_inputs(block_num).await.unwrap();
 
     // Generate state proof
     let stack_ops = builder.block.container.sorted_stack();
@@ -356,4 +362,18 @@ async fn test_state_circuit_block_a() {
     let prover =
         MockProver::<Fp>::run(DEGREE as u32, &circuit, vec![]).unwrap();
     prover.verify().expect("state_circuit verification failed");
+}
+
+#[tokio::test]
+async fn test_state_circuit_block_transfer_0() {
+    log_init();
+    let block_num = GEN_DATA.blocks.get("Transfer 0").unwrap();
+    test_state_circuit_block(*block_num).await;
+}
+
+#[tokio::test]
+async fn test_state_circuit_block_deploy_greeter() {
+    log_init();
+    let block_num = GEN_DATA.blocks.get("Deploy Greeter").unwrap();
+    test_state_circuit_block(*block_num).await;
 }


### PR DESCRIPTION
In the integration testing setup we already had a block with an ETH transfer, but we just didn't use it as inputs for the state and evm circuit.

This is a very small PR that test (via integration) the state and evm circuit with an ETH transfer.  Currently the CircuitInputBuilder doesn't generate the BeginTx, EndTx, EndBlock circuit steps, so the circuits in this test will have mostly empty inputs; but this will soon change and I thought it was a good idea to already have an integration test for the moment we have those 3 steps generated by the CircuitInputBuilder.