### PR TITLE
Variable step height

### DIFF
--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -44,7 +44,7 @@ impl<F: Field> Circuit<F> for TestCircuit<F> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        config.assign_block(&mut layouter, &self.block)?;
+        config.assign_block(&mut layouter, &self.block, false)?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,7 +1,7 @@
 // Step dimension
 pub(crate) const STEP_WIDTH: usize = 32;
 /// Step height
-pub const STEP_HEIGHT: usize = 16;
+pub const MAX_STEP_HEIGHT: usize = 16;
 pub(crate) const N_CELLS_STEP_STATE: usize = 10;
 
 /// Maximum number of bytes that an integer can fit in field without wrapping


### PR DESCRIPTION
Step 1/3 of experimental optimizations done here: https://github.com/Brechtpd/zkevm-circuits/pull/2.

This on its own does not make the circuit on itself faster to prove, just allows more instructions to be included in the same circuit. So instead of each execution state taking up `STEP_HEIGHT` rows, they now take up only as many rows as needed. This will get even more important for subsequent optimizations.
```
ADD: 9 rows
MUL: 9 rows
BITWISE: 9 rows
BeginTx: 13 rows
BYTE: 9 rows
CALLDATACOPY: 7 rows
CALLDATALOAD: 10 rows
CALLDATASIZE: 6 rows
CALLER: 6 rows
CALLVALUE: 6 rows
CMP: 9 rows
DUP: 6 rows
EndBlock: 4 rows
EndTx: 15 rows
ErrorOutOfGasStaticMemoryExpansion: 8 rows
JUMP: 6 rows
JUMPDEST: 6 rows
JUMPI: 6 rows
GAS: 6 rows
MEMORY: 8 rows
COPYTOMEMORY: 14 rows
PC: 6 rows
POP: 6 rows
PUSH: 7 rows
SELFBALANCE: 6 rows
SCMP: 9 rows
SIGNEXTEND: 10 rows
STOP: 5 rows
SWAP: 6 rows
MSIZE: 6 rows
COINBASE: 6 rows
TIMESTAMP: 6 rows
NUMBER: 6 rows
SLOAD: 6 rows
SSTORE: 6 rows
EXTCODEHASH: 6 rows
ISZERO: 6 rows
```

How to set `q_step_last` still left as a TODO as it already was, but with a variable step height that maybe gets a bit more complicated, though I believe not too hard.