### PR TITLE
fix base conversion

### DIFF
--- a/keccak256/src/gates/tables.rs
+++ b/keccak256/src/gates/tables.rs
@@ -240,8 +240,11 @@ impl<F: FieldExt> BaseInfo<F> {
             v.reverse();
             v
         };
+        // Use rchunks + rev so that the remainder chunks stay at the big-endian
+        // side
         let input_coefs: Vec<F> = input_chunks
-            .chunks(self.num_chunks)
+            .rchunks(self.num_chunks)
+            .rev()
             .map(|chunks| f_from_radix_be(chunks, self.input_base))
             .collect();
         let convert_chunk = match self.input_base {
@@ -257,7 +260,8 @@ impl<F: FieldExt> BaseInfo<F> {
         };
 
         let output_coefs: Vec<F> = input_chunks
-            .chunks(self.num_chunks)
+            .rchunks(self.num_chunks)
+            .rev()
             .map(|chunks| {
                 let converted_chunks: Vec<u8> =
                     chunks.iter().map(|&x| convert_chunk(x)).collect_vec();


### PR DESCRIPTION
### Problem

#306

The input has 64 chunks. The lookup can process n chunks. We split the input chunks into 64/n groups and perform lookups and running sums for them.
The running sum is in big-endian style `accumulation = accumulation*radix**n + coef` to save columns.
This works fine when n is a multiple of 64, say 16.
But for base 9 we lookup n=5 chunks at a time. There would be one group that has 4 chunks.
Since we use big-endian style running sums, the 4 chunks group must be on the big-endian side. The current implementation put the 4 chunks group on the little-endian side.

### Solution

Move the 4 chunks group to the big-endian side.

