### PR TITLE
Add CODEOWNERS file to repo to auto-assign reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+* @appliedzkp/zkevm-reviewers
+
+zkevm-circuits/src/state_circuit/ @miha-stopar
+zkevm-circuits/src/state_circuit.rs @miha-stopar


### PR DESCRIPTION
Since the solution https://github.com/appliedzkp/zkevm-circuits/pull/428 is impossible to implement as a bug affecting
the gh actions prevents it.
An alternative to automatically assign reviews for the reviewing team is
to use a CODEOWNERS file.

So this PR adds this file configured to assign all reviews to
`appliedzkp/zkevm-reviewers` and also Miha specifically to any state
circuit PR.

Resolves: https://github.com/appliedzkp/zkevm-circuits/issues/423