### PR TITLE
Fix EVM Circuit benchmark

### DIFF
--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -115,7 +115,7 @@ mod evm_circ_benches {
             &verifier_params,
             pk.get_vk(),
             strategy,
-            &[],
+            &[&[]],
             &mut verifier_transcript,
         )
         .unwrap();


### PR DESCRIPTION
As @han0110 said. Before #341 &[&[]] is passed
(as single proof instance with no instnace columns values).
Now we were passing &[] only for instances.
Which basically means that num_proofs=0.

This was causing the errors during the benchmarks triggered in #352.

Resolves: #363 

Co-authored-by: @han0110