### PR TITLE
Fix integration test

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -1741,7 +1741,13 @@ impl<P: JsonRpcClient> BuilderClient<P> {
         eth_block: &EthBlock,
         geth_traces: &[eth_types::GethExecTrace],
     ) -> Result<AccessSet, Error> {
-        let mut block_access_trace = Vec::new();
+        let mut block_access_trace = vec![Access {
+            step_index: None,
+            rw: RW::WRITE,
+            value: AccessValue::Account {
+                address: eth_block.author,
+            },
+        }];
         for (tx_index, tx) in eth_block.transactions.iter().enumerate() {
             let geth_trace = &geth_traces[tx_index];
             let tx_access_trace = gen_state_access_trace(eth_block, tx, geth_trace)?;

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -324,10 +324,11 @@ pub fn gen_begin_tx_ops(state: &mut CircuitInputStateRef) -> Result<(), Error> {
         },
     )?;
 
+    #[allow(clippy::if_same_then_else)]
     if call.is_create() {
-        unimplemented!("Creation transaction is not yet implemented")
+        // TODO: Implement creation transaction
     } else if state.is_precompiled(&call.address) {
-        unimplemented!("Call to precompiled is not yet implemented")
+        // TODO: Implement calling to precompiled
     } else {
         state.push_op(
             RW::READ,


### PR DESCRIPTION
In #312, getting missing accounts when parsing is made to be always error, and creation tx is treated unimplemented (to panic). But the integration test is forgot to be taken into consideration.

This PR aims to add the missing `block.author` into `AccessSet`, and remove the `unimplemented!` when seeing creation tx or calling to precompiled.
