### PR TITLE
Split eth-types Error

### DIFF
--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -1,0 +1,47 @@
+//! Error module for the bus-mapping crate
+
+use core::fmt::{Display, Formatter, Result as FmtResult};
+use eth_types::{Address, GethExecStep};
+use ethers_providers::ProviderError;
+use std::error::Error as StdError;
+
+/// Error type for any BusMapping related failure.
+#[derive(Debug)]
+pub enum Error {
+    /// Serde de/serialization error.
+    SerdeError(serde_json::error::Error),
+    /// Error while generating a trace.
+    TracingError,
+    /// JSON-RPC related error.
+    JSONRpcError(ProviderError),
+    /// OpcodeId is not a call type.
+    OpcodeIdNotCallType,
+    /// Account not found in the StateDB
+    AccountNotFound(Address),
+    /// Unable to figure out error at a [`GethExecStep`]
+    UnexpectedExecStepError(&'static str, Box<GethExecStep>),
+    /// Invalid [`GethExecStep`] due to an invalid/unexpected value in it.
+    InvalidGethExecStep(&'static str, Box<GethExecStep>),
+    /// Eth type related error.
+    EthTypeError(eth_types::Error),
+}
+
+impl From<eth_types::Error> for Error {
+    fn from(err: eth_types::Error) -> Self {
+        Error::EthTypeError(err)
+    }
+}
+
+impl From<ProviderError> for Error {
+    fn from(err: ProviderError) -> Self {
+        Error::JSONRpcError(err)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl StdError for Error {}

--- a/bus-mapping/src/error.rs
+++ b/bus-mapping/src/error.rs
@@ -1,7 +1,7 @@
 //! Error module for the bus-mapping crate
 
 use core::fmt::{Display, Formatter, Result as FmtResult};
-use eth_types::{Address, GethExecStep};
+use eth_types::{Address, GethExecStep, Word};
 use ethers_providers::ProviderError;
 use std::error::Error as StdError;
 
@@ -18,6 +18,8 @@ pub enum Error {
     OpcodeIdNotCallType,
     /// Account not found in the StateDB
     AccountNotFound(Address),
+    /// Storage key not found in the StateDB
+    StorageKeyNotFound(Address, Word),
     /// Unable to figure out error at a [`GethExecStep`]
     UnexpectedExecStepError(&'static str, Box<GethExecStep>),
     /// Invalid [`GethExecStep`] due to an invalid/unexpected value in it.

--- a/bus-mapping/src/lib.rs
+++ b/bus-mapping/src/lib.rs
@@ -218,6 +218,7 @@
 #![allow(clippy::upper_case_acronyms)] // Too pedantic
 
 extern crate alloc;
+pub mod error;
 pub mod evm;
 pub mod exec_trace;
 pub mod external_tracer;
@@ -229,4 +230,4 @@ pub(crate) mod geth_errors;
 pub mod mock;
 pub mod rpc;
 pub mod state_db;
-pub use eth_types::Error;
+pub use error::Error;

--- a/eth-types/src/error.rs
+++ b/eth-types/src/error.rs
@@ -1,8 +1,6 @@
-//! Error module for the bus-mapping crate
+//! Error module for the eth-types crate
 
-use crate::{Address, GethExecStep, Word};
 use core::fmt::{Display, Formatter, Result as FmtResult};
-use ethers_providers::ProviderError;
 use std::error::Error as StdError;
 
 /// Error type for any BusMapping related failure.
@@ -14,10 +12,6 @@ pub enum Error {
     MemAddressParsing,
     /// Error while parsing a `StackAddress`.
     StackAddressParsing,
-    /// Error while trying to convert to an incorrect `OpcodeId`.
-    InvalidOpConversion,
-    /// Serde de/serialization error.
-    SerdeError(serde_json::error::Error),
     /// Error while trying to access an invalid/empty Stack location.
     InvalidStackPointer,
     /// Error while trying to access an invalid/empty Memory location.
@@ -27,26 +21,6 @@ pub enum Error {
     /// Error when an EvmWord is too big to be converted into a
     /// `MemoryAddress`.
     WordToMemAddr,
-    /// Error while generating a trace.
-    TracingError,
-    /// JSON-RPC related error.
-    JSONRpcError(ProviderError),
-    /// OpcodeId is not a call type.
-    OpcodeIdNotCallType,
-    /// Account not found in the StateDB
-    AccountNotFound(Address),
-    /// Storage key not found in the StateDB
-    StorageKeyNotFound(Address, Word),
-    /// Unable to figure out error at a [`GethExecStep`]
-    UnexpectedExecStepError(&'static str, Box<GethExecStep>),
-    /// Invalid [`GethExecStep`] due to an invalid/unexpected value in it.
-    InvalidGethExecStep(&'static str, Box<GethExecStep>),
-}
-
-impl From<ProviderError> for Error {
-    fn from(err: ProviderError) -> Self {
-        Error::JSONRpcError(err)
-    }
 }
 
 impl Display for Error {

--- a/eth-types/src/error.rs
+++ b/eth-types/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     MemAddressParsing,
     /// Error while parsing a `StackAddress`.
     StackAddressParsing,
+    /// Error while trying to convert to an incorrect `OpcodeId`.
+    InvalidOpConversion,
     /// Error while trying to access an invalid/empty Stack location.
     InvalidStackPointer,
     /// Error while trying to access an invalid/empty Memory location.


### PR DESCRIPTION
Close https://github.com/appliedzkp/zkevm-circuits/issues/294

Move `bus-mapping` related errors out of `eth-types`.