### PR TITLE
Feat/prover: add prover command line utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,6 @@ dependencies = [
  "ethers-providers",
  "hex",
  "lazy_static",
- "log",
  "pairing_bn256",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "ethers-providers",
  "hex",
  "lazy_static",
+ "log",
  "pairing_bn256",
  "regex",
  "serde",
@@ -2680,6 +2681,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "prover"
+version = "0.1.0"
+dependencies = [
+ "bus-mapping",
+ "env_logger",
+ "eth-types",
+ "ethers-providers",
+ "halo2",
+ "log",
+ "pairing_bn256",
+ "rand",
+ "serde",
+ "serde_json",
+ "tokio",
+ "zkevm-circuits",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,9 +3133,9 @@ checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
-version = "1.0.131"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -3143,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.131"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3154,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -3460,9 +3479,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
     "circuit-benchmarks",
     "eth-types",
     "external-tracer",
-    "mock"
+    "mock",
+    "prover"
 ]
 
 [patch.crates-io]

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -204,6 +204,13 @@ impl Block {
         history_hashes: Vec<Word>,
         eth_block: &eth_types::Block<TX>,
     ) -> Result<Self, Error> {
+        if eth_block.base_fee_per_gas.is_none() {
+            // FIXME: resolve this once we have proper EIP-1559 support
+            log::warn!(
+                "This does not look like a EIP-1559 block - base_fee_per_gas defaults to zero"
+            );
+        }
+
         Ok(Self {
             chain_id,
             history_hashes,
@@ -217,8 +224,7 @@ impl Block {
             timestamp: eth_block.timestamp,
             difficulty: eth_block.difficulty,
             base_fee: eth_block
-                .base_fee_per_gas
-                .ok_or(Error::EthTypeError(eth_types::Error::IncompleteBlock))?,
+                .base_fee_per_gas.unwrap_or_default(),
             container: OperationContainer::new(),
             txs: Vec::new(),
             code: HashMap::new(),

--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -223,8 +223,7 @@ impl Block {
                 .into(),
             timestamp: eth_block.timestamp,
             difficulty: eth_block.difficulty,
-            base_fee: eth_block
-                .base_fee_per_gas.unwrap_or_default(),
+            base_fee: eth_block.base_fee_per_gas.unwrap_or_default(),
             container: OperationContainer::new(),
             txs: Vec::new(),
             code: HashMap::new(),

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "prover"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bus-mapping = { path = "../bus-mapping"}
+env_logger = "0.9.0"
+ethers-providers = "0.6"
+eth-types = { path = "../eth-types" }
+halo2 = { git = "https://github.com/appliedzkp/halo2.git", rev = "b78c39cacc1c79d287032f1b5f94beb661b3fb42" }
+log = "0.4.14"
+pairing = { git = 'https://github.com/appliedzkp/pairing', package = "pairing_bn256" }
+rand = "0.8.4"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.78"
+tokio = { version = "1.16.1", features = ["macros", "rt-multi-thread"] }
+zkevm-circuits = { path = "../zkevm-circuits", features = ["test"] }

--- a/prover/src/bin/gen_params.rs
+++ b/prover/src/bin/gen_params.rs
@@ -8,12 +8,12 @@ use std::io::Write;
 /// Can be invoked with: gen_params <degree> <path to file>
 fn main() {
     let mut args = env::args();
+    let params_path: String = args.next_back().expect("path to file");
     let degree: u32 = args
-        .nth(1)
+        .next_back()
         .expect("degree")
         .parse::<u32>()
         .expect("valid number");
-    let params_path: String = args.nth(0).expect("path to file");
     let mut file = File::create(&params_path).expect("Failed to create file");
 
     println!("Generating params with degree: {}", degree);

--- a/prover/src/bin/gen_params.rs
+++ b/prover/src/bin/gen_params.rs
@@ -1,0 +1,28 @@
+use halo2::poly::commitment::Setup;
+use pairing::bn256::Bn256;
+use std::env;
+use std::fs::File;
+use std::io::Write;
+
+/// This utility supports parameter generation.
+/// Can be invoked with: gen_params <degree> <path to file>
+fn main() {
+    let mut args = env::args();
+    let degree: u32 = args
+        .nth(1)
+        .expect("degree")
+        .parse::<u32>()
+        .expect("valid number");
+    let params_path: String = args.nth(0).expect("path to file");
+    let mut file = File::create(&params_path).expect("Failed to create file");
+
+    println!("Generating params with degree: {}", degree);
+
+    let params = Setup::<Bn256>::new(degree, rand::rngs::OsRng::default());
+    let mut buf = Vec::new();
+    params.write(&mut buf).expect("Failed to write params");
+    file.write_all(&buf[..])
+        .expect("Failed to write params to file");
+
+    println!("Written to {}", params_path);
+}

--- a/prover/src/bin/prover_cmd.rs
+++ b/prover/src/bin/prover_cmd.rs
@@ -82,11 +82,6 @@ async fn main() {
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
         create_proof(&params, &pk, &[circuit], &[], &mut transcript).expect("evm proof");
         evm_proof = transcript.finalize();
-
-        // verify
-        // let params = Setup::<Bn256>::verifier_params(&params, 0).unwrap();
-        // let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&evm_proof[..]);
-        // verify_proof(&params, pk.get_vk(), &[], &mut transcript).unwrap();
     }
 
     {
@@ -127,11 +122,6 @@ async fn main() {
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
         create_proof(&params, &pk, &[circuit], &[], &mut transcript).expect("state proof");
         state_proof = transcript.finalize();
-
-        // verify
-        // let params = Setup::<Bn256>::verifier_params(&params, 0).unwrap();
-        // let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&state_proof[..]);
-        // verify_proof(&params, pk.get_vk(), &[], &mut transcript).unwrap();
     }
 
     serde_json::to_writer(

--- a/prover/src/bin/prover_cmd.rs
+++ b/prover/src/bin/prover_cmd.rs
@@ -68,16 +68,7 @@ async fn main() {
     let state_proof;
     {
         // generate evm_circuit proof
-        //
-        // TODO: why blocks.txs()[0]?
-        // https://github.com/scroll-tech/zkevm-circuits/issues/68
-        let code_hash = builder.block.txs()[0].calls()[0].code_hash;
-        let bytecode = builder
-            .code_db
-            .0
-            .get(&code_hash)
-            .expect("code_hash not found");
-        let block = block_convert(Fr::rand(), bytecode, &builder.block);
+        let block = block_convert(&builder.block, &builder.code_db);
         let circuit = TestCircuit::<Fr>::new(block, FixedTableTag::iterator().collect());
 
         // TODO: can this be pre-generated to a file?

--- a/prover/src/bin/prover_cmd.rs
+++ b/prover/src/bin/prover_cmd.rs
@@ -49,7 +49,7 @@ async fn main() {
         .expect("Cannot parse PARAMS_PATH env var");
 
     // load polynomial commitment parameters
-    let params_fs = File::open(&params_path).expect("couldn't load sha256_params");
+    let params_fs = File::open(&params_path).expect("couldn't open params");
     let params: Params<G1Affine> =
         Params::read::<_>(&mut BufReader::new(params_fs)).expect("Failed to read params");
 
@@ -65,6 +65,7 @@ async fn main() {
         // generate evm_circuit proof
         //
         // TODO: why blocks.txs()[0]?
+        // https://github.com/scroll-tech/zkevm-circuits/issues/68
         let code_hash = builder.block.txs()[0].calls()[0].code_hash;
         let bytecode = builder
             .code_db
@@ -75,6 +76,9 @@ async fn main() {
         let circuit = TestCircuit::<Fr>::new(block, FixedTableTag::iterator().collect());
 
         // TODO: can this be pre-generated to a file?
+        // related
+        // https://github.com/zcash/halo2/issues/443
+        // https://github.com/zcash/halo2/issues/449
         let vk = keygen_vk(&params, &circuit).unwrap();
         let pk = keygen_pk(&params, vk, &circuit).unwrap();
 
@@ -114,7 +118,7 @@ async fn main() {
             storage_ops,
         };
 
-        // TODO: can this be pre-generated to a file?
+        // TODO: same quest like in the first scope
         let vk = keygen_vk(&params, &circuit).unwrap();
         let pk = keygen_pk(&params, vk, &circuit).unwrap();
 

--- a/prover/src/bin/prover_cmd.rs
+++ b/prover/src/bin/prover_cmd.rs
@@ -1,0 +1,145 @@
+use bus_mapping::circuit_input_builder::BuilderClient;
+use bus_mapping::rpc::GethClient;
+use env_logger::Env;
+use ethers_providers::Http;
+use halo2::{
+    arithmetic::BaseExt,
+    plonk::*,
+    poly::commitment::Params,
+    transcript::{Blake2bWrite, Challenge255},
+};
+use pairing::bn256::{Fr, G1Affine};
+use std::env::var;
+use std::fs::File;
+use std::io::BufReader;
+use std::str::FromStr;
+use zkevm_circuits::evm_circuit::{
+    table::FixedTableTag, test::TestCircuit, witness::block_convert,
+};
+use zkevm_circuits::state_circuit::StateCircuit;
+
+#[derive(serde::Serialize)]
+pub struct Proofs {
+    state_proof: eth_types::Bytes,
+    evm_proof: eth_types::Bytes,
+}
+
+/// This command generates and prints the proofs to stdout.
+/// Required environment variables:
+/// - BLOCK_NUM - the block number to generate the proof for
+/// - RPC_URL - a geth http rpc that supports the debug namespace
+/// - PARAMS_PATH - a path to a file generated with the gen_params tool
+// TODO: move the proof generation into a module once we implement a rpc daemon for generating
+// proofs.
+#[tokio::main]
+async fn main() {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    let block_num: u64 = var("BLOCK_NUM")
+        .unwrap()
+        .parse()
+        .expect("Cannot parse BLOCK_NUM env var");
+    let rpc_url: String = var("RPC_URL")
+        .unwrap()
+        .parse()
+        .expect("Cannot parse RPC_URL env var");
+    let params_path: String = var("PARAMS_PATH")
+        .unwrap()
+        .parse()
+        .expect("Cannot parse PARAMS_PATH env var");
+
+    // load polynomial commitment parameters
+    let params_fs = File::open(&params_path).expect("couldn't load sha256_params");
+    let params: Params<G1Affine> =
+        Params::read::<_>(&mut BufReader::new(params_fs)).expect("Failed to read params");
+
+    // request & build the inputs for the circuits
+    let geth_client = GethClient::new(Http::from_str(&rpc_url).unwrap());
+    let builder = BuilderClient::new(geth_client).await.unwrap();
+    let builder = builder.gen_inputs(block_num).await.unwrap();
+
+    // TODO: only {evm,state}_proof are implemented right now
+    let evm_proof;
+    let state_proof;
+    {
+        // generate evm_circuit proof
+        //
+        // TODO: why blocks.txs()[0]?
+        let code_hash = builder.block.txs()[0].calls()[0].code_hash;
+        let bytecode = builder
+            .code_db
+            .0
+            .get(&code_hash)
+            .expect("code_hash not found");
+        let block = block_convert(Fr::rand(), bytecode, &builder.block);
+        let circuit = TestCircuit::<Fr>::new(block, FixedTableTag::iterator().collect());
+
+        // TODO: can this be pre-generated to a file?
+        let vk = keygen_vk(&params, &circuit).unwrap();
+        let pk = keygen_pk(&params, vk, &circuit).unwrap();
+
+        // create a proof
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+        create_proof(&params, &pk, &[circuit], &[], &mut transcript).expect("evm proof");
+        evm_proof = transcript.finalize();
+
+        // verify
+        // let params = Setup::<Bn256>::verifier_params(&params, 0).unwrap();
+        // let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&evm_proof[..]);
+        // verify_proof(&params, pk.get_vk(), &[], &mut transcript).unwrap();
+    }
+
+    {
+        // generate state_circuit proof
+        //
+        // TODO: this should be configurable
+        const MEMORY_ADDRESS_MAX: usize = 2000;
+        const STACK_ADDRESS_MAX: usize = 1300;
+        const MEMORY_ROWS_MAX: usize = 16384;
+        const STACK_ROWS_MAX: usize = 16384;
+        const STORAGE_ROWS_MAX: usize = 16384;
+        const GLOBAL_COUNTER_MAX: usize = MEMORY_ROWS_MAX + STACK_ROWS_MAX + STORAGE_ROWS_MAX;
+
+        let stack_ops = builder.block.container.sorted_stack();
+        let memory_ops = builder.block.container.sorted_memory();
+        let storage_ops = builder.block.container.sorted_storage();
+        let circuit = StateCircuit::<
+            Fr,
+            true,
+            GLOBAL_COUNTER_MAX,
+            MEMORY_ROWS_MAX,
+            MEMORY_ADDRESS_MAX,
+            STACK_ROWS_MAX,
+            STACK_ADDRESS_MAX,
+            STORAGE_ROWS_MAX,
+        > {
+            randomness: Fr::rand(),
+            memory_ops,
+            stack_ops,
+            storage_ops,
+        };
+
+        // TODO: can this be pre-generated to a file?
+        let vk = keygen_vk(&params, &circuit).unwrap();
+        let pk = keygen_pk(&params, vk, &circuit).unwrap();
+
+        // create a proof
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+        create_proof(&params, &pk, &[circuit], &[], &mut transcript).expect("state proof");
+        state_proof = transcript.finalize();
+
+        // verify
+        // let params = Setup::<Bn256>::verifier_params(&params, 0).unwrap();
+        // let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&state_proof[..]);
+        // verify_proof(&params, pk.get_vk(), &[], &mut transcript).unwrap();
+    }
+
+    serde_json::to_writer(
+        std::io::stdout(),
+        &Proofs {
+            evm_proof: evm_proof.into(),
+            state_proof: state_proof.into(),
+        },
+    )
+    .expect("serialize and write");
+}

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -30,3 +30,7 @@ mock = { path = "../mock" }
 [[bench]]
 name = "binary_value"
 harness = false
+
+[features]
+default = []
+test = []

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -98,8 +98,8 @@ impl<F: FieldExt> EvmCircuit<F> {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod test {
+#[cfg(feature = "test")]
+pub mod test {
     use crate::{
         evm_circuit::{
             param::STEP_HEIGHT,
@@ -148,7 +148,7 @@ pub(crate) mod test {
     }
 
     #[derive(Clone)]
-    pub(crate) struct TestCircuitConfig<F> {
+    pub struct TestCircuitConfig<F> {
         tx_table: [Column<Advice>; 4],
         rw_table: [Column<Advice>; 10],
         bytecode_table: [Column<Advice>; 4],
@@ -310,7 +310,7 @@ pub(crate) mod test {
     }
 
     #[derive(Default)]
-    pub(crate) struct TestCircuit<F> {
+    pub struct TestCircuit<F> {
         block: Block<F>,
         fixed_table_tags: Vec<FixedTableTag>,
     }
@@ -386,7 +386,7 @@ pub(crate) mod test {
         }
     }
 
-    pub(crate) fn run_test_circuit<F: FieldExt>(
+    pub fn run_test_circuit<F: FieldExt>(
         block: Block<F>,
         fixed_table_tags: Vec<FixedTableTag>,
     ) -> Result<(), Vec<VerifyFailure>> {
@@ -420,7 +420,7 @@ pub(crate) mod test {
         prover.verify()
     }
 
-    pub(crate) fn run_test_circuit_incomplete_fixed_table<F: FieldExt>(
+    pub fn run_test_circuit_incomplete_fixed_table<F: FieldExt>(
         block: Block<F>,
     ) -> Result<(), Vec<VerifyFailure>> {
         run_test_circuit(
@@ -436,7 +436,7 @@ pub(crate) mod test {
         )
     }
 
-    pub(crate) fn run_test_circuit_complete_fixed_table<F: FieldExt>(
+    pub fn run_test_circuit_complete_fixed_table<F: FieldExt>(
         block: Block<F>,
     ) -> Result<(), Vec<VerifyFailure>> {
         run_test_circuit(block, FixedTableTag::iterator().collect())


### PR DESCRIPTION
The first version includes two commands:
###### gen_params
For generating circuit commitment parameters
###### prover_cmd
that generates circuit proofs and prints them as json to stdout.

Another rpc daemon is needed for a later stage so that it becomes possible to defer generating/requesting proofs over http.