### PR TITLE
Initialize `LastCallee*` of `CallContext`

### DIFF
--- a/bus-mapping/src/operation.rs
+++ b/bus-mapping/src/operation.rs
@@ -652,6 +652,12 @@ pub enum CallContextField {
     IsPersistent,
     /// IsStatic
     IsStatic,
+    /// LastCalleeId
+    LastCalleeId,
+    /// LastCalleeReturnDataOffset
+    LastCalleeReturnDataOffset,
+    /// LastCalleeReturnDataLength
+    LastCalleeReturnDataLength,
     /// IsRoot
     IsRoot,
     /// IsCreate

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -144,12 +144,15 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             ),
             (CallContextFieldTag::Value, tx_value.expr()),
             (CallContextFieldTag::IsStatic, 0.expr()),
+            (CallContextFieldTag::LastCalleeId, 0.expr()),
+            (CallContextFieldTag::LastCalleeReturnDataOffset, 0.expr()),
+            (CallContextFieldTag::LastCalleeReturnDataLength, 0.expr()),
         ] {
             cb.call_context_lookup(false.expr(), Some(call_id.expr()), field_tag, value);
         }
 
         cb.require_step_state_transition(StepStateTransition {
-            // 16 read/write including:
+            // 19 read/write including:
             //   - Read CallContext TxId
             //   - Read CallContext RwCounterEndOfReversion
             //   - Read CallContext IsPersistent
@@ -166,7 +169,10 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
             //   - Read CallContext CallDataLength
             //   - Read CallContext Value
             //   - Read CallContext IsStatic
-            rw_counter: Delta(16.expr()),
+            //   - Read CallContext LastCalleeId
+            //   - Read CallContext LastCalleeReturnDataOffset
+            //   - Read CallContext LastCalleeReturnDataLength
+            rw_counter: Delta(19.expr()),
             call_id: To(call_id.expr()),
             is_root: To(true.expr()),
             is_create: To(false.expr()),
@@ -360,7 +366,7 @@ mod test {
                     },
                     ExecStep {
                         execution_state: ExecutionState::STOP,
-                        rw_counter: 17,
+                        rw_counter: 20,
                         program_counter: 0,
                         stack_pointer: STACK_CAPACITY,
                         gas_left: 0,
@@ -526,6 +532,27 @@ mod test {
                                 is_write: false,
                                 call_id: 1,
                                 field_tag: CallContextFieldTag::IsStatic,
+                                value: Word::zero(),
+                            },
+                            Rw::CallContext {
+                                rw_counter: 17,
+                                is_write: false,
+                                call_id: 1,
+                                field_tag: CallContextFieldTag::LastCalleeId,
+                                value: Word::zero(),
+                            },
+                            Rw::CallContext {
+                                rw_counter: 18,
+                                is_write: false,
+                                call_id: 1,
+                                field_tag: CallContextFieldTag::LastCalleeReturnDataOffset,
+                                value: Word::zero(),
+                            },
+                            Rw::CallContext {
+                                rw_counter: 19,
+                                is_write: false,
+                                call_id: 1,
+                                field_tag: CallContextFieldTag::LastCalleeReturnDataLength,
                                 value: Word::zero(),
                             },
                         ],

--- a/zkevm-circuits/src/evm_circuit/table.rs
+++ b/zkevm-circuits/src/evm_circuit/table.rs
@@ -178,6 +178,10 @@ pub enum CallContextFieldTag {
     IsPersistent,
     IsStatic,
 
+    LastCalleeId,
+    LastCalleeReturnDataOffset,
+    LastCalleeReturnDataLength,
+
     IsRoot,
     IsCreate,
     CodeSource,

--- a/zkevm-circuits/src/evm_circuit/witness.rs
+++ b/zkevm-circuits/src/evm_circuit/witness.rs
@@ -898,6 +898,13 @@ impl From<&operation::OperationContainer> for RwMap {
                         CallContextField::IsSuccess => CallContextFieldTag::IsSuccess,
                         CallContextField::IsPersistent => CallContextFieldTag::IsPersistent,
                         CallContextField::IsStatic => CallContextFieldTag::IsStatic,
+                        CallContextField::LastCalleeId => CallContextFieldTag::LastCalleeId,
+                        CallContextField::LastCalleeReturnDataOffset => {
+                            CallContextFieldTag::LastCalleeReturnDataOffset
+                        }
+                        CallContextField::LastCalleeReturnDataLength => {
+                            CallContextFieldTag::LastCalleeReturnDataLength
+                        }
                         CallContextField::IsRoot => CallContextFieldTag::IsRoot,
                         CallContextField::IsCreate => CallContextFieldTag::IsCreate,
                         CallContextField::CodeSource => CallContextFieldTag::CodeSource,


### PR DESCRIPTION
This PR is once #278, and aims to initialize last callee's information of `CallContext` in `BeginTx`.

For spec, see appliedzkp/zkevm-specs#99.

It depends on #292.
