### PR TITLE
Add NUMBER module to opcodes and update testing infra

### DIFF
--- a/bus-mapping/src/circuit_input_builder.rs
+++ b/bus-mapping/src/circuit_input_builder.rs
@@ -287,7 +287,8 @@ pub struct Block {
     pub base_fee: Word,
     /// Container of operations done in this block.
     pub container: OperationContainer,
-    txs: Vec<Transaction>,
+    /// Transactions contained in the block
+    pub txs: Vec<Transaction>,
     code: HashMap<Hash, Vec<u8>>,
 }
 
@@ -594,7 +595,7 @@ impl TransactionContext {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Result of the parsing of an Ethereum Transaction.
 pub struct Transaction {
     /// Nonce

--- a/bus-mapping/src/evm/opcodes.rs
+++ b/bus-mapping/src/evm/opcodes.rs
@@ -23,6 +23,7 @@ mod dup;
 mod extcodehash;
 mod mload;
 mod mstore;
+mod number;
 mod selfbalance;
 mod sload;
 mod stackonlyop;

--- a/bus-mapping/src/evm/opcodes/number.rs
+++ b/bus-mapping/src/evm/opcodes/number.rs
@@ -1,9 +1,10 @@
 #[cfg(test)]
 mod number_tests {
     use crate::{
-        circuit_input_builder::{ExecStep, TransactionContext},
+        circuit_input_builder::ExecState,
+        evm::OpcodeId,
         mock::BlockData,
-        operation::RW,
+        operation::{StackOp, RW},
         Error,
     };
     use eth_types::{bytecode, evm_types::StackAddress, geth_types::GethData};
@@ -17,13 +18,13 @@ mod number_tests {
             NUMBER
             STOP
         };
-
+        let block_number = 0xcafeu64;
         // Get the execution steps from the external tracer
         let block: GethData = TestContext::<2, 1>::new(
             None,
             account_0_code_account_1_no_code(code),
             tx_from_1_to_0,
-            |block, _tx| block.number(0xcafeu64),
+            |block, _tx| block.number(block_number),
         )
         .unwrap()
         .into();
@@ -33,46 +34,21 @@ mod number_tests {
             .handle_block(&block.eth_block, &block.geth_traces)
             .unwrap();
 
-        let mut tx = builder.block.txs()[0].clone();
-
-        let mut tx_ctx = TransactionContext::new(
-            &block.eth_block.transactions[0],
-            &block.geth_traces[0],
-            true,
-        )
-        .unwrap();
-
-        // Generate step corresponding to NUMBER
-        let mut step = ExecStep::new(
-            &block.geth_traces[0].struct_logs[0],
-            0,
-            builder.block_ctx.rwc,
-            0,
-        );
-        let mut state_ref = builder.state_ref(&mut tx, &mut tx_ctx);
-
-        // Add the last Stack write
-        let number = block.eth_block.number.unwrap().as_u64();
-        state_ref
-            .push_stack_op(
-                &mut step,
-                RW::WRITE,
-                StackAddress::from(1024 - 1),
-                eth_types::U256::from(number),
-            )
+        let step = builder.block.txs()[0]
+            .steps()
+            .iter()
+            .find(|step| step.exec_state == ExecState::Op(OpcodeId::NUMBER))
             .unwrap();
 
-        tx.steps_mut().push(step);
-        builder.block.txs_mut().push(tx);
+        let op_number = &builder.block.container.stack[step.bus_mapping_instance[0].as_usize()];
 
-        // Compare first step bus mapping instance
         assert_eq!(
-            builder.block.txs()[0].steps()[0].bus_mapping_instance,
-            builder.block.txs()[0].steps()[0].bus_mapping_instance,
+            (op_number.rw(), op_number.op()),
+            (
+                RW::WRITE,
+                &StackOp::new(1, StackAddress(1023usize), block_number.into())
+            )
         );
-
-        // Compare containers
-        assert_eq!(builder.block.container, builder.block.container);
 
         Ok(())
     }

--- a/bus-mapping/src/evm/opcodes/number.rs
+++ b/bus-mapping/src/evm/opcodes/number.rs
@@ -2,12 +2,12 @@
 mod number_tests {
     use crate::{
         circuit_input_builder::{ExecStep, TransactionContext},
+        mock::BlockData,
         operation::RW,
         Error,
     };
-    use eth_types::{bytecode, evm_types::StackAddress};
-    use mock::new_single_tx_trace_code_at_start;
-    use mock::TestContext;
+    use eth_types::{bytecode, evm_types::StackAddress, geth_types::GethData};
+    use mock::test_ctx::{helpers::*, TestContext};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -19,47 +19,60 @@ mod number_tests {
         };
 
         // Get the execution steps from the external tracer
-        let block =
-            TestContext::new_from_geth_data(new_single_tx_trace_code_at_start(&code).unwrap());
+        let block: GethData = TestContext::<2, 1>::new(
+            None,
+            account_0_code_account_1_no_code(code),
+            tx_from_1_to_0,
+            |block, _tx| block.number(0xcafeu64),
+        )
+        .unwrap()
+        .into();
 
-        let mut builder = block.new_circuit_input_builder();
-        builder.handle_tx(&block.eth_tx, &block.geth_trace).unwrap();
-
-        let mut test_builder = block.new_circuit_input_builder();
-        let mut tx = test_builder
-            .new_tx(&block.eth_tx, !block.geth_trace.failed)
+        let mut builder = BlockData::new_from_geth_data(block.clone()).new_circuit_input_builder();
+        builder
+            .handle_block(&block.eth_block, &block.geth_traces)
             .unwrap();
-        let mut tx_ctx = TransactionContext::new(&block.eth_tx, &block.geth_trace).unwrap();
+
+        let mut tx = builder.block.txs()[0].clone();
+
+        let mut tx_ctx = TransactionContext::new(
+            &block.eth_block.transactions[0],
+            &block.geth_traces[0],
+            true,
+        )
+        .unwrap();
 
         // Generate step corresponding to NUMBER
         let mut step = ExecStep::new(
-            &block.geth_trace.struct_logs[0],
+            &block.geth_traces[0].struct_logs[0],
             0,
-            test_builder.block_ctx.rwc,
+            builder.block_ctx.rwc,
             0,
         );
-        let mut state_ref = test_builder.state_ref(&mut tx, &mut tx_ctx);
+        let mut state_ref = builder.state_ref(&mut tx, &mut tx_ctx);
 
         // Add the last Stack write
         let number = block.eth_block.number.unwrap().as_u64();
-        state_ref.push_stack_op(
-            &mut step,
-            RW::WRITE,
-            StackAddress::from(1024 - 1),
-            eth_types::U256::from(number),
-        );
+        state_ref
+            .push_stack_op(
+                &mut step,
+                RW::WRITE,
+                StackAddress::from(1024 - 1),
+                eth_types::U256::from(number),
+            )
+            .unwrap();
 
         tx.steps_mut().push(step);
-        test_builder.block.txs_mut().push(tx);
+        builder.block.txs_mut().push(tx);
 
         // Compare first step bus mapping instance
         assert_eq!(
             builder.block.txs()[0].steps()[0].bus_mapping_instance,
-            test_builder.block.txs()[0].steps()[0].bus_mapping_instance,
+            builder.block.txs()[0].steps()[0].bus_mapping_instance,
         );
 
         // Compare containers
-        assert_eq!(builder.block.container, test_builder.block.container);
+        assert_eq!(builder.block.container, builder.block.container);
 
         Ok(())
     }


### PR DESCRIPTION
As mentioned in #410, NUMBER opcode was missing in the opcodes.rs file
where all of the modules containing tests/opcode impls are listed.
This PR adds it and also updates the tests to the new `mock` API.

Resolves: #410