### PR TITLE
Simplify rho gates

### DIFF
--- a/keccak256/src/gates/gate_helpers.rs
+++ b/keccak256/src/gates/gate_helpers.rs
@@ -1,15 +1,6 @@
-use halo2::circuit::Cell;
 use num_bigint::BigUint;
 use pairing::arithmetic::FieldExt;
 use std::convert::TryInto;
-
-#[derive(Debug, Clone, Copy)]
-pub struct BlockCount<F> {
-    pub cell: Cell,
-    pub value: F,
-}
-
-pub type BlockCount2<F> = (BlockCount<F>, BlockCount<F>);
 
 /// Convert a bigUint value to FieldExt
 ///

--- a/keccak256/src/gates/rho.rs
+++ b/keccak256/src/gates/rho.rs
@@ -86,7 +86,7 @@ impl<F: FieldExt> RhoConfig<F> {
             .flatten()
             .collect::<Vec<_>>();
         self.overflow_check_config.assign_region(
-            &mut layouter.namespace(|| "Final block count check"),
+            &mut layouter.namespace(|| "Final overflow check"),
             step2_od_join,
             step3_od_join,
         )?;

--- a/keccak256/src/gates/rho.rs
+++ b/keccak256/src/gates/rho.rs
@@ -1,24 +1,20 @@
 use crate::gates::{
-    gate_helpers::BlockCount2,
-    rho_checks::{
-        BlockCountFinalConfig, LaneRotateConversionConfig
-    },
+    rho_checks::{LaneRotateConversionConfig, OverflowCheckConfig},
     tables::{Base13toBase9TableConfig, SpecialChunkTableConfig},
 };
 
 use halo2::{
-    circuit::{Cell, Layouter, Region},
+    circuit::{Cell, Layouter},
     plonk::{Advice, Column, ConstraintSystem, Error},
 };
-use itertools::Itertools;
 use pairing::arithmetic::FieldExt;
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
 pub struct RhoConfig<F> {
     state: [Column<Advice>; 25],
-    state_rotate_convert_configs: [LaneRotateConversionConfig<F>; 25],
-    final_block_count_config: BlockCountFinalConfig<F>,
+    lane_configs: [LaneRotateConversionConfig<F>; 25],
+    overflow_check_config: OverflowCheckConfig<F>,
     base13_to_9_table: Base13toBase9TableConfig<F>,
     special_chunk_table: SpecialChunkTableConfig<F>,
 }
@@ -30,24 +26,31 @@ impl<F: FieldExt> RhoConfig<F> {
         base13_to_9_table: Base13toBase9TableConfig<F>,
         special_chunk_table: SpecialChunkTableConfig<F>,
     ) -> Self {
-        let state_rotate_convert_configs = state.iter().enumerate()
+        let lane_configs: [LaneRotateConversionConfig<F>; 25] = state
+            .iter()
+            .enumerate()
             .map(|(idx, &lane)| {
                 LaneRotateConversionConfig::configure(
                     meta,
                     idx,
                     lane,
-                    base13_to_9_table,
-                    special_chunk_table,
+                    &base13_to_9_table,
+                    &special_chunk_table,
                 )
             })
             .collect::<Vec<_>>()
             .try_into()
             .unwrap();
-        let final_block_count_config = BlockCountFinalConfig::configure(meta);
+        let overflow_detector_cols = lane_configs
+            .iter()
+            .map(|config| config.overflow_detector)
+            .collect();
+        let overflow_check_config =
+            OverflowCheckConfig::configure(meta, overflow_detector_cols);
         Self {
             state,
-            state_rotate_convert_configs,
-            final_block_count_config,
+            lane_configs,
+            overflow_check_config,
             base13_to_9_table,
             special_chunk_table,
         }
@@ -57,53 +60,42 @@ impl<F: FieldExt> RhoConfig<F> {
         layouter: &mut impl Layouter<F>,
         state: [(Cell, F); 25],
     ) -> Result<[(Cell, F); 25], Error> {
-        type R<F> = ((Cell, F), BlockCount2<F>);
-        let lane_and_bcs: Result<Vec<R<F>>, Error> = state
+        type R<F> = ((Cell, F), Vec<(Cell, F)>, Vec<(Cell, F)>);
+        let lane_and_ods: Result<Vec<R<F>>, Error> = state
             .iter()
-            .enumerate()
-            .map(|(idx, &lane)| -> Result<R<F>, Error> {
-                let (lane_next_row, bc) =
-                    self.state_rotate_convert_configs[idx].assign_region(
-                        &mut layouter.namespace(|| format!("arc lane {}", idx)),
-                        lane,
-                    )?;
-                Ok((lane_next_row, bc))
+            .zip(self.lane_configs.iter())
+            .map(|(&lane, lane_config)| -> Result<R<F>, Error> {
+                let (out_lane, step2_od, step3_od) =
+                    lane_config.assign_region(layouter, lane)?;
+                Ok((out_lane, step2_od, step3_od))
             })
             .into_iter()
             .collect();
-        let lane_and_bcs = lane_and_bcs?;
-        let lane_and_bcs: [R<F>; 25] = lane_and_bcs.try_into().unwrap();
+        let lane_and_ods = lane_and_ods?;
+        let lane_and_ods: [R<F>; 25] = lane_and_ods.try_into().unwrap();
+        let next_state = lane_and_ods.clone().map(|(out_lane, _, _)| out_lane);
 
-        let block_counts = lane_and_bcs.map(|(_, bc)| bc);
-        let next_state = lane_and_bcs.map(|(lane_next_row, _)| lane_next_row);
-
-        self.final_block_count_config.assign_region(
+        let step2_od_join = lane_and_ods
+            .iter()
+            .map(|(_, step2_od, _)| step2_od.clone())
+            .flatten()
+            .collect::<Vec<_>>();
+        let step3_od_join = lane_and_ods
+            .iter()
+            .map(|(_, _, step3_od)| step3_od.clone())
+            .flatten()
+            .collect::<Vec<_>>();
+        self.overflow_check_config.assign_region(
             &mut layouter.namespace(|| "Final block count check"),
-            block_counts,
+            step2_od_join,
+            step3_od_join,
         )?;
         Ok(next_state)
     }
 
-    pub fn assign_region(
-        &self,
-        region: &mut Region<'_, F>,
-        offset: usize,
-        next_state: [(Cell, F); 25],
-    ) -> Result<(), Error> {
-        for (idx, next_lane) in next_state.iter().enumerate() {
-            let cell = region.assign_advice(
-                || "lane next row",
-                self.state[idx],
-                offset + 1,
-                || Ok(next_lane.1),
-            )?;
-            region.constrain_equal(cell, next_lane.0)?;
-        }
-        Ok(())
-    }
-
     pub fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
-        self.state_rotate_convert_configs[0].load(layouter)?;
+        self.base13_to_9_table.load(layouter)?;
+        self.special_chunk_table.load(layouter)?;
         Ok(())
     }
 }
@@ -114,6 +106,9 @@ mod tests {
     use crate::arith_helpers::*;
     use crate::common::*;
     use crate::gates::gate_helpers::*;
+    use crate::gates::tables::{
+        Base13toBase9TableConfig, SpecialChunkTableConfig,
+    };
     use crate::keccak_arith::*;
     use halo2::circuit::Layouter;
     use halo2::plonk::{Advice, Column, ConstraintSystem, Error};
@@ -143,24 +138,15 @@ mod tests {
                     .collect::<Vec<_>>()
                     .try_into()
                     .unwrap();
-                let cols: [Column<Advice>; 7] = state[0..7].try_into().unwrap();
-                let adv = RhoAdvices::from(cols);
-                let axiliary = [state[8], state[9]];
 
-                let base13_to_9 = [
-                    meta.lookup_table_column(),
-                    meta.lookup_table_column(),
-                    meta.lookup_table_column(),
-                ];
-                let special =
-                    [meta.lookup_table_column(), meta.lookup_table_column()];
+                let base13_to_9 = Base13toBase9TableConfig::configure(meta);
+                let special_chunk_table =
+                    SpecialChunkTableConfig::configure(meta);
                 RhoConfig::configure(
                     meta,
                     state,
-                    &adv,
-                    axiliary,
                     base13_to_9,
-                    special,
+                    special_chunk_table,
                 )
             }
 
@@ -198,18 +184,6 @@ mod tests {
                 let next_state =
                     config.assign_rotation_checks(&mut layouter, state)?;
                 assert_eq!(next_state.map(|lane| lane.1), self.out_state);
-                layouter.assign_region(
-                    || "assign output state",
-                    |mut region| {
-                        let offset = 1;
-                        config.assign_region(
-                            &mut region,
-                            offset,
-                            next_state,
-                        )?;
-                        Ok(())
-                    },
-                )?;
                 Ok(())
             }
         }
@@ -240,10 +214,10 @@ mod tests {
             in_state,
             out_state,
         };
+        let k = 15;
         #[cfg(feature = "dev-graph")]
         {
             use plotters::prelude::*;
-            let k = 15;
             let root =
                 BitMapBackend::new("rho-test-circuit.png", (16384, 65536))
                     .into_drawing_area();
@@ -254,7 +228,7 @@ mod tests {
                 .unwrap();
         }
         // Test without public inputs
-        let prover = MockProver::<Fp>::run(15, &circuit, vec![]).unwrap();
+        let prover = MockProver::<Fp>::run(k, &circuit, vec![]).unwrap();
 
         assert_eq!(prover.verify(), Ok(()));
     }

--- a/keccak256/src/gates/rho_checks.rs
+++ b/keccak256/src/gates/rho_checks.rs
@@ -197,7 +197,7 @@ impl<F: FieldExt> LaneRotateConversionConfig<F> {
             let acc = meta.query_advice(output_acc, Rotation::cur());
             let acc_next = meta.query_advice(output_acc, Rotation::next());
             // delta_acc === coef * power_of_base
-            let poly = acc_next - acc.clone() - coef * pob;
+            let poly = acc_next - acc - coef * pob;
             vec![
                 ("check for q_normal", q_normal * poly.clone()),
                 ("check for q_special", q_special * poly),
@@ -371,7 +371,7 @@ impl<F: FieldExt> LaneRotateConversionConfig<F> {
                         offset,
                         || Ok(biguint_to_f::<F>(&special.output_acc_pre)),
                     )?;
-                    let lane = {
+                    {
                         let value = biguint_to_f::<F>(&special.output_acc_post);
                         let cell = region.assign_advice(
                             || "Special output acc post",
@@ -380,8 +380,7 @@ impl<F: FieldExt> LaneRotateConversionConfig<F> {
                             || Ok(value),
                         )?;
                         (cell, value)
-                    };
-                    lane
+                    }
                 };
                 Ok((output_lane, step2_od, step3_od))
             },

--- a/keccak256/src/gates/rho_checks.rs
+++ b/keccak256/src/gates/rho_checks.rs
@@ -10,15 +10,15 @@
 //!
 //! We call the a coefficient of the polynomial a chunk.
 //!
-//! The output chunks represent the output bits of the lane in binary, where b0
-//! is the least significant bit and b63 is the most significant bit.
+//! The output chunks represent the output bits of the lane in binary, in little
+//! endian.
 //!
 //! Note that the input lane is special because it's an output from the Theta
 //! step, so it has 65 chunks. It holds that `0 <= a0 + a64 < 13`. We refer a0
 //! to be low value and a64 high value.
 //!
 //! In the Rho step we perform the **rotation** of chunk positions and the
-//! **convertion** from base 13 to base 9.
+//! **conversion** from base 13 to base 9.
 //!
 //! More formally speaking, we have a transform `T`, where `bi = T(aj)` for some
 //! `i`, `j`, and `ai` is not special chunks.
@@ -40,7 +40,7 @@
 //! The goal is to check the conversion from the base 13 input lane to the base
 //! 9 output lane is sound.
 //!
-//! ### The Essential
+//! ### The Normal Slices
 //!
 //! For each lane, we split up the lane in slices of chunks.
 //! - We run down the input accumulator by subtracting each `input_coef *

--- a/keccak256/src/gates/rho_checks.rs
+++ b/keccak256/src/gates/rho_checks.rs
@@ -431,6 +431,7 @@ impl<F: FieldExt> SumConfig<F> {
                 let mut sum = F::zero();
                 let mut offset = 0;
                 for &(cell_from, value) in xs.iter() {
+                    self.q_enable.enable(&mut region, offset)?;
                     let cell_to = region.assign_advice(
                         || "x",
                         self.x,

--- a/keccak256/src/gates/tables.rs
+++ b/keccak256/src/gates/tables.rs
@@ -2,7 +2,7 @@ use crate::arith_helpers::{
     convert_b13_coef, convert_b9_coef, f_from_radix_be, B13, B2, B9,
 };
 use crate::common::LANE_SIZE;
-use crate::gates::rho_helpers::{get_block_count, BASE_NUM_OF_CHUNKS};
+use crate::gates::rho_helpers::{get_overflow_detector, BASE_NUM_OF_CHUNKS};
 use halo2::{
     arithmetic::FieldExt,
     circuit::Layouter,
@@ -23,7 +23,7 @@ const NUM_OF_B9_CHUNKS: usize = 5;
 pub struct Base13toBase9TableConfig<F> {
     pub base13: TableColumn,
     pub base9: TableColumn,
-    pub block_count: TableColumn,
+    pub overflow_detector: TableColumn,
     _marker: PhantomData<F>,
 }
 
@@ -61,12 +61,12 @@ impl<F: FieldExt> Base13toBase9TableConfig<F> {
                         },
                     )?;
                     table.assign_cell(
-                        || "block_count",
-                        self.block_count,
+                        || "overflow_detector",
+                        self.overflow_detector,
                         i,
                         || {
                             Ok(F::from(
-                                get_block_count(
+                                get_overflow_detector(
                                     b13_chunks.clone().try_into().unwrap(),
                                 )
                                 .into(),
@@ -83,7 +83,7 @@ impl<F: FieldExt> Base13toBase9TableConfig<F> {
         Self {
             base13: meta.lookup_table_column(),
             base9: meta.lookup_table_column(),
-            block_count: meta.lookup_table_column(),
+            overflow_detector: meta.lookup_table_column(),
             _marker: PhantomData,
         }
     }

--- a/keccak256/src/gates/tables.rs
+++ b/keccak256/src/gates/tables.rs
@@ -6,8 +6,7 @@ use crate::gates::rho_helpers::{get_block_count, BASE_NUM_OF_CHUNKS};
 use halo2::{
     arithmetic::FieldExt,
     circuit::Layouter,
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector, TableColumn},
-    poly::Rotation,
+    plonk::{ConstraintSystem, Error, TableColumn},
 };
 use std::convert::TryInto;
 use std::marker::PhantomData;

--- a/keccak256/src/gates/tables.rs
+++ b/keccak256/src/gates/tables.rs
@@ -22,9 +22,9 @@ const NUM_OF_B9_CHUNKS: usize = 5;
 
 #[derive(Debug, Clone)]
 pub struct Base13toBase9TableConfig<F> {
-    base13: TableColumn,
-    base9: TableColumn,
-    block_count: TableColumn,
+    pub base13: TableColumn,
+    pub base9: TableColumn,
+    pub block_count: TableColumn,
     _marker: PhantomData<F>,
 }
 
@@ -80,34 +80,13 @@ impl<F: FieldExt> Base13toBase9TableConfig<F> {
         )
     }
 
-    pub(crate) fn configure(
-        meta: &mut ConstraintSystem<F>,
-        q_enable: Selector,
-        base13_coef: Column<Advice>,
-        base9_coef: Column<Advice>,
-        block_count: Column<Advice>,
-        fixed: [TableColumn; 3],
-    ) -> Self {
-        let config = Self {
-            base13: fixed[0],
-            base9: fixed[1],
-            block_count: fixed[2],
+    pub(crate) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        Self {
+            base13: meta.lookup_table_column(),
+            base9: meta.lookup_table_column(),
+            block_count: meta.lookup_table_column(),
             _marker: PhantomData,
-        };
-
-        meta.lookup(|meta| {
-            let q_enable = meta.query_selector(q_enable);
-            let base13_coef = meta.query_advice(base13_coef, Rotation::cur());
-            let base9_coef = meta.query_advice(base9_coef, Rotation::cur());
-            let bc = meta.query_advice(block_count, Rotation::cur());
-
-            vec![
-                (q_enable.clone() * base13_coef, config.base13),
-                (q_enable.clone() * base9_coef, config.base9),
-                (q_enable * bc, config.block_count),
-            ]
-        });
-        config
+        }
     }
 }
 
@@ -116,8 +95,8 @@ impl<F: FieldExt> Base13toBase9TableConfig<F> {
 /// - The last output coef: `convert_b13_coef(high_value + low_value)`
 #[derive(Debug, Clone)]
 pub struct SpecialChunkTableConfig<F> {
-    last_chunk: TableColumn,
-    output_coef: TableColumn,
+    pub last_chunk: TableColumn,
+    pub output_coef: TableColumn,
     _marker: PhantomData<F>,
 }
 
@@ -165,32 +144,12 @@ impl<F: FieldExt> SpecialChunkTableConfig<F> {
         )
     }
 
-    pub(crate) fn configure(
-        meta: &mut ConstraintSystem<F>,
-        q_enable: Selector,
-        last_chunk_advice: Column<Advice>,
-        output_coef_advice: Column<Advice>,
-        cols: [TableColumn; 2],
-    ) -> Self {
-        let config = Self {
-            last_chunk: cols[0],
-            output_coef: cols[1],
+    pub(crate) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        Self {
+            last_chunk: meta.lookup_table_column(),
+            output_coef: meta.lookup_table_column(),
             _marker: PhantomData,
-        };
-        // Lookup for special chunk conversion
-        meta.lookup(|meta| {
-            let q_enable = meta.query_selector(q_enable);
-            let last_chunk_advice =
-                meta.query_advice(last_chunk_advice, Rotation::cur());
-            let output_coef_advice =
-                meta.query_advice(output_coef_advice, Rotation::cur());
-
-            vec![
-                (q_enable.clone() * last_chunk_advice, config.last_chunk),
-                (q_enable * output_coef_advice, config.output_coef),
-            ]
-        });
-        config
+        }
     }
 }
 


### PR DESCRIPTION
### Problem

- Rho gate logic is complicated.
- We have 25 lane configs, each has 16~17 normal chunk configs and a special chunk config.
- Block count is a strange name
- The aggregation of Block count is complicated
  - We do running sum for step2 and step3 accumulation "within" the lane config
  - We do another running sum to sum up step2 and step3 accumulation "across" lanes  (BlockCountAccConfig)
  - We then do the range check in the BlockCountFinalConfig.

### Solution

- We clean up the lane config. A lane config now deals with normal chunks and special chunks together, no more sub-configs. Gate logic is more transparent now.
- Block count is renamed to overflow detector to reflect its true purpose.
- We collect all the overflow detector cells using copy gates. Use only a common running sum config to sum them within and across lanes.