### PR TITLE
[Keccak] Fix the verifier path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.png
 .DS_Store
+.vscode/

--- a/keccak256/src/gates/rho_checks.rs
+++ b/keccak256/src/gates/rho_checks.rs
@@ -255,7 +255,6 @@ impl<F: Field> LaneRotateConversionConfig<F> {
         ),
         Error,
     > {
-        // TODO: Handle this better once AssignedCell has the API to do so.
         let (conversions, special) = RhoLane::new(
             f_to_biguint(*lane_base_13.value().unwrap_or(&F::zero())),
             self.rotation,
@@ -433,7 +432,6 @@ impl<F: Field> SumConfig<F> {
                     self.q_enable.enable(&mut region, offset)?;
                     xs_item.copy_advice(|| "x", &mut region, self.x, offset)?;
                     region.assign_advice(|| "sum", self.sum, offset, || Ok(sum))?;
-                    // TODO: Handle this better once AssignedCell has the API to do so
                     sum += xs_item.value().unwrap_or(&F::zero());
                     offset += 1;
                 }


### PR DESCRIPTION
Fix #344

At this point, I'm actually not sure at this point if using Option improves the situation.
The None adds another level of complexity. 

For example, in the base conversion, the prover should compute the witness for input and the verifier should place 16 cells. There are two approaches:
1. The verifier runs `compute_witness` like prover but with input value 0. Example: rho_check
2. We could modify the prover's`compute_witness` to handle all Option<&F> instead of F. The verifier runs `compute_witness` too. Example: Base conversion's compute_witness.

I was expecting approach 2 to make the verifier's code clearer, but approach one is much simpler.
WDYT @CPerezz and @therealyingtong 