### PR TITLE
CI: Skip dependencies for doc checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --all --document-private-items
+          args: --no-deps --all --document-private-items
 
   fmt:
     if: github.event.pull_request.draft == false

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clippy: ## Run clippy checks over all workspace members
 	@cargo clippy --all-features --all-targets -- -D clippy::all
 
 doc: ## Generate and tests docs including private items
-	@cargo doc --all --document-private-items
+	@cargo doc --no-deps --all --document-private-items
 
 fmt: ## Check whether the code is formated correctly
 	@cargo check --all-features


### PR DESCRIPTION
Resolve https://github.com/appliedzkp/zkevm-circuits/issues/377
Resolve https://github.com/appliedzkp/zkevm-circuits/issues/378

With this change we just skip building the docs for our dependencies in the CI (which is not meaningful to us), and this should resolve the race that makes this test sometimes fail when building the `bitvec` docs for different versions in the same folder.