### PR TITLE
Degree reduction

### DIFF
--- a/.github/proverCiScripts/execBench.sh
+++ b/.github/proverCiScripts/execBench.sh
@@ -33,4 +33,4 @@ cd $target_dir;
 logfile=$_date--${circuit}_bench-$k.proverlog
 
 export PATH=$PATH:/usr/local/go/bin
-DEGREE=$k ~/.cargo/bin/cargo test --profile bench bench_${run_suffix} -p circuit-benchmarks --features benches  -- --nocapture > "$target_dir/$logfile" 2>&1
+RUST_MIN_STACK=4194304 DEGREE=$k ~/.cargo/bin/cargo test --profile bench bench_${run_suffix} -p circuit-benchmarks --features benches  -- --nocapture > "$target_dir/$logfile" 2>&1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ members = [
     "prover"
 ]
 
+[patch."https://github.com/appliedzkp/halo2.git"]
+halo2_proofs = { git = "https://github.com/Brechtpd/halo2/", branch = "lazy-eval" }
+
 [patch.crates-io]
 halo2_proofs = { git = "https://github.com/appliedzkp/halo2.git", tag = "v2022_03_06" }
 # This fork makes bitvec 0.20.x work with funty 1.1 and funty 1.2.  Without

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ test_benches: ## Compiles the benchmarks
 
 test-all: fmt doc clippy test_benches test ## Run all the CI checks locally (in your actual toolchain) 
 
-evm_bench: ## Run Evm Circuit benchmarks 
-	@cargo test --profile bench bench_evm_circuit_prover -p circuit-benchmarks --features benches  -- --nocapture
+evm_bench: ## Run Evm Circuit benchmarks
+	@RUST_MIN_STACK=4194304 cargo test --profile bench bench_evm_circuit_prover -p circuit-benchmarks --features benches  -- --nocapture
 
 state_bench: ## Run State Circuit benchmarks
 	@cargo test --profile bench bench_state_circuit_prover -p circuit-benchmarks --features benches  -- --nocapture

--- a/circuit-benchmarks/src/evm_circuit.rs
+++ b/circuit-benchmarks/src/evm_circuit.rs
@@ -44,7 +44,7 @@ impl<F: Field> Circuit<F> for TestCircuit<F> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        config.assign_block(&mut layouter, &self.block)?;
+        config.assign_block(&mut layouter, &self.block, false)?;
         Ok(())
     }
 }

--- a/zkevm-circuits/src/evm_circuit/execution.rs
+++ b/zkevm-circuits/src/evm_circuit/execution.rs
@@ -1,3 +1,4 @@
+use super::util::{CachedRegion, StoredExpression};
 use crate::{
     evm_circuit::{
         param::{MAX_STEP_HEIGHT, STEP_WIDTH},
@@ -16,7 +17,6 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use std::{collections::HashMap, convert::TryInto, iter};
-use super::util::{CachedRegion, StoredExpression};
 
 mod add;
 mod begin_tx;

--- a/zkevm-circuits/src/evm_circuit/execution/add.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/add.rs
@@ -6,7 +6,7 @@ use crate::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             math_gadget::{AddWordsGadget, PairSelectGadget},
-            select,
+            select, CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -14,7 +14,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 // AddGadget verifies ADD and SUB at the same time by an extra swap flag,
 // when it's ADD, we annotate stack as [a, b, ...] and [c, ...],
@@ -73,7 +73,7 @@ impl<F: Field> ExecutionGadget<F> for AddGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/begin_tx.rs
@@ -11,7 +11,7 @@ use crate::{
                 Transition::{Delta, To},
             },
             math_gadget::{MulWordByU64Gadget, RangeCheckGadget},
-            select, Cell, RandomLinearCombination, Word,
+            select, CachedRegion, Cell, RandomLinearCombination, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -20,7 +20,7 @@ use crate::{
 use eth_types::evm_types::GasCost;
 use eth_types::Field;
 use eth_types::{ToLittleEndian, ToScalar};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BeginTxGadget<F> {
@@ -217,7 +217,7 @@ impl<F: Field> ExecutionGadget<F> for BeginTxGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         tx: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/bitwise.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/bitwise.rs
@@ -6,7 +6,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            Word,
+            CachedRegion, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -15,7 +15,7 @@ use crate::{
 use eth_types::evm_types::OpcodeId;
 use eth_types::Field;
 use eth_types::ToLittleEndian;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BitwiseGadget<F> {
@@ -80,7 +80,7 @@ impl<F: Field> ExecutionGadget<F> for BitwiseGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/byte.rs
@@ -6,7 +6,7 @@ use crate::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             math_gadget::{IsEqualGadget, IsZeroGadget},
-            sum, Word,
+            sum, CachedRegion, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -16,7 +16,7 @@ use array_init::array_init;
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
 use eth_types::ToLittleEndian;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ByteGadget<F> {
@@ -92,7 +92,7 @@ impl<F: Field> ExecutionGadget<F> for ByteGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatacopy.rs
@@ -12,7 +12,7 @@ use crate::{
             },
             from_bytes,
             memory_gadget::{MemoryAddressGadget, MemoryCopierGasGadget, MemoryExpansionGadget},
-            Cell, MemoryAddress,
+            CachedRegion, Cell, MemoryAddress,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -21,7 +21,8 @@ use crate::{
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
 use eth_types::ToLittleEndian;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -168,7 +169,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataCopyGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         tx: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldataload.rs
@@ -2,10 +2,7 @@ use std::convert::TryInto;
 
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{
-    circuit::Region,
-    plonk::{Error, Expression},
-};
+use halo2_proofs::plonk::{Error, Expression};
 
 use crate::{
     evm_circuit::{
@@ -16,7 +13,7 @@ use crate::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             memory_gadget::BufferReaderGadget,
-            Cell, MemoryAddress, RandomLinearCombination,
+            CachedRegion, Cell, MemoryAddress, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -174,7 +171,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataLoadGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         tx: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/calldatasize.rs
@@ -7,7 +7,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -15,7 +15,8 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -62,7 +63,7 @@ impl<F: Field> ExecutionGadget<F> for CallDataSizeGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _tx: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/caller.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/caller.rs
@@ -7,7 +7,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -15,7 +15,8 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -63,7 +64,7 @@ impl<F: Field> ExecutionGadget<F> for CallerGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/callvalue.rs
@@ -6,7 +6,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            Cell, Word,
+            CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -14,7 +14,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct CallValueGadget<F> {
@@ -62,7 +62,7 @@ impl<F: Field> ExecutionGadget<F> for CallValueGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/coinbase.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/coinbase.rs
@@ -7,7 +7,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -16,7 +16,8 @@ use crate::{
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
 use eth_types::ToLittleEndian;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -62,7 +63,7 @@ impl<F: Field> ExecutionGadget<F> for CoinbaseGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/comparator.rs
@@ -7,14 +7,14 @@ use crate::{
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             from_bytes,
             math_gadget::{ComparisonGadget, IsEqualGadget},
-            select, Cell, Word,
+            select, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ComparatorGadget<F> {
@@ -106,7 +106,7 @@ impl<F: Field> ExecutionGadget<F> for ComparatorGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/dup.rs
@@ -5,14 +5,14 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            Cell, Word,
+            CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct DupGadget<F> {
@@ -56,7 +56,7 @@ impl<F: Field> ExecutionGadget<F> for DupGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/end_block.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_block.rs
@@ -1,11 +1,12 @@
 use crate::evm_circuit::{
     execution::ExecutionGadget,
     step::ExecutionState,
-    util::constraint_builder::ConstraintBuilder,
+    util::{constraint_builder::ConstraintBuilder, CachedRegion},
     witness::{Block, Call, ExecStep, Transaction},
 };
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
@@ -32,7 +33,7 @@ impl<F: Field> ExecutionGadget<F> for EndBlockGadget<F> {
 
     fn assign_exec_step(
         &self,
-        _region: &mut Region<'_, F>,
+        _region: &mut CachedRegion<'_, '_, F>,
         _offset: usize,
         _: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/end_tx.rs
@@ -10,14 +10,14 @@ use crate::{
             math_gadget::{
                 AddWordsGadget, ConstantDivisionGadget, MinMaxGadget, MulWordByU64Gadget,
             },
-            Cell,
+            CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::MAX_REFUND_QUOTIENT_OF_GAS_USED, Field, ToScalar};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct EndTxGadget<F> {
@@ -138,7 +138,7 @@ impl<F: Field> ExecutionGadget<F> for EndTxGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         tx: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/error_oog_static_memory.rs
@@ -7,14 +7,14 @@ use crate::{
             constraint_builder::ConstraintBuilder,
             math_gadget::{IsEqualGadget, IsZeroGadget, RangeCheckGadget},
             memory_gadget::{address_high, address_low, MemoryExpansionGadget},
-            Cell, Word,
+            CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorOOGStaticMemoryGadget<F> {
@@ -89,7 +89,7 @@ impl<F: Field> ExecutionGadget<F> for ErrorOOGStaticMemoryGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/extcodehash.rs
@@ -7,7 +7,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, Cell, RandomLinearCombination, Word,
+            from_bytes, CachedRegion, Cell, RandomLinearCombination, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -16,7 +16,7 @@ use crate::{
 use eth_types::ToLittleEndian;
 use eth_types::{evm_types::GasCost, Field, ToAddress, ToScalar, U256};
 use ethers_core::utils::keccak256;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -154,7 +154,7 @@ impl<F: Field> ExecutionGadget<F> for ExtcodehashGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         tx: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/gas.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/gas.rs
@@ -6,14 +6,14 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct GasGadget<F> {
@@ -59,7 +59,7 @@ impl<F: Field> ExecutionGadget<F> for GasGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         _block: &Block<F>,
         _transaction: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
@@ -5,7 +5,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            math_gadget, Cell, Word,
+            math_gadget, Cell, Word, CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -13,7 +13,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct IsZeroGadget<F> {
@@ -55,7 +55,7 @@ impl<F: Field> ExecutionGadget<F> for IsZeroGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/is_zero.rs
@@ -5,7 +5,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            math_gadget, Cell, Word, CachedRegion,
+            math_gadget, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },

--- a/zkevm-circuits/src/evm_circuit/execution/jump.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jump.rs
@@ -9,14 +9,15 @@ use crate::{
                 ConstraintBuilder, StepStateTransition,
                 Transition::{Delta, To},
             },
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -62,7 +63,7 @@ impl<F: Field> ExecutionGadget<F> for JumpGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/jumpdest.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpdest.rs
@@ -5,6 +5,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -12,7 +13,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct JumpdestGadget<F> {
@@ -39,7 +40,7 @@ impl<F: Field> ExecutionGadget<F> for JumpdestGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         _: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/jumpi.rs
@@ -11,14 +11,15 @@ use crate::{
             },
             from_bytes,
             math_gadget::IsZeroGadget,
-            select, Cell, RandomLinearCombination, Word,
+            select, CachedRegion, Cell, RandomLinearCombination, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -84,7 +85,7 @@ impl<F: Field> ExecutionGadget<F> for JumpiGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory.rs
@@ -12,14 +12,15 @@ use crate::{
             from_bytes,
             math_gadget::IsEqualGadget,
             memory_gadget::MemoryExpansionGadget,
-            select, MemoryAddress, Word,
+            select, CachedRegion, MemoryAddress, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
@@ -135,7 +136,7 @@ impl<F: Field> ExecutionGadget<F> for MemoryGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/memory_copy.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/memory_copy.rs
@@ -8,7 +8,7 @@ use crate::{
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             math_gadget::ComparisonGadget,
             memory_gadget::BufferReaderGadget,
-            Cell,
+            CachedRegion, Cell,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -16,7 +16,7 @@ use crate::{
 };
 use bus_mapping::circuit_input_builder::StepAuxiliaryData;
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 // The max number of bytes that can be copied in a step limited by the number
 // of cells in a step
@@ -160,7 +160,7 @@ impl<F: Field> ExecutionGadget<F> for CopyToMemoryGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         tx: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/msize.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/msize.rs
@@ -6,7 +6,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -14,7 +14,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct MsizeGadget<F> {
@@ -59,7 +59,7 @@ impl<F: Field> ExecutionGadget<F> for MsizeGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         _: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/mul.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/mul.rs
@@ -6,6 +6,7 @@ use crate::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             math_gadget::MulWordsGadget,
+            CachedRegion,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -13,7 +14,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 // MulGadget verifies MUL: a * b mod 2^256 is equal to c,
 #[derive(Clone, Debug)]
@@ -57,7 +58,7 @@ impl<F: Field> ExecutionGadget<F> for MulGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/number.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/number.rs
@@ -7,7 +7,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -15,7 +15,8 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]
@@ -61,7 +62,7 @@ impl<F: Field> ExecutionGadget<F> for NumberGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pc.rs
@@ -6,7 +6,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -14,7 +14,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct PcGadget<F> {
@@ -59,7 +59,7 @@ impl<F: Field> ExecutionGadget<F> for PcGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         _: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/pop.rs
@@ -5,7 +5,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            Cell, Word,
+            CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -13,7 +13,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct PopGadget<F> {
@@ -51,7 +51,7 @@ impl<F: Field> ExecutionGadget<F> for PopGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/push.rs
@@ -5,7 +5,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            sum, Cell, Word,
+            sum, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -13,7 +13,7 @@ use crate::{
 };
 use array_init::array_init;
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct PushGadget<F> {
@@ -114,7 +114,7 @@ impl<F: Field> ExecutionGadget<F> for PushGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/selfbalance.rs
@@ -6,7 +6,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            Cell, Word,
+            CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -14,7 +14,7 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian, ToScalar};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SelfbalanceGadget<F> {
@@ -59,7 +59,7 @@ impl<F: Field> ExecutionGadget<F> for SelfbalanceGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signed_comparator.rs
@@ -7,14 +7,14 @@ use crate::{
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             from_bytes,
             math_gadget::{ComparisonGadget, IsEqualGadget, LtGadget},
-            select, Cell, Word,
+            select, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 /// Gadget that implements the ExecutionGadget trait to handle the Opcodes SLT
 /// and SGT.
@@ -144,7 +144,7 @@ impl<F: Field> ExecutionGadget<F> for SignedComparatorGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _transaction: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/signextend.rs
@@ -8,7 +8,7 @@ use crate::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             math_gadget::{IsEqualGadget, IsZeroGadget},
-            select, sum, Cell, Word,
+            select, sum, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -17,7 +17,7 @@ use crate::{
 use array_init::array_init;
 use bus_mapping::evm::OpcodeId;
 use eth_types::{Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SignextendGadget<F> {
@@ -153,7 +153,7 @@ impl<F: Field> ExecutionGadget<F> for SignextendGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/sload.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sload.rs
@@ -6,17 +6,14 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            select, Cell, Word,
+            select, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
-use halo2_proofs::{
-    circuit::Region,
-    plonk::{Error, Expression},
-};
+use halo2_proofs::plonk::{Error, Expression};
 
 #[derive(Clone, Debug)]
 pub(crate) struct SloadGadget<F> {
@@ -104,7 +101,7 @@ impl<F: Field> ExecutionGadget<F> for SloadGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         tx: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/sstore.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/sstore.rs
@@ -7,17 +7,14 @@ use crate::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
             math_gadget::{IsEqualGadget, IsZeroGadget},
-            not, select, Cell, Word,
+            not, select, CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::GasCost, Field, ToLittleEndian, ToScalar};
-use halo2_proofs::{
-    circuit::Region,
-    plonk::{Error, Expression},
-};
+use halo2_proofs::plonk::{Error, Expression};
 
 #[derive(Clone, Debug)]
 pub(crate) struct SstoreGadget<F> {
@@ -156,7 +153,7 @@ impl<F: Field> ExecutionGadget<F> for SstoreGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         tx: &Transaction,
@@ -309,7 +306,7 @@ impl<F: Field> SstoreGasGadget<F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         value: eth_types::Word,
         value_prev: eth_types::Word,
@@ -471,7 +468,7 @@ impl<F: Field> SstoreTxRefundGadget<F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         tx_refund_old: u64,
         value: eth_types::Word,

--- a/zkevm-circuits/src/evm_circuit/execution/stop.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/stop.rs
@@ -2,13 +2,13 @@ use crate::{
     evm_circuit::{
         execution::ExecutionGadget,
         step::ExecutionState,
-        util::{constraint_builder::ConstraintBuilder, Cell},
+        util::{constraint_builder::ConstraintBuilder, CachedRegion, Cell},
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct StopGadget<F> {
@@ -32,7 +32,7 @@ impl<F: Field> ExecutionGadget<F> for StopGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         _: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/swap.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/swap.rs
@@ -5,14 +5,14 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            Cell, Word,
+            CachedRegion, Cell, Word,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
     util::Expr,
 };
 use eth_types::{evm_types::OpcodeId, Field, ToLittleEndian};
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SwapGadget<F> {
@@ -60,7 +60,7 @@ impl<F: Field> ExecutionGadget<F> for SwapGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/execution/timestamp.rs
+++ b/zkevm-circuits/src/evm_circuit/execution/timestamp.rs
@@ -7,7 +7,7 @@ use crate::{
         util::{
             common_gadget::SameContextGadget,
             constraint_builder::{ConstraintBuilder, StepStateTransition, Transition::Delta},
-            from_bytes, RandomLinearCombination,
+            from_bytes, CachedRegion, RandomLinearCombination,
         },
         witness::{Block, Call, ExecStep, Transaction},
     },
@@ -15,7 +15,8 @@ use crate::{
 };
 use bus_mapping::evm::OpcodeId;
 use eth_types::Field;
-use halo2_proofs::{circuit::Region, plonk::Error};
+use halo2_proofs::plonk::Error;
+
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]
@@ -59,7 +60,7 @@ impl<F: Field> ExecutionGadget<F> for TimestampGadget<F> {
 
     fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,7 +1,7 @@
 // Step dimension
 pub(crate) const STEP_WIDTH: usize = 32;
 /// Step height
-pub const STEP_HEIGHT: usize = 16;
+pub const MAX_STEP_HEIGHT: usize = 16;
 pub(crate) const N_CELLS_STEP_STATE: usize = 10;
 
 /// Maximum number of bytes that an integer can fit in field without wrapping

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -1,7 +1,7 @@
 // Step dimension
 pub(crate) const STEP_WIDTH: usize = 32;
 /// Step height
-pub const MAX_STEP_HEIGHT: usize = 16;
+pub const MAX_STEP_HEIGHT: usize = 20;
 pub(crate) const N_CELLS_STEP_STATE: usize = 10;
 
 /// Maximum number of bytes that an integer can fit in field without wrapping

--- a/zkevm-circuits/src/evm_circuit/step.rs
+++ b/zkevm-circuits/src/evm_circuit/step.rs
@@ -1,3 +1,4 @@
+use super::util::CachedRegion;
 use crate::{
     evm_circuit::{
         param::{MAX_STEP_HEIGHT, N_CELLS_STEP_STATE, STEP_WIDTH},
@@ -10,7 +11,6 @@ use bus_mapping::evm::OpcodeId;
 use eth_types::ToLittleEndian;
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::Region,
     plonk::{Advice, Column, ConstraintSystem, Error, Expression},
 };
 use std::collections::VecDeque;
@@ -556,7 +556,7 @@ impl<F: FieldExt> Step<F> {
 
     pub(crate) fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         block: &Block<F>,
         _: &Transaction,

--- a/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/common_gadget.rs
@@ -1,3 +1,4 @@
+use super::CachedRegion;
 use crate::{
     evm_circuit::{
         param::N_BYTES_GAS,
@@ -12,10 +13,7 @@ use crate::{
     util::Expr,
 };
 use eth_types::{Field, U256};
-use halo2_proofs::{
-    circuit::Region,
-    plonk::{Error, Expression},
-};
+use halo2_proofs::plonk::{Error, Expression};
 use std::convert::TryInto;
 
 /// Construction of execution state that stays in the same call context, which
@@ -60,7 +58,7 @@ impl<F: Field> SameContextGadget<F> {
 
     pub(crate) fn assign_exec_step(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         step: &ExecStep,
     ) -> Result<(), Error> {
@@ -126,7 +124,7 @@ impl<F: Field, const N_ADDENDS: usize, const INCREASE: bool>
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         addends: Vec<U256>,
         sum: U256,
@@ -172,7 +170,7 @@ impl<F: Field> TransferWithGasFeeGadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         (sender_balance, sender_balance_prev): (U256, U256),
         (receiver_balance, receiver_balance_prev): (U256, U256),

--- a/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/math_gadget.rs
@@ -1,3 +1,4 @@
+use super::CachedRegion;
 use crate::{
     evm_circuit::util::{
         self, constraint_builder::ConstraintBuilder, from_bytes, pow_of_two, pow_of_two_expr,
@@ -7,7 +8,7 @@ use crate::{
 };
 use eth_types::{Field, ToLittleEndian, ToScalar, Word};
 use halo2_proofs::plonk::Error;
-use halo2_proofs::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
+use halo2_proofs::{arithmetic::FieldExt, plonk::Expression};
 use std::convert::TryFrom;
 
 /// Returns `1` when `value == 0`, and returns `0` otherwise.
@@ -41,7 +42,7 @@ impl<F: FieldExt> IsZeroGadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         value: F,
     ) -> Result<F, Error> {
@@ -78,7 +79,7 @@ impl<F: FieldExt> IsEqualGadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         lhs: F,
         rhs: F,
@@ -164,7 +165,7 @@ impl<F: Field, const N_ADDENDS: usize, const CHECK_OVREFLOW: bool>
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         addends: [Word; N_ADDENDS],
         sum: Word,
@@ -297,7 +298,7 @@ impl<F: FieldExt> MulWordsGadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         a: Word,
         b: Word,
@@ -318,7 +319,7 @@ impl<F: FieldExt> MulWordsGadget<F> {
     //assign t0 ~ t3 and v0, v1
     fn assign_witness(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         wa: &Word,
         wb: &Word,
@@ -437,7 +438,7 @@ impl<F: FieldExt> MulWordByU64Gadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         multiplicand: Word,
         multiplier: u64,
@@ -493,7 +494,7 @@ impl<F: Field, const N_BYTES: usize> RangeCheckGadget<F, N_BYTES> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         value: F,
     ) -> Result<(), Error> {
@@ -548,7 +549,7 @@ impl<F: Field, const N_BYTES: usize> LtGadget<F, N_BYTES> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         lhs: F,
         rhs: F,
@@ -602,7 +603,7 @@ impl<F: Field, const N_BYTES: usize> ComparisonGadget<F, N_BYTES> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         lhs: F,
         rhs: F,
@@ -654,7 +655,7 @@ impl<F: FieldExt> PairSelectGadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         value: F,
         a: F,
@@ -722,7 +723,7 @@ impl<F: Field, const N_BYTES: usize> ConstantDivisionGadget<F, N_BYTES> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         numerator: u128,
     ) -> Result<(u128, u128), Error> {
@@ -775,7 +776,7 @@ impl<F: Field, const N_BYTES: usize> MinMaxGadget<F, N_BYTES> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         lhs: F,
         rhs: F,

--- a/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
+++ b/zkevm-circuits/src/evm_circuit/util/memory_gadget.rs
@@ -1,3 +1,4 @@
+use super::CachedRegion;
 use crate::{
     evm_circuit::{
         param::{N_BYTES_GAS, N_BYTES_MEMORY_ADDRESS, N_BYTES_MEMORY_WORD_SIZE},
@@ -14,7 +15,6 @@ use array_init::array_init;
 use eth_types::{evm_types::GasCost, Field, ToLittleEndian, U256};
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::Region,
     plonk::{Error, Expression},
 };
 use std::convert::TryInto;
@@ -94,7 +94,7 @@ impl<F: FieldExt> MemoryAddressGadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         memory_offset: U256,
         memory_length: U256,
@@ -175,7 +175,7 @@ impl<F: Field> MemoryWordSizeGadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         address: u64,
     ) -> Result<u64, Error> {
@@ -279,7 +279,7 @@ impl<F: Field, const N: usize, const N_BYTES_MEMORY_WORD_SIZE: usize>
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         curr_memory_word_size: u64,
         addresses: [u64; N],
@@ -376,7 +376,7 @@ impl<F: Field> MemoryCopierGasGadget<F> {
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         num_bytes: u64,
         memory_expansion_gas_cost: u64,
@@ -489,7 +489,7 @@ impl<F: Field, const MAX_BYTES: usize, const ADDR_SIZE_IN_BYTES: usize>
 
     pub(crate) fn assign(
         &self,
-        region: &mut Region<'_, F>,
+        region: &mut CachedRegion<'_, '_, F>,
         offset: usize,
         addr_start: u64,
         addr_end: u64,


### PR DESCRIPTION
Step 2/3 of experimental optimizations done here: https://github.com/Brechtpd/zkevm-circuits/pull/2.
Code is based on https://github.com/appliedzkp/zkevm-circuits/pull/416 so ideally that one should be merged first.
Code depends on some small halo2 changes: https://github.com/appliedzkp/halo2/pull/54

Currently only tries to reduced the degree to a max of 9 (which is an extended degree of 8x, lowered from 16x), because more is currently not really possible until the lookups are done in a different way (which will be done in a subsequent PR).

The degree is lowered which makes the circuit faster to prove (around ~30% faster), though this comes at the cost of using more cells which can increase the number of rows that are required for an opcode.

```
ADD: 9 rows
MUL: 9 rows
BITWISE: 9 rows
BeginTx: 13 rows
BYTE: 11 rows
CALLDATACOPY: 7 rows
CALLDATALOAD: 13 rows
CALLDATASIZE: 6 rows
CALLER: 6 rows
CALLVALUE: 6 rows
CMP: 9 rows
DUP: 6 rows
EndBlock: 4 rows
EndTx: 15 rows
ErrorOutOfGasStaticMemoryExpansion: 8 rows
JUMP: 6 rows
JUMPDEST: 6 rows
JUMPI: 6 rows
GAS: 6 rows
MEMORY: 8 rows
COPYTOMEMORY: 19 rows
PC: 6 rows
POP: 6 rows
PUSH: 8 rows
SELFBALANCE: 6 rows
SCMP: 9 rows
SIGNEXTEND: 11 rows
STOP: 5 rows
SWAP: 6 rows
MSIZE: 6 rows
COINBASE: 6 rows
TIMESTAMP: 6 rows
NUMBER: 6 rows
SLOAD: 6 rows
SSTORE: 6 rows
EXTCODEHASH: 6 rows
ISZERO: 6 rows
```

These are not optimal, but I will be tweaking things a bit more after the lookup refactor.